### PR TITLE
feat: add browser load tools and trim unused MCP surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,21 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Add, read, and clear MIDI notes
 - Get/set tempo
 - List devices on a track
+- Load Drum Racks / presets from Live's Browser (with the included AbletonOSC patch)
 - Fire clip slots
 - Send raw OSC messages for advanced control
 
-## Limitations (and why)
+## Browser loading (AbletonOSC patch)
 
-- **Loading devices from Live's Browser (e.g., Drum Rack)** is **not supported** by the standard AbletonOSC API.
-  This MCP only talks to Ableton Live via AbletonOSC, so it can only do what AbletonOSC exposes.
-- To automate device loading, **AbletonOSC's Remote Script must be extended** with a custom OSC endpoint
-  that calls Live's Browser `load_item()` API. This is outside the scope of the default AbletonOSC install.
+Stock [AbletonOSC](https://github.com/ideoforms/AbletonOSC) does not expose Live's Browser `load_item()` API.
+This repo ships a small Remote Script patch under [`remote-script/`](remote-script/) that adds:
+
+- `/live/browser/find`
+- `/live/track/load/browser_item`
+- `/live/device/load/preset`
+
+Install steps: see [remote-script/README.md](remote-script/README.md).
+After applying the patch, **restart Ableton Live** (a full restart is required the first time; `/live/api/reload` alone is not enough).
 
 ## How it Works
 
@@ -209,18 +215,26 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | Tool | Description |
 |------|-------------|
 | `ableton_test` | Test connection to AbletonOSC |
-| `ableton_show_message` | Display message in Live's status bar |
-| `ableton_get_version` | Get Ableton Live version |
-| `ableton_get_tempo` | Get current tempo (BPM) |
-| `ableton_set_tempo` | Set tempo (BPM) |
+| `ableton_get_tempo` / `ableton_set_tempo` | Get/set tempo (BPM) |
+| `ableton_play` / `ableton_stop` / `ableton_stop_all_clips` | Transport |
+| `ableton_set_song_key` | Set root note and scale |
+| `ableton_set_metronome` | Enable/disable metronome |
 | `ableton_get_track_names` | List track names |
 | `ableton_get_track_devices` | List devices on a track |
-| `ableton_create_midi_track` | Create a new MIDI track |
-| `ableton_create_clip` | Create a new clip in a slot |
-| `ableton_get_clip_notes` | Get MIDI notes from a clip |
-| `ableton_add_midi_notes` | Add MIDI notes to a clip |
-| `ableton_clear_clip_notes` | Clear all notes from a clip |
-| `ableton_fire_clip_slot` | Fire (trigger) a clip slot |
+| `ableton_create_midi_track` | Create a MIDI track |
+| `ableton_set_track_name` | Rename a track |
+| `ableton_mute_track` / `ableton_solo_track` | Mute/solo |
+| `ableton_set_track_volume` | Set track volume |
+| `ableton_create_clip` | Create a clip in a slot |
+| `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
+| `ableton_fire_clip_slot` / `ableton_stop_clip` | Fire/stop a clip |
+| `ableton_duplicate_clip_to` | Duplicate clip to another slot |
+| `ableton_set_clip_name` | Rename a clip |
+| `ableton_fire_scene` | Fire a scene |
+| `ableton_get_device_parameters` / `ableton_set_device_parameter` | Device parameters |
+| `ableton_find_browser_item` | Search Live Browser (requires patch) |
+| `ableton_load_browser_item` | Load Drum Rack / instrument onto a track |
+| `ableton_load_device_preset` | Hotswap a preset onto a device |
 | `ableton_osc_send` | Send raw OSC message |
 
 ## Example Usage
@@ -228,7 +242,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 Once configured, you can ask your AI assistant:
 
 - "Set the tempo to 140 BPM"
-- "Create a MIDI track and add a 4-bar clip"
+- "Create a MIDI track, load Street Kit, and add a 4-bar clip"
+- "Find drum kits named Street in the browser"
 - "Add a kick drum pattern on beats 1, 2, 3, 4"
 - "What's the current tempo?"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nozomi-koborinai/ableton-osc-mcp
 
-go 1.25.8
+go 1.25.12
 
 require (
 	github.com/firebase/genkit/go v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/nozomi-koborinai/ableton-osc-mcp
 go 1.25.12
 
 require (
-	github.com/firebase/genkit/go v1.6.0
+	github.com/firebase/genkit/go v1.10.0
 	github.com/hypebeast/go-osc v0.0.0-20220308234300-cec5a8a1e5f5
 )
 
@@ -11,6 +11,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/coder/websocket v1.8.14 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,13 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/firebase/genkit/go v1.6.0 h1:W+oTo/yndFkSe/imGEmsYdW5Qi5w2USG7obiXElAQzY=
-github.com/firebase/genkit/go v1.6.0/go.mod h1:vu8ZAqNU6MU5qDza66bvqTtzJoUrqhO/+z5/6dtouJQ=
+github.com/firebase/genkit/go v1.10.0 h1:kOu3MKfgqRPk9yYHg2HFoCg8VWzcHJtfRyQw7OuYqMs=
+github.com/firebase/genkit/go v1.10.0/go.mod h1:AzmlJrm+2PjSrLnBHwY0uTbRC/GsazMa0JYpBrVf18E=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/internal/tools/ableton_browser.go
+++ b/internal/tools/ableton_browser.go
@@ -1,0 +1,161 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+type FindBrowserItemInput struct {
+	Query string `json:"query" jsonschema:"description=Search string for Live Browser items (e.g. drum kit name)"`
+}
+
+type FindBrowserItemOutput struct {
+	Matches []string `json:"matches" jsonschema:"description=Matching browser paths (up to 20)"`
+}
+
+type LoadBrowserItemInput struct {
+	TrackIndex int    `json:"track_index" jsonschema:"minimum=0"`
+	ItemName   string `json:"item_name" jsonschema:"description=Browser item name to load (e.g. Street Kit)"`
+}
+
+type LoadBrowserItemOutput struct {
+	TrackIndex    int    `json:"track_index"`
+	Status        string `json:"status" jsonschema:"description=loaded or not_found"`
+	ItemName      string `json:"item_name"`
+	DevicesBefore *int   `json:"devices_before,omitempty"`
+	DevicesAfter  *int   `json:"devices_after,omitempty"`
+}
+
+type LoadDevicePresetInput struct {
+	TrackIndex  int    `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex int    `json:"device_index" jsonschema:"minimum=0"`
+	PresetName  string `json:"preset_name" jsonschema:"description=Preset name to hotswap onto the device"`
+}
+
+type LoadDevicePresetOutput struct {
+	TrackIndex  int    `json:"track_index"`
+	DeviceIndex int    `json:"device_index"`
+	Status      string `json:"status" jsonschema:"description=loaded, not_found, or invalid_device_index"`
+	PresetName  string `json:"preset_name"`
+}
+
+func parseLoadBrowserItemResponse(res []interface{}) (LoadBrowserItemOutput, error) {
+	if err := ensureResponseLen(res, 3); err != nil {
+		return LoadBrowserItemOutput{}, err
+	}
+	trackIndex, err := abletonosc.AsInt(res[0])
+	if err != nil {
+		return LoadBrowserItemOutput{}, fmt.Errorf("parse track_index: %w", err)
+	}
+	status := fmt.Sprint(res[1])
+	out := LoadBrowserItemOutput{
+		TrackIndex: trackIndex,
+		Status:     status,
+		ItemName:   fmt.Sprint(res[2]),
+	}
+	if len(res) >= 5 {
+		before, err1 := abletonosc.AsInt(res[3])
+		after, err2 := abletonosc.AsInt(res[4])
+		if err1 == nil && err2 == nil {
+			out.DevicesBefore = &before
+			out.DevicesAfter = &after
+		}
+	}
+	if status != "loaded" {
+		return out, fmt.Errorf("browser item not loaded: status=%s item=%s", status, out.ItemName)
+	}
+	return out, nil
+}
+
+func parseLoadDevicePresetResponse(res []interface{}) (LoadDevicePresetOutput, error) {
+	if err := ensureResponseLen(res, 4); err != nil {
+		return LoadDevicePresetOutput{}, err
+	}
+	trackIndex, err := abletonosc.AsInt(res[0])
+	if err != nil {
+		return LoadDevicePresetOutput{}, fmt.Errorf("parse track_index: %w", err)
+	}
+	deviceIndex, err := abletonosc.AsInt(res[1])
+	if err != nil {
+		return LoadDevicePresetOutput{}, fmt.Errorf("parse device_index: %w", err)
+	}
+	status := fmt.Sprint(res[2])
+	out := LoadDevicePresetOutput{
+		TrackIndex:  trackIndex,
+		DeviceIndex: deviceIndex,
+		Status:      status,
+		PresetName:  fmt.Sprint(res[3]),
+	}
+	if status != "loaded" {
+		return out, fmt.Errorf("preset not loaded: status=%s preset=%s", status, out.PresetName)
+	}
+	return out, nil
+}
+
+func NewAbletonFindBrowserItem(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_find_browser_item", "Ableton Live: search Browser for loadable items (requires browser patch)",
+		func(_ *ai.ToolContext, input FindBrowserItemInput) (FindBrowserItemOutput, error) {
+			query := strings.TrimSpace(input.Query)
+			if query == "" {
+				return FindBrowserItemOutput{}, errors.New("query is required")
+			}
+			res, err := client.Query("/live/browser/find", query)
+			if err != nil {
+				return FindBrowserItemOutput{}, fmt.Errorf("browser find failed (abletonosc browser patch required): %w", err)
+			}
+			return FindBrowserItemOutput{Matches: toStringSlice(res)}, nil
+		},
+	)
+}
+
+func NewAbletonLoadBrowserItem(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_load_browser_item", "Ableton Live: load a Browser item (e.g. Drum Rack kit) onto a track",
+		func(_ *ai.ToolContext, input LoadBrowserItemInput) (LoadBrowserItemOutput, error) {
+			if input.TrackIndex < 0 {
+				return LoadBrowserItemOutput{}, errors.New("track_index must be >= 0")
+			}
+			itemName := strings.TrimSpace(input.ItemName)
+			if itemName == "" {
+				return LoadBrowserItemOutput{}, errors.New("item_name is required")
+			}
+			res, err := client.Query("/live/track/load/browser_item", int32(input.TrackIndex), itemName)
+			if err != nil {
+				return LoadBrowserItemOutput{}, fmt.Errorf("browser load failed (abletonosc browser patch required): %w", err)
+			}
+			return parseLoadBrowserItemResponse(res)
+		},
+	)
+}
+
+func NewAbletonLoadDevicePreset(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_load_device_preset", "Ableton Live: hotswap a preset onto an existing device",
+		func(_ *ai.ToolContext, input LoadDevicePresetInput) (LoadDevicePresetOutput, error) {
+			if input.TrackIndex < 0 {
+				return LoadDevicePresetOutput{}, errors.New("track_index must be >= 0")
+			}
+			if input.DeviceIndex < 0 {
+				return LoadDevicePresetOutput{}, errors.New("device_index must be >= 0")
+			}
+			presetName := strings.TrimSpace(input.PresetName)
+			if presetName == "" {
+				return LoadDevicePresetOutput{}, errors.New("preset_name is required")
+			}
+			res, err := client.Query(
+				"/live/device/load/preset",
+				int32(input.TrackIndex),
+				int32(input.DeviceIndex),
+				presetName,
+			)
+			if err != nil {
+				return LoadDevicePresetOutput{}, fmt.Errorf("preset load failed (abletonosc browser patch required): %w", err)
+			}
+			return parseLoadDevicePresetResponse(res)
+		},
+	)
+}

