### PR TITLE
fix: bind OSC reply socket to 127.0.0.1

### DIFF
--- a/internal/abletonosc/client.go
+++ b/internal/abletonosc/client.go
@@ -70,7 +70,9 @@ func NewClient(remoteHost string, remotePort int, localPort int, timeout time.Du
 		pending:    make(map[string][]waitItem),
 	}
 
-	addr := fmt.Sprintf("0.0.0.0:%d", localPort)
+	// Bind IPv4 loopback explicitly. AbletonOSC replies to 127.0.0.1:<clientPort>;
+	// listening on 0.0.0.0 can end up IPv6-only on newer Go/macOS and miss replies.
+	addr := fmt.Sprintf("127.0.0.1:%d", localPort)
 	c.server = &osc.Server{
 		Addr: addr,
 		Dispatcher: anyDispatcher{


### PR DESCRIPTION
## Summary
- Bind the MCP OSC reply listener to `127.0.0.1` instead of `0.0.0.0`
- Fixes missing query replies (`ableton_test`, browser find/load, etc.) when AbletonOSC responds over IPv4 and the listener ends up IPv6-only on newer Go/macOS

## Test plan
- [x] `go test ./...`
- [x] Local binary: `ableton_test` returns `ok` with Ableton Live + AbletonOSC running
- [x] Confirmed listener shows `UDP 127.0.0.1:11001` (IPv4)
- [x] After merge: tag `v0.1.1-alpha`, `brew upgrade ableton-osc-mcp`, restore MCP configs to Homebrew binary