### PR TITLE
fix: remove duplicate .exe extension in release artifact name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,7 @@ builds:
 archives:
   - id: binary
     format: binary
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if eq .Os \"windows\" }}.exe{{ end }}"
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
GoReleaser's binary format already appends .exe for Windows builds.