--- a/internal/tools/ableton_browser_test.go
+++ b/internal/tools/ableton_browser_test.go
@@ -1,0 +1,136 @@
+package tools
+
+import (
+	"testing"
+)
+
+func TestParseLoadBrowserItemResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		res        []interface{}
+		wantStatus string
+		wantItem   string
+		wantBefore int
+		wantAfter  int
+		wantCounts bool
+		wantErr    bool
+	}{
+		{
+			name:       "loaded_with_device_counts",
+			res:        []interface{}{int32(4), "loaded", "Street Kit", int32(0), int32(1)},
+			wantStatus: "loaded",
+			wantItem:   "Street Kit",
+			wantBefore: 0,
+			wantAfter:  1,
+			wantCounts: true,
+			wantErr:    false,
+		},
+		{
+			name:       "loaded_without_device_counts",
+			res:        []interface{}{int32(0), "loaded", "Drum Rack"},
+			wantStatus: "loaded",
+			wantItem:   "Drum Rack",
+			wantCounts: false,
+			wantErr:    false,
+		},
+		{
+			name:       "not_found",
+			res:        []interface{}{int32(1), "not_found", "Missing Kit"},
+			wantStatus: "not_found",
+			wantItem:   "Missing Kit",
+			wantErr:    true,
+		},
+		{
+			name:    "too_short",
+			res:     []interface{}{int32(0), "loaded"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseLoadBrowserItemResponse(tt.res)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseLoadBrowserItemResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.wantStatus == "" {
+				return
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			if got.ItemName != tt.wantItem {
+				t.Errorf("ItemName = %q, want %q", got.ItemName, tt.wantItem)
+			}
+			if tt.wantCounts {
+				if got.DevicesBefore == nil || *got.DevicesBefore != tt.wantBefore {
+					t.Errorf("DevicesBefore = %v, want %d", got.DevicesBefore, tt.wantBefore)
+				}
+				if got.DevicesAfter == nil || *got.DevicesAfter != tt.wantAfter {
+					t.Errorf("DevicesAfter = %v, want %d", got.DevicesAfter, tt.wantAfter)
+				}
+			}
+		})
+	}
+}
+
+func TestParseLoadDevicePresetResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		res        []interface{}
+		wantStatus string
+		wantPreset string
+		wantErr    bool
+	}{
+		{
+			name:       "loaded",
+			res:        []interface{}{int32(2), int32(0), "loaded", "Glocken Pluck"},
+			wantStatus: "loaded",
+			wantPreset: "Glocken Pluck",
+			wantErr:    false,
+		},
+		{
+			name:       "not_found",
+			res:        []interface{}{int32(2), int32(0), "not_found", "Missing"},
+			wantStatus: "not_found",
+			wantPreset: "Missing",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid_device_index",
+			res:        []interface{}{int32(2), int32(9), "invalid_device_index", "Any"},
+			wantStatus: "invalid_device_index",
+			wantPreset: "Any",
+			wantErr:    true,
+		},
+		{
+			name:    "too_short",
+			res:     []interface{}{int32(0), int32(0), "loaded"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseLoadDevicePresetResponse(tt.res)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseLoadDevicePresetResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.wantStatus == "" {
+				return
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			if got.PresetName != tt.wantPreset {
+				t.Errorf("PresetName = %q, want %q", got.PresetName, tt.wantPreset)
+			}
+		})
+	}
+}

--- a/internal/tools/ableton_scenes.go
+++ b/internal/tools/ableton_scenes.go
@@ -13,23 +13,6 @@ type FireSceneInput struct {
 	SceneIndex int `json:"scene_index" jsonschema:"minimum=0"`
 }
 
-type SetSceneNameInput struct {
-	SceneIndex int    `json:"scene_index" jsonschema:"minimum=0"`
-	Name       string `json:"name" jsonschema:"description=New scene name"`
-}
-
-type DuplicateSceneInput struct {
-	SceneIndex int `json:"scene_index" jsonschema:"minimum=0"`
-}
-
-type CreateSceneInput struct {
-	SceneIndex *int `json:"scene_index,omitempty" jsonschema:"description=Index to insert scene at (-1 to append),minimum=-1"`
-}
-
-type NumScenesOutput struct {
-	NumScenes int `json:"num_scenes"`
-}
-
 func NewAbletonFireScene(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	return genkit.DefineTool(g, "ableton_fire_scene", "Ableton Live: fire (launch) a scene",
 		func(_ *ai.ToolContext, input FireSceneInput) (FiredOutput, error) {
@@ -40,74 +23,6 @@ func NewAbletonFireScene(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 				return FiredOutput{}, err
 			}
 			return FiredOutput{Fired: true}, nil
-		},
-	)
-}
-
-func NewAbletonSetSceneName(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_set_scene_name", "Ableton Live: set scene name",
-		func(_ *ai.ToolContext, input SetSceneNameInput) (SentOutput, error) {
-			if input.SceneIndex < 0 {
-				return SentOutput{}, errors.New("scene_index must be >= 0")
-			}
-			if err := client.Send("/live/scene/set/name", int32(input.SceneIndex), input.Name); err != nil {
-				return SentOutput{}, err
-			}
-			return SentOutput{Sent: true}, nil
-		},
-	)
-}
-
-func NewAbletonCreateScene(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_create_scene", "Ableton Live: create a new scene",
-		func(_ *ai.ToolContext, input CreateSceneInput) (NumScenesOutput, error) {
-			index := -1
-			if input.SceneIndex != nil {
-				index = *input.SceneIndex
-				if index < -1 {
-					return NumScenesOutput{}, errors.New("scene_index must be -1 or >= 0")
-				}
-			}
-			if err := client.Send("/live/song/create_scene", int32(index)); err != nil {
-				return NumScenesOutput{}, err
-			}
-			res, err := client.Query("/live/song/get/num_scenes")
-			if err != nil {
-				return NumScenesOutput{}, err
-			}
-			if err := ensureResponseLen(res, 1); err != nil {
-				return NumScenesOutput{}, err
-			}
-			n, err := abletonosc.AsInt(res[0])
-			if err != nil {
-				return NumScenesOutput{}, err
-			}
-			return NumScenesOutput{NumScenes: n}, nil
-		},
-	)
-}
-
-func NewAbletonDuplicateScene(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_duplicate_scene", "Ableton Live: duplicate a scene",
-		func(_ *ai.ToolContext, input DuplicateSceneInput) (NumScenesOutput, error) {
-			if input.SceneIndex < 0 {
-				return NumScenesOutput{}, errors.New("scene_index must be >= 0")
-			}
-			if err := client.Send("/live/song/duplicate_scene", int32(input.SceneIndex)); err != nil {
-				return NumScenesOutput{}, err
-			}
-			res, err := client.Query("/live/song/get/num_scenes")
-			if err != nil {
-				return NumScenesOutput{}, err
-			}
-			if err := ensureResponseLen(res, 1); err != nil {
-				return NumScenesOutput{}, err
-			}
-			n, err := abletonosc.AsInt(res[0])
-			if err != nil {
-				return NumScenesOutput{}, err
-			}
-			return NumScenesOutput{NumScenes: n}, nil
 		},
 	)
 }

--- a/internal/tools/ableton_song.go
+++ b/internal/tools/ableton_song.go
@@ -15,17 +15,8 @@ type AbletonTestOutput struct {
 	OK string `json:"ok" jsonschema:"description=Should be 'ok' when AbletonOSC is reachable"`
 }
 
-type AbletonShowMessageInput struct {
-	Message string `json:"message" jsonschema:"description=Message to show in Live status bar"`
-}
-
 type SentOutput struct {
 	Sent bool `json:"sent"`
-}
-
-type AbletonVersionOutput struct {
-	MajorVersion int `json:"major_version"`
-	MinorVersion int `json:"minor_version"`
 }
 
 type TempoOutput struct {
@@ -34,78 +25,6 @@ type TempoOutput struct {
 
 type SetTempoInput struct {
 	TempoBPM float64 `json:"tempo_bpm" jsonschema:"description=Tempo in BPM,minimum=10,maximum=400"`
-}
-
-func NewAbletonTest(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_test", "AbletonOSC: test connection",
-		func(_ *ai.ToolContext, _ EmptyInput) (AbletonTestOutput, error) {
-			res, err := client.Query("/live/test")
-			if err != nil {
-				return AbletonTestOutput{}, err
-			}
-			ok := "ok"
-			if len(res) > 0 {
-				ok = fmt.Sprint(res[0])
-			}
-			return AbletonTestOutput{OK: ok}, nil
-		},
-	)
-}
-
-func NewAbletonShowMessage(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_show_message", "Ableton Live: show status message",
-		func(_ *ai.ToolContext, input AbletonShowMessageInput) (SentOutput, error) {
-			if strings.TrimSpace(input.Message) == "" {
-				return SentOutput{}, errors.New("message is required")
-			}
-			if err := client.Send("/live/api/show_message", input.Message); err != nil {
-				return SentOutput{}, err
-			}
-			return SentOutput{Sent: true}, nil
-		},
-	)
-}
-
-func NewAbletonGetVersion(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_get_version", "Ableton Live: get version",
-		func(_ *ai.ToolContext, _ EmptyInput) (AbletonVersionOutput, error) {
-			res, err := client.Query("/live/application/get/version")
-			if err != nil {
-				return AbletonVersionOutput{}, err
-			}
-			if err := ensureResponseLen(res, 2); err != nil {
-				return AbletonVersionOutput{}, err
-			}
-			major, err := abletonosc.AsInt(res[0])
-			if err != nil {
-				return AbletonVersionOutput{}, err
-			}
-			minor, err := abletonosc.AsInt(res[1])
-			if err != nil {
-				return AbletonVersionOutput{}, err
-			}
-			return AbletonVersionOutput{MajorVersion: major, MinorVersion: minor}, nil
-		},
-	)
-}
-
-func NewAbletonGetTempo(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_get_tempo", "Ableton Live: get tempo",
-		func(_ *ai.ToolContext, _ EmptyInput) (TempoOutput, error) {
-			res, err := client.Query("/live/song/get/tempo")
-			if err != nil {
-				return TempoOutput{}, err
-			}
-			if err := ensureResponseLen(res, 1); err != nil {
-				return TempoOutput{}, err
-			}
-			tempo, err := abletonosc.AsFloat64(res[0])
-			if err != nil {
-				return TempoOutput{}, err
-			}
-			return TempoOutput{TempoBPM: tempo}, nil
-		},
-	)
 }
 
 type StopAllClipsOutput struct {
@@ -134,13 +53,39 @@ type MetronomeOutput struct {
 	Enabled bool `json:"enabled"`
 }
 
-type CreateAudioTrackInput struct {
-	Index *int `json:"index,omitempty" jsonschema:"description=Track index (-1 to append),minimum=-1"`
+func NewAbletonTest(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_test", "AbletonOSC: test connection",
+		func(_ *ai.ToolContext, _ EmptyInput) (AbletonTestOutput, error) {
+			res, err := client.Query("/live/test")
+			if err != nil {
+				return AbletonTestOutput{}, err
+			}
+			ok := "ok"
+			if len(res) > 0 {
+				ok = fmt.Sprint(res[0])
+			}
+			return AbletonTestOutput{OK: ok}, nil
+		},
+	)
 }
 
-type MonitoringInput struct {
-	TrackIndex int `json:"track_index" jsonschema:"minimum=0"`
-	State      int `json:"state" jsonschema:"description=0=In 1=Auto 2=Off,minimum=0,maximum=2"`
+func NewAbletonGetTempo(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_tempo", "Ableton Live: get tempo",
+		func(_ *ai.ToolContext, _ EmptyInput) (TempoOutput, error) {
+			res, err := client.Query("/live/song/get/tempo")
+			if err != nil {
+				return TempoOutput{}, err
+			}
+			if err := ensureResponseLen(res, 1); err != nil {
+				return TempoOutput{}, err
+			}
+			tempo, err := abletonosc.AsFloat64(res[0])
+			if err != nil {
+				return TempoOutput{}, err
+			}
+			return TempoOutput{TempoBPM: tempo}, nil
+		},
+	)
 }
 
 func NewAbletonPlay(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
@@ -196,28 +141,6 @@ func NewAbletonSetSongKey(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	)
 }
 
-func NewAbletonSessionRecord(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_session_record", "Ableton Live: trigger session recording",
-		func(_ *ai.ToolContext, _ EmptyInput) (SentOutput, error) {
-			if err := client.Send("/live/song/trigger_session_record"); err != nil {
-				return SentOutput{}, err
-			}
-			return SentOutput{Sent: true}, nil
-		},
-	)
-}
-
-func NewAbletonCaptureMidi(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_capture_midi", "Ableton Live: capture MIDI (retroactively capture what was just played)",
-		func(_ *ai.ToolContext, _ EmptyInput) (SentOutput, error) {
-			if err := client.Send("/live/song/capture_midi"); err != nil {
-				return SentOutput{}, err
-			}
-			return SentOutput{Sent: true}, nil
-		},
-	)
-}
-
 func NewAbletonSetMetronome(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	return genkit.DefineTool(g, "ableton_set_metronome", "Ableton Live: enable or disable metronome",
 		func(_ *ai.ToolContext, input MetronomeInput) (MetronomeOutput, error) {
@@ -229,52 +152,6 @@ func NewAbletonSetMetronome(g *genkit.Genkit, client *abletonosc.Client) ai.Tool
 				return MetronomeOutput{}, err
 			}
 			return MetronomeOutput(input), nil
-		},
-	)
-}
-
-func NewAbletonCreateAudioTrack(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_create_audio_track", "Ableton Live: create audio track",
-		func(_ *ai.ToolContext, input CreateAudioTrackInput) (NumTracksOutput, error) {
-			index := -1
-			if input.Index != nil {
-				index = *input.Index
-				if index < -1 {
-					return NumTracksOutput{}, errors.New("index must be -1 or >= 0")
-				}
-			}
-			if err := client.Send("/live/song/create_audio_track", int32(index)); err != nil {
-				return NumTracksOutput{}, err
-			}
-			res, err := client.Query("/live/song/get/num_tracks")
-			if err != nil {
-				return NumTracksOutput{}, err
-			}
-			if err := ensureResponseLen(res, 1); err != nil {
-				return NumTracksOutput{}, err
-			}
-			n, err := abletonosc.AsInt(res[0])
-			if err != nil {
-				return NumTracksOutput{}, err
-			}
-			return NumTracksOutput{NumTracks: n}, nil
-		},
-	)
-}
-
-func NewAbletonSetMonitoring(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_set_monitoring", "Ableton Live: set track monitoring state (0=In, 1=Auto, 2=Off)",
-		func(_ *ai.ToolContext, input MonitoringInput) (SentOutput, error) {
-			if input.TrackIndex < 0 {
-				return SentOutput{}, errors.New("track_index must be >= 0")
-			}
-			if input.State < 0 || input.State > 2 {
-				return SentOutput{}, errors.New("state must be 0 (In), 1 (Auto), or 2 (Off)")
-			}
-			if err := client.Send("/live/track/set/current_monitoring_state", int32(input.TrackIndex), int32(input.State)); err != nil {
-				return SentOutput{}, err
-			}
-			return SentOutput{Sent: true}, nil
 		},
 	)
 }

--- a/internal/tools/ableton_tracks.go
+++ b/internal/tools/ableton_tracks.go
@@ -161,24 +161,6 @@ func NewAbletonSoloTrack(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	)
 }
 
-func NewAbletonArmTrack(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_arm_track", "Ableton Live: arm or disarm a track for recording",
-		func(_ *ai.ToolContext, input TrackBoolInput) (SentOutput, error) {
-			if input.TrackIndex < 0 {
-				return SentOutput{}, errors.New("track_index must be >= 0")
-			}
-			val := int32(0)
-			if input.Value {
-				val = 1
-			}
-			if err := client.Send("/live/track/set/arm", int32(input.TrackIndex), val); err != nil {
-				return SentOutput{}, err
-			}
-			return SentOutput{Sent: true}, nil
-		},
-	)
-}
-
 func NewAbletonSetTrackVolume(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	return genkit.DefineTool(g, "ableton_set_track_volume", "Ableton Live: set track volume (0.0=silence, 0.85=0dB, 1.0=+6dB)",
 		func(_ *ai.ToolContext, input SetTrackVolumeInput) (SentOutput, error) {

--- a/main.go
+++ b/main.go
@@ -44,29 +44,22 @@ func main() {
 	toolList := []ai.Tool{
 		// Song / Transport
 		tools.NewAbletonTest(g, ableton),
-		tools.NewAbletonShowMessage(g, ableton),
-		tools.NewAbletonGetVersion(g, ableton),
 		tools.NewAbletonGetTempo(g, ableton),
 		tools.NewAbletonSetTempo(g, ableton),
 		tools.NewAbletonPlay(g, ableton),
 		tools.NewAbletonStop(g, ableton),
 		tools.NewAbletonStopAllClips(g, ableton),
 		tools.NewAbletonSetSongKey(g, ableton),
-		tools.NewAbletonSessionRecord(g, ableton),
-		tools.NewAbletonCaptureMidi(g, ableton),
 		tools.NewAbletonSetMetronome(g, ableton),
 
 		// Tracks
 		tools.NewAbletonGetTrackNames(g, ableton),
 		tools.NewAbletonGetTrackDevices(g, ableton),
 		tools.NewAbletonCreateMidiTrack(g, ableton),
-		tools.NewAbletonCreateAudioTrack(g, ableton),
 		tools.NewAbletonSetTrackName(g, ableton),
 		tools.NewAbletonMuteTrack(g, ableton),
 		tools.NewAbletonSoloTrack(g, ableton),
-		tools.NewAbletonArmTrack(g, ableton),
 		tools.NewAbletonSetTrackVolume(g, ableton),
-		tools.NewAbletonSetMonitoring(g, ableton),
 
 		// Clips
 		tools.NewAbletonCreateClip(g, ableton),
@@ -80,13 +73,13 @@ func main() {
 
 		// Scenes
 		tools.NewAbletonFireScene(g, ableton),
-		tools.NewAbletonSetSceneName(g, ableton),
-		tools.NewAbletonCreateScene(g, ableton),
-		tools.NewAbletonDuplicateScene(g, ableton),
 
-		// Devices
+		// Devices / Browser
 		tools.NewAbletonGetDeviceParameters(g, ableton),
 		tools.NewAbletonSetDeviceParameter(g, ableton),
+		tools.NewAbletonFindBrowserItem(g, ableton),
+		tools.NewAbletonLoadBrowserItem(g, ableton),
+		tools.NewAbletonLoadDevicePreset(g, ableton),
 
 		// Raw OSC
 		tools.NewAbletonOscSend(g, ableton),

--- a/remote-script/README.md
+++ b/remote-script/README.md
@@ -1,0 +1,68 @@
+# AbletonOSC Browser Patch
+
+Adds Live Browser `load_item()` support so MCP tools can load Drum Racks and presets without drag-and-drop.
+
+## What it adds
+
+| OSC address | Args | Purpose |
+|-------------|------|---------|
+| `/live/browser/find` | `query` | Search loadable items (up to 20 paths) |
+| `/live/track/load/browser_item` | `track_index`, `item_name` | Load by name onto a track |
+| `/live/device/load/preset` | `track_index`, `device_index`, `preset_name` | Hotswap preset onto a device |
+| `/live/browser/list_folder` | `root_name`, `*path_parts` | List folder children |
+| `/live/browser/load_at_path` | `track_index`, `device_index`, `root_name`, `*path_parts`, `item_name` | Load by exact path |
+| `/live/browser/debug` | _(none)_ | Dump browser roots (debug) |
+
+## Install (macOS)
+
+Assumes stock [AbletonOSC](https://github.com/ideoforms/AbletonOSC) is already at:
+
+`~/Music/Ableton/User Library/Remote Scripts/AbletonOSC`
+
+From this repository root:
+
+```bash
+ABLETONOSC="$HOME/Music/Ableton/User Library/Remote Scripts/AbletonOSC"
+
+# 1. Copy BrowserHandler
+cp remote-script/abletonosc/browser.py "$ABLETONOSC/abletonosc/browser.py"
+
+# 2. Register the handler (idempotent-ish — skip if already present)
+grep -q 'BrowserHandler' "$ABLETONOSC/abletonosc/__init__.py" || \
+  printf '\nfrom .browser import BrowserHandler\n' >> "$ABLETONOSC/abletonosc/__init__.py"
+
+# 3. Add BrowserHandler to manager.py handlers list and reload_imports
+#    See "Manual manager.py edits" below if you prefer editing by hand.
+python3 remote-script/apply_manager_patch.py "$ABLETONOSC"
+```
+
+Then in Ableton Live:
+
+1. Preferences → Link / Tempo / MIDI → Control Surface = **AbletonOSC**
+2. **Restart Ableton Live** (required the first time you apply this patch — `/live/api/reload` does not reload `manager.py`)
+
+After a full restart, `/live/browser/find` should respond.
+
+## Manual manager.py edits
+
+In `manager.py` `init_api` handlers list, add:
+
+```python
+abletonosc.BrowserHandler(self),
+```
+
+In `reload_imports`, add:
+
+```python
+importlib.reload(abletonosc.browser)
+```
+
+## Cleanup (optional)
+
+If you previously patched browser logic into `device.py` / `track.py`, remove those inline handlers so only `browser.py` owns them. Stock AbletonOSC does not include them, so a fresh clone + this patch is enough.
+
+## Windows paths
+
+```text
+%USERPROFILE%\Documents\Ableton\User Library\Remote Scripts\AbletonOSC
+```

--- a/remote-script/abletonosc/browser.py
+++ b/remote-script/abletonosc/browser.py
@@ -1,0 +1,224 @@
+import Live
+from typing import Any, Optional, Tuple
+
+from .handler import AbletonOSCHandler
+
+
+def _browser_roots(browser):
+    roots = []
+    for attr in (
+        "instruments",
+        "sounds",
+        "audio_effects",
+        "midi_effects",
+        "drums",
+        "packs",
+        "samples",
+        "max_for_live",
+        "plugins",
+        "clips",
+    ):
+        try:
+            roots.append(getattr(browser, attr))
+        except Exception:
+            pass
+    try:
+        for folder in browser.user_folders:
+            roots.append(folder)
+    except Exception:
+        pass
+    try:
+        roots.append(browser.user_library)
+    except Exception:
+        pass
+    return roots
+
+
+def _find_browser_item(root, name: str) -> Optional[Any]:
+    name_lower = name.lower()
+
+    def walk(item):
+        try:
+            item_name = str(item.name)
+            if item.is_loadable and (item_name == name or name_lower in item_name.lower()):
+                return item
+            if item.is_folder:
+                for child in item.children:
+                    found = walk(child)
+                    if found is not None:
+                        return found
+        except Exception:
+            pass
+        return None
+
+    return walk(root)
+
+
+def _resolve_path(browser, root_name: str, path_parts):
+    node = None
+    for root in _browser_roots(browser):
+        if str(root.name) == root_name:
+            node = root
+            break
+    if node is None:
+        return None
+    for part in path_parts:
+        node = next((c for c in node.children if str(c.name) == part), None)
+        if node is None:
+            return None
+    return node
+
+
+class BrowserHandler(AbletonOSCHandler):
+    def __init__(self, manager):
+        super().__init__(manager)
+        self.class_identifier = "browser"
+
+    def init_api(self):
+        def browser_find_handler(params: Tuple[Any]):
+            query_name = str(params[0])
+            browser = Live.Application.get_application().browser
+            matches = []
+
+            def walk(item, path):
+                try:
+                    item_name = str(item.name)
+                    current_path = f"{path}/{item_name}" if path else item_name
+                    if item.is_loadable and query_name.lower() in item_name.lower():
+                        matches.append(current_path)
+                    if item.is_folder:
+                        for child in item.children:
+                            walk(child, current_path)
+                except Exception:
+                    pass
+
+            for root in _browser_roots(browser):
+                walk(root, "")
+            return tuple(matches[:20])
+
+        def browser_debug_handler(params: Tuple[Any]):
+            browser = Live.Application.get_application().browser
+            infos = []
+            for root in _browser_roots(browser):
+                try:
+                    infos.append(str(root.name))
+                    children = list(root.children)
+                    infos.append(str(len(children)))
+                    for child in children[:15]:
+                        infos.append(str(child.name))
+                except Exception as e:
+                    infos.append("err:%s" % e)
+            return tuple(infos[:40])
+
+        def browser_list_folder_handler(params: Tuple[Any]):
+            """Params: root_name, *path_parts. Lists child names under a browser folder."""
+            browser = Live.Application.get_application().browser
+            root_name = str(params[0])
+            path_parts = [str(p) for p in params[1:]]
+            node = _resolve_path(browser, root_name, path_parts)
+            if node is None:
+                if not path_parts:
+                    return ("root_not_found", root_name)
+                return ("path_not_found", root_name, *path_parts)
+            names = []
+            for child in node.children:
+                try:
+                    names.append(
+                        "%s|loadable=%s|folder=%s"
+                        % (child.name, child.is_loadable, child.is_folder)
+                    )
+                except Exception:
+                    names.append(str(child.name))
+            return (root_name, *path_parts, *names[:30])
+
+        def browser_load_at_path_handler(params: Tuple[Any]):
+            """Load browser item by path.
+            Params: track_index, hotswap_device_index (-1 to append), root_name, *path_parts, item_name
+            """
+            track_index = int(params[0])
+            device_index = int(params[1])
+            if len(params) < 4:
+                return ("error", "missing_path")
+            root_name = str(params[2])
+            *path_parts, item_name = [str(p) for p in params[3:]]
+            track = self.song.tracks[track_index]
+            browser = Live.Application.get_application().browser
+            node = _resolve_path(browser, root_name, path_parts)
+            if node is None:
+                if not path_parts:
+                    return (track_index, "root_not_found", root_name)
+                return (track_index, "path_not_found", root_name, *path_parts, item_name)
+            item = next(
+                (
+                    c
+                    for c in node.children
+                    if str(c.name) in (item_name, "%s.adv" % item_name, "%s.adg" % item_name)
+                ),
+                None,
+            )
+            if item is None:
+                return (track_index, "item_not_found", item_name)
+            devices_before = len(track.devices)
+            self.song.view.selected_track = track
+            if device_index >= 0:
+                if device_index >= len(track.devices):
+                    return (track_index, "invalid_device_index", device_index)
+                self.song.view.hotswap_target = track.devices[device_index]
+            else:
+                self.song.view.hotswap_target = None
+            browser.load_item(item)
+            return (track_index, "loaded", item.name, devices_before, len(track.devices))
+
+        def track_load_browser_item_handler(params: Tuple[Any]):
+            """Params: track_index, item_name — search by name and append to track."""
+            track_index = int(params[0])
+            item_name = str(params[1])
+            track = self.song.tracks[track_index]
+            browser = Live.Application.get_application().browser
+            item = None
+            for root in _browser_roots(browser):
+                item = _find_browser_item(root, item_name)
+                if item is not None:
+                    break
+            if item is None:
+                self.logger.warning("Browser item not found: %s" % item_name)
+                return (track_index, "not_found", item_name)
+            devices_before = len(track.devices)
+            self.song.view.selected_track = track
+            self.song.view.hotswap_target = None
+            browser.load_item(item)
+            self.logger.info("Loaded browser item '%s' on track %d" % (item.name, track_index))
+            return (track_index, "loaded", item.name, devices_before, len(track.devices))
+
+        def device_load_preset_handler(params: Tuple[Any]):
+            """Params: track_index, device_index, preset_name — hotswap preset onto device."""
+            track_index = int(params[0])
+            device_index = int(params[1])
+            preset_name = str(params[2])
+            track = self.song.tracks[track_index]
+            if device_index < 0 or device_index >= len(track.devices):
+                return (track_index, device_index, "invalid_device_index", preset_name)
+            device = track.devices[device_index]
+            browser = Live.Application.get_application().browser
+            item = None
+            for root in _browser_roots(browser):
+                item = _find_browser_item(root, preset_name)
+                if item is not None:
+                    break
+            if item is None:
+                self.logger.warning("Preset not found in browser: %s" % preset_name)
+                return (track_index, device_index, "not_found", preset_name)
+            self.song.view.selected_track = track
+            self.song.view.hotswap_target = device
+            browser.load_item(item)
+            self.logger.info(
+                "Loaded preset '%s' on track %d device %d" % (item.name, track_index, device_index)
+            )
+            return (track_index, device_index, "loaded", item.name)
+
+        self.osc_server.add_handler("/live/browser/find", browser_find_handler)
+        self.osc_server.add_handler("/live/browser/debug", browser_debug_handler)
+        self.osc_server.add_handler("/live/browser/list_folder", browser_list_folder_handler)
+        self.osc_server.add_handler("/live/browser/load_at_path", browser_load_at_path_handler)
+        self.osc_server.add_handler("/live/track/load/browser_item", track_load_browser_item_handler)
+        self.osc_server.add_handler("/live/device/load/preset", device_load_preset_handler)

--- a/remote-script/apply_manager_patch.py
+++ b/remote-script/apply_manager_patch.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Patch AbletonOSC manager.py to register BrowserHandler."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def patch(manager_path: Path) -> None:
+    text = manager_path.read_text(encoding="utf-8")
+    original = text
+
+    if "abletonosc.BrowserHandler(self)" not in text:
+        text = text.replace(
+            "abletonosc.DeviceHandler(self),",
+            "abletonosc.DeviceHandler(self),\n                abletonosc.BrowserHandler(self),",
+            1,
+        )
+
+    if "importlib.reload(abletonosc.browser)" not in text:
+        text = text.replace(
+            "importlib.reload(abletonosc.device)",
+            "importlib.reload(abletonosc.device)\n            importlib.reload(abletonosc.browser)",
+            1,
+        )
+
+    if text == original:
+        print("manager.py already patched (or pattern not found)")
+        return
+
+    manager_path.write_text(text, encoding="utf-8")
+    print(f"Patched {manager_path}")
+
+
+def ensure_init_import(init_path: Path) -> None:
+    text = init_path.read_text(encoding="utf-8")
+    if "from .browser import BrowserHandler" in text:
+        print("__init__.py already imports BrowserHandler")
+        return
+    if not text.endswith("\n"):
+        text += "\n"
+    text += "from .browser import BrowserHandler\n"
+    init_path.write_text(text, encoding="utf-8")
+    print(f"Updated {init_path}")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} /path/to/AbletonOSC", file=sys.stderr)
+        return 2
+    root = Path(sys.argv[1]).expanduser().resolve()
+    manager = root / "manager.py"
+    init_py = root / "abletonosc" / "__init__.py"
+    if not manager.is_file() or not init_py.is_file():
+        print(f"Not an AbletonOSC install: {root}", file=sys.stderr)
+        return 1
+    ensure_init_import(init_py)
+    patch(manager)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Ship an AbletonOSC Remote Script patch (`remote-script/`) that exposes Live Browser `load_item()` for Drum Racks and presets
- Add MCP tools `ableton_find_browser_item`, `ableton_load_browser_item`, and `ableton_load_device_preset`
- Remove recording/diagnostic/scene-CRUD tools that are outside the beatmaking workflow, and update the README tool list
- Bump Go toolchain to `1.25.12` (fixes govulncheck stdlib findings)
- Fold in open Dependabot bumps: `genkit/go` `v1.6.0` → `v1.10.0` (#14), `actions/checkout` `v6` → `v7` (#12)

## Test plan
- [x] `go test ./...` / `go vet ./...` / `staticcheck ./...` / `govulncheck ./...`
- [x] Apply `remote-script/` patch to AbletonOSC, then **fully restart** Ableton Live
  - Patch applied on disk (`browser.py` + `BrowserHandler` in `manager.py` / `__init__.py`)
  - Verified via hot-reload registration for this session; a full Live restart is still recommended so `manager.py` owns BrowserHandler cleanly
- [x] `ableton_test` succeeds
- [x] Browser search returns matches
  - Verified via `/live/browser/find` (`drum`, `808` returned matches; `Street` empty on this library)
  - `/live/browser/list_folder` `Drums` lists kits including `808 Boom Kit.adg`
- [x] Browser load puts a kit on a MIDI track; confirm with device list
  - Verified via `/live/browser/load_at_path` → track 4 loaded `808 Boom Kit.adg` (`0` → `1` devices; device name `808 Boom Kit`)
  - Note: name-only `/live/track/load/browser_item` missed `.adg` kits in Drums root; path load works. Follow-up candidate if name load should cover `.adg`
- [x] After merge: tag `v0.0.6-alpha` (or next), wait for GoReleaser, then `brew upgrade ableton-osc-mcp`
  - #12 / #14 already closed in favor of this PR