### PR TITLE
feat: mix bus, bounce session pass (v0.2.0-alpha)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,12 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_get_track_names` | List track names |
 | `ableton_get_track_devices` | List devices on a track |
 | `ableton_create_midi_track` | Create a MIDI track |
+| `ableton_create_audio_track` | Create an audio track |
 | `ableton_set_track_name` | Rename a track |
 | `ableton_mute_track` / `ableton_solo_track` | Mute/solo |
+| `ableton_arm_track` | Arm/disarm for recording |
+| `ableton_get_track_input_routing` / `ableton_set_track_input_routing` | Input routing (e.g. Resampling) |
+| `ableton_set_monitoring` | Monitoring state (0=In 1=Auto 2=Off) |
 | `ableton_set_track_volume` | Set track volume |
 | `ableton_create_clip` | Create a clip in a slot |
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
@@ -235,6 +239,12 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_find_browser_item` | Search Live Browser (requires patch) |
 | `ableton_load_browser_item` | Load Drum Rack / instrument onto a track |
 | `ableton_load_device_preset` | Hotswap a preset onto a device |
+| `ableton_get_track_meter` | Track output meter levels |
+| `ableton_get_master_meter` / `ableton_get_master_volume` / `ableton_set_master_volume` | Master meter/volume (requires master patch) |
+| `ableton_get_master_devices` / `ableton_get_master_device_parameters` / `ableton_set_master_device_parameter` | Master devices (requires master patch) |
+| `ableton_load_on_master` | Load Browser item onto master (requires browser+master patch) |
+| `ableton_get_session_record` / `ableton_set_session_record` | Session Record on/off |
+| `ableton_bounce_session_pass` | Record a scene pass onto a Bounce track via Resampling (tens of seconds; does not export WAV) |
 | `ableton_osc_send` | Send raw OSC message |
 
 ## Example Usage

--- a/internal/abletonosc/client.go
+++ b/internal/abletonosc/client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -11,43 +12,24 @@ import (
 	"github.com/hypebeast/go-osc/osc"
 )
 
-type anyDispatcher struct {
-	onMessage func(msg *osc.Message)
-}
-
-func (d anyDispatcher) Dispatch(packet osc.Packet) {
-	switch p := packet.(type) {
-	case *osc.Message:
-		d.onMessage(p)
-	case *osc.Bundle:
-		for _, msg := range p.Messages {
-			d.onMessage(msg)
-		}
-		for _, b := range p.Bundles {
-			d.Dispatch(b)
-		}
-	default:
-		// ignore
-	}
-}
-
 type waitItem struct {
 	ch    chan []interface{}
 	timer *time.Timer
 }
 
 type Client struct {
-	remoteHost string
-	remotePort int
+	remoteAddr *net.UDPAddr
 	timeout    time.Duration
 
-	client *osc.Client
-	server *osc.Server
+	conn net.PacketConn
 
 	mu      sync.Mutex
 	pending map[string][]waitItem
 }
 
+// NewClient binds one UDP socket for both send and receive.
+// AbletonOSC always replies to localPort (default 11001); using a single
+// socket avoids missed replies when send uses a separate ephemeral port.
 func NewClient(remoteHost string, remotePort int, localPort int, timeout time.Duration) (*Client, error) {
 	if remoteHost == "" {
 		return nil, errors.New("remoteHost is empty")
@@ -62,38 +44,67 @@ func NewClient(remoteHost string, remotePort int, localPort int, timeout time.Du
 		timeout = 500 * time.Millisecond
 	}
 
+	remoteAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", remoteHost, remotePort))
+	if err != nil {
+		return nil, fmt.Errorf("resolve remote: %w", err)
+	}
+
+	// Bind IPv4 loopback explicitly. Listening on 0.0.0.0 can end up IPv6-only
+	// on newer Go/macOS and miss AbletonOSC replies to 127.0.0.1.
+	localAddr := fmt.Sprintf("127.0.0.1:%d", localPort)
+	conn, err := net.ListenPacket("udp", localAddr)
+	if err != nil {
+		return nil, fmt.Errorf("listen %s: %w", localAddr, err)
+	}
+
 	c := &Client{
-		remoteHost: remoteHost,
-		remotePort: remotePort,
+		remoteAddr: remoteAddr,
 		timeout:    timeout,
-		client:     osc.NewClient(remoteHost, remotePort),
+		conn:       conn,
 		pending:    make(map[string][]waitItem),
 	}
 
-	// Bind IPv4 loopback explicitly. AbletonOSC replies to 127.0.0.1:<clientPort>;
-	// listening on 0.0.0.0 can end up IPv6-only on newer Go/macOS and miss replies.
-	addr := fmt.Sprintf("127.0.0.1:%d", localPort)
-	c.server = &osc.Server{
-		Addr: addr,
-		Dispatcher: anyDispatcher{
-			onMessage: c.handleMessage,
-		},
-	}
-
-	go func() {
-		// ListenAndServe will return on CloseConnection(); that's fine.
-		if err := c.server.ListenAndServe(); err != nil {
-			// Avoid stdout: MCP uses stdout. log writes to stderr.
-			log.Printf("AbletonOSC listen ended: %v", err)
-		}
-	}()
-
+	go c.readLoop()
 	return c, nil
 }
 
+func (c *Client) readLoop() {
+	buf := make([]byte, 65535)
+	for {
+		n, _, err := c.conn.ReadFrom(buf)
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			log.Printf("AbletonOSC read error: %v", err)
+			continue
+		}
+		packet, err := osc.ParsePacket(string(buf[:n]))
+		if err != nil {
+			log.Printf("AbletonOSC parse error: %v", err)
+			continue
+		}
+		c.dispatchPacket(packet)
+	}
+}
+
+func (c *Client) dispatchPacket(packet osc.Packet) {
+	switch p := packet.(type) {
+	case *osc.Message:
+		c.handleMessage(p)
+	case *osc.Bundle:
+		for _, msg := range p.Messages {
+			c.handleMessage(msg)
+		}
+		for _, b := range p.Bundles {
+			c.dispatchPacket(b)
+		}
+	}
+}
+
 func (c *Client) Close() error {
-	if c.server != nil {
-		return c.server.CloseConnection()
+	if c.conn != nil {
+		return c.conn.Close()
 	}
 	return nil
 }
@@ -104,7 +115,12 @@ func (c *Client) Send(address string, args ...interface{}) error {
 	}
 	msg := osc.NewMessage(address)
 	msg.Append(args...)
-	return c.client.Send(msg)
+	data, err := msg.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	_, err = c.conn.WriteTo(data, c.remoteAddr)
+	return err
 }
 
 func (c *Client) Query(address string, args ...interface{}) ([]interface{}, error) {
@@ -151,7 +167,6 @@ func (c *Client) QueryWithTimeout(timeout time.Duration, address string, args ..
 }
 
 func dropFirstWaiter(queue []waitItem, ch chan []interface{}) []waitItem {
-	// dropFirstWaiter removes the first matching waiter in FIFO order.
 	for i, w := range queue {
 		if w.ch == ch {
 			queue[i].timer.Stop()

--- a/internal/tools/ableton_mix.go
+++ b/internal/tools/ableton_mix.go
@@ -1,0 +1,322 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+type TrackMeterInput struct {
+	TrackIndex int `json:"track_index" jsonschema:"description=Track index (0-based regular tracks),minimum=0"`
+}
+
+type MeterOutput struct {
+	TrackIndex *int    `json:"track_index,omitempty"`
+	Level      float64 `json:"level" jsonschema:"description=Combined output meter level (0.0-1.0)"`
+	Left       float64 `json:"left"`
+	Right      float64 `json:"right"`
+}
+
+type MasterVolumeOutput struct {
+	Volume float64 `json:"volume" jsonschema:"description=Master volume (0.0=silence, ~0.85=0dB)"`
+}
+
+type SetMasterVolumeInput struct {
+	Volume float64 `json:"volume" jsonschema:"description=Master volume (0.0=silence, ~0.85=0dB),minimum=0,maximum=1"`
+}
+
+type MasterDevicesOutput struct {
+	Devices []TrackDevice `json:"devices"`
+}
+
+type MasterDeviceParametersInput struct {
+	DeviceIndex int `json:"device_index" jsonschema:"minimum=0"`
+}
+
+type SetMasterDeviceParameterInput struct {
+	DeviceIndex    int     `json:"device_index" jsonschema:"minimum=0"`
+	ParameterIndex int     `json:"parameter_index" jsonschema:"minimum=0"`
+	Value          float64 `json:"value"`
+}
+
+type LoadOnMasterInput struct {
+	RootName  string   `json:"root_name" jsonschema:"description=Browser root (e.g. Audio Effects)"`
+	PathParts []string `json:"path_parts,omitempty" jsonschema:"description=Optional folder path under root"`
+	ItemName  string   `json:"item_name" jsonschema:"description=Preset/device filename (e.g. Limiter.adv)"`
+}
+
+type LoadOnMasterOutput struct {
+	Loaded        string `json:"loaded"`
+	DevicesBefore int    `json:"devices_before"`
+	DevicesAfter  int    `json:"devices_after"`
+}
+
+func NewAbletonGetTrackMeter(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_track_meter", "Ableton Live: get track output meter levels",
+		func(_ *ai.ToolContext, input TrackMeterInput) (MeterOutput, error) {
+			if input.TrackIndex < 0 {
+				return MeterOutput{}, errors.New("track_index must be >= 0")
+			}
+			idx := int32(input.TrackIndex)
+			level, err := queryMeter(client, "/live/track/get/output_meter_level", idx)
+			if err != nil {
+				return MeterOutput{}, err
+			}
+			left, err := queryMeter(client, "/live/track/get/output_meter_left", idx)
+			if err != nil {
+				return MeterOutput{}, err
+			}
+			right, err := queryMeter(client, "/live/track/get/output_meter_right", idx)
+			if err != nil {
+				return MeterOutput{}, err
+			}
+			ti := input.TrackIndex
+			return MeterOutput{TrackIndex: &ti, Level: level, Left: left, Right: right}, nil
+		},
+	)
+}
+
+func NewAbletonGetMasterMeter(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_master_meter", "Ableton Live: get master output meter levels (requires master patch)",
+		func(_ *ai.ToolContext, _ struct{}) (MeterOutput, error) {
+			level, err := queryMeter(client, "/live/master/get/output_meter_level")
+			if err != nil {
+				return MeterOutput{}, err
+			}
+			left, err := queryMeter(client, "/live/master/get/output_meter_left")
+			if err != nil {
+				return MeterOutput{}, err
+			}
+			right, err := queryMeter(client, "/live/master/get/output_meter_right")
+			if err != nil {
+				return MeterOutput{}, err
+			}
+			return MeterOutput{Level: level, Left: left, Right: right}, nil
+		},
+	)
+}
+
+func NewAbletonGetMasterVolume(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_master_volume", "Ableton Live: get master volume (requires master patch)",
+		func(_ *ai.ToolContext, _ struct{}) (MasterVolumeOutput, error) {
+			res, err := client.Query("/live/master/get/volume")
+			if err != nil {
+				return MasterVolumeOutput{}, err
+			}
+			if err := ensureResponseLen(res, 1); err != nil {
+				return MasterVolumeOutput{}, err
+			}
+			v, err := abletonosc.AsFloat64(res[0])
+			if err != nil {
+				return MasterVolumeOutput{}, err
+			}
+			return MasterVolumeOutput{Volume: v}, nil
+		},
+	)
+}
+
+func NewAbletonSetMasterVolume(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_master_volume", "Ableton Live: set master volume (requires master patch)",
+		func(_ *ai.ToolContext, input SetMasterVolumeInput) (SentOutput, error) {
+			if input.Volume < 0 || input.Volume > 1 {
+				return SentOutput{}, errors.New("volume must be between 0 and 1")
+			}
+			if err := client.Send("/live/master/set/volume", float32(input.Volume)); err != nil {
+				return SentOutput{}, err
+			}
+			return SentOutput{Sent: true}, nil
+		},
+	)
+}
+
+func NewAbletonGetMasterDevices(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_master_devices", "Ableton Live: list devices on master track (requires master patch)",
+		func(_ *ai.ToolContext, _ struct{}) (MasterDevicesOutput, error) {
+			namesRes, err := client.Query("/live/master/get/devices/name")
+			if err != nil {
+				return MasterDevicesOutput{}, err
+			}
+			classRes, err := client.Query("/live/master/get/devices/class_name")
+			if err != nil {
+				return MasterDevicesOutput{}, err
+			}
+			typeRes, err := client.Query("/live/master/get/devices/type")
+			if err != nil {
+				return MasterDevicesOutput{}, err
+			}
+			n := len(namesRes)
+			if len(classRes) < n {
+				n = len(classRes)
+			}
+			if len(typeRes) < n {
+				n = len(typeRes)
+			}
+			devices := make([]TrackDevice, 0, n)
+			for i := 0; i < n; i++ {
+				t, err := abletonosc.AsInt(typeRes[i])
+				if err != nil {
+					return MasterDevicesOutput{}, err
+				}
+				devices = append(devices, TrackDevice{
+					Name:      fmt.Sprint(namesRes[i]),
+					ClassName: fmt.Sprint(classRes[i]),
+					Type:      t,
+				})
+			}
+			return MasterDevicesOutput{Devices: devices}, nil
+		},
+	)
+}
+
+func NewAbletonGetMasterDeviceParameters(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_master_device_parameters", "Ableton Live: get master device parameters (requires master patch)",
+		func(_ *ai.ToolContext, input MasterDeviceParametersInput) (DeviceParametersOutput, error) {
+			if input.DeviceIndex < 0 {
+				return DeviceParametersOutput{}, errors.New("device_index must be >= 0")
+			}
+			idx := int32(input.DeviceIndex)
+			namesRes, err := client.Query("/live/master/device/get/parameters/name", idx)
+			if err != nil {
+				return DeviceParametersOutput{}, err
+			}
+			valuesRes, err := client.Query("/live/master/device/get/parameters/value", idx)
+			if err != nil {
+				return DeviceParametersOutput{}, err
+			}
+			minsRes, err := client.Query("/live/master/device/get/parameters/min", idx)
+			if err != nil {
+				return DeviceParametersOutput{}, err
+			}
+			maxsRes, err := client.Query("/live/master/device/get/parameters/max", idx)
+			if err != nil {
+				return DeviceParametersOutput{}, err
+			}
+			names := skipLeadingIndex(namesRes)
+			values := skipLeadingIndex(valuesRes)
+			mins := skipLeadingIndex(minsRes)
+			maxs := skipLeadingIndex(maxsRes)
+			n := len(names)
+			if len(values) < n {
+				n = len(values)
+			}
+			if len(mins) < n {
+				n = len(mins)
+			}
+			if len(maxs) < n {
+				n = len(maxs)
+			}
+			params := make([]DeviceParameter, 0, n)
+			for i := 0; i < n; i++ {
+				v, err := abletonosc.AsFloat64(values[i])
+				if err != nil {
+					return DeviceParametersOutput{}, err
+				}
+				mn, err := abletonosc.AsFloat64(mins[i])
+				if err != nil {
+					return DeviceParametersOutput{}, err
+				}
+				mx, err := abletonosc.AsFloat64(maxs[i])
+				if err != nil {
+					return DeviceParametersOutput{}, err
+				}
+				params = append(params, DeviceParameter{
+					Index: i,
+					Name:  fmt.Sprint(names[i]),
+					Value: v,
+					Min:   mn,
+					Max:   mx,
+				})
+			}
+			return DeviceParametersOutput{
+				TrackIndex:  -1,
+				DeviceIndex: input.DeviceIndex,
+				Parameters:  params,
+			}, nil
+		},
+	)
+}
+
+func NewAbletonSetMasterDeviceParameter(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_master_device_parameter", "Ableton Live: set a master device parameter (requires master patch)",
+		func(_ *ai.ToolContext, input SetMasterDeviceParameterInput) (SentOutput, error) {
+			if input.DeviceIndex < 0 || input.ParameterIndex < 0 {
+				return SentOutput{}, errors.New("device_index and parameter_index must be >= 0")
+			}
+			if _, err := client.Query(
+				"/live/master/device/set/parameter/value",
+				int32(input.DeviceIndex),
+				int32(input.ParameterIndex),
+				float32(input.Value),
+			); err != nil {
+				return SentOutput{}, err
+			}
+			return SentOutput{Sent: true}, nil
+		},
+	)
+}
+
+func NewAbletonLoadOnMaster(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_load_on_master", "Ableton Live: load a Browser item onto the master track (requires browser+master patch)",
+		func(_ *ai.ToolContext, input LoadOnMasterInput) (LoadOnMasterOutput, error) {
+			if input.RootName == "" || input.ItemName == "" {
+				return LoadOnMasterOutput{}, errors.New("root_name and item_name are required")
+			}
+			args := []interface{}{int32(-1), int32(-1), input.RootName}
+			for _, p := range input.PathParts {
+				args = append(args, p)
+			}
+			args = append(args, input.ItemName)
+			res, err := client.QueryWithTimeout(10*time.Second, "/live/browser/load_at_path", args...)
+			if err != nil {
+				return LoadOnMasterOutput{}, err
+			}
+			if err := ensureResponseLen(res, 5); err != nil {
+				return LoadOnMasterOutput{}, err
+			}
+			status := fmt.Sprint(res[1])
+			if status != "loaded" {
+				return LoadOnMasterOutput{}, fmt.Errorf("load failed: status=%s reply=%v", status, res)
+			}
+			before, err := abletonosc.AsInt(res[3])
+			if err != nil {
+				return LoadOnMasterOutput{}, err
+			}
+			after, err := abletonosc.AsInt(res[4])
+			if err != nil {
+				return LoadOnMasterOutput{}, err
+			}
+			return LoadOnMasterOutput{
+				Loaded:        fmt.Sprint(res[2]),
+				DevicesBefore: before,
+				DevicesAfter:  after,
+			}, nil
+		},
+	)
+}
+
+func queryMeter(client *abletonosc.Client, address string, args ...interface{}) (float64, error) {
+	res, err := client.Query(address, args...)
+	if err != nil {
+		return 0, err
+	}
+	// track meter: [track_index, value]; master meter: [value]
+	if len(res) >= 2 {
+		return abletonosc.AsFloat64(res[1])
+	}
+	if len(res) >= 1 {
+		return abletonosc.AsFloat64(res[0])
+	}
+	return 0, errors.New("empty meter response")
+}
+
+func skipLeadingIndex(res []interface{}) []interface{} {
+	if len(res) == 0 {
+		return res
+	}
+	return res[1:]
+}

--- a/internal/tools/ableton_record.go
+++ b/internal/tools/ableton_record.go
@@ -1,0 +1,400 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+type CreateAudioTrackInput struct {
+	Index *int `json:"index,omitempty" jsonschema:"description=Track index (-1 to append),minimum=-1"`
+}
+
+type ArmTrackInput struct {
+	TrackIndex int  `json:"track_index" jsonschema:"minimum=0"`
+	Armed      bool `json:"armed" jsonschema:"description=true to arm; false to disarm"`
+}
+
+type SetInputRoutingInput struct {
+	TrackIndex  int    `json:"track_index" jsonschema:"minimum=0"`
+	RoutingType string `json:"routing_type" jsonschema:"description=Input routing type display name (e.g. Resampling)"`
+}
+
+type InputRoutingOutput struct {
+	TrackIndex  int      `json:"track_index"`
+	RoutingType string   `json:"routing_type"`
+	Available   []string `json:"available,omitempty"`
+}
+
+type SetMonitoringInput struct {
+	TrackIndex int `json:"track_index" jsonschema:"minimum=0"`
+	State      int `json:"state" jsonschema:"description=0=In 1=Auto 2=Off,minimum=0,maximum=2"`
+}
+
+type SessionRecordInput struct {
+	Enabled bool `json:"enabled" jsonschema:"description=true to enable Session Record"`
+}
+
+type SessionRecordOutput struct {
+	Enabled bool `json:"enabled"`
+}
+
+type BounceSessionPassInput struct {
+	SceneIndices []int  `json:"scene_indices,omitempty" jsonschema:"description=Scene indices to fire in order (default Intro/Verse/Hook/Bridge/Hook = 2,1,0,3,0)"`
+	BarsPerScene int    `json:"bars_per_scene,omitempty" jsonschema:"description=Bars to wait after each scene fire (default 4),minimum=1,maximum=64"`
+	TrackName    string `json:"track_name,omitempty" jsonschema:"description=Bounce destination track name (default Bounce)"`
+}
+
+type BounceSessionPassOutput struct {
+	OK           bool    `json:"ok"`
+	TrackIndex   int     `json:"track_index"`
+	TrackName    string  `json:"track_name"`
+	ScenesFired  []int   `json:"scenes_fired"`
+	BarsPerScene int     `json:"bars_per_scene"`
+	DurationSec  float64 `json:"duration_sec"`
+	RoutingType  string  `json:"routing_type"`
+}
+
+func NewAbletonCreateAudioTrack(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_create_audio_track", "Ableton Live: create audio track",
+		func(_ *ai.ToolContext, input CreateAudioTrackInput) (NumTracksOutput, error) {
+			index := -1
+			if input.Index != nil {
+				index = *input.Index
+				if index < -1 {
+					return NumTracksOutput{}, errors.New("index must be -1 or >= 0")
+				}
+			}
+			if err := client.Send("/live/song/create_audio_track", int32(index)); err != nil {
+				return NumTracksOutput{}, err
+			}
+			res, err := client.Query("/live/song/get/num_tracks")
+			if err != nil {
+				return NumTracksOutput{}, err
+			}
+			if err := ensureResponseLen(res, 1); err != nil {
+				return NumTracksOutput{}, err
+			}
+			n, err := abletonosc.AsInt(res[0])
+			if err != nil {
+				return NumTracksOutput{}, err
+			}
+			return NumTracksOutput{NumTracks: n}, nil
+		},
+	)
+}
+
+func NewAbletonArmTrack(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_arm_track", "Ableton Live: arm or disarm a track for recording",
+		func(_ *ai.ToolContext, input ArmTrackInput) (SentOutput, error) {
+			if input.TrackIndex < 0 {
+				return SentOutput{}, errors.New("track_index must be >= 0")
+			}
+			val := int32(0)
+			if input.Armed {
+				val = 1
+			}
+			if err := client.Send("/live/track/set/arm", int32(input.TrackIndex), val); err != nil {
+				return SentOutput{}, err
+			}
+			return SentOutput{Sent: true}, nil
+		},
+	)
+}
+
+func NewAbletonGetTrackInputRouting(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_track_input_routing", "Ableton Live: get track input routing type and available types",
+		func(_ *ai.ToolContext, input TrackDevicesInput) (InputRoutingOutput, error) {
+			if input.TrackIndex < 0 {
+				return InputRoutingOutput{}, errors.New("track_index must be >= 0")
+			}
+			cur, err := client.Query("/live/track/get/input_routing_type", int32(input.TrackIndex))
+			if err != nil {
+				return InputRoutingOutput{}, err
+			}
+			if err := ensureResponseLen(cur, 2); err != nil {
+				return InputRoutingOutput{}, err
+			}
+			avail, err := client.Query("/live/track/get/available_input_routing_types", int32(input.TrackIndex))
+			if err != nil {
+				return InputRoutingOutput{}, err
+			}
+			if err := ensureResponseLen(avail, 1); err != nil {
+				return InputRoutingOutput{}, err
+			}
+			return InputRoutingOutput{
+				TrackIndex:  input.TrackIndex,
+				RoutingType: fmt.Sprint(cur[1]),
+				Available:   toStringSlice(avail[1:]),
+			}, nil
+		},
+	)
+}
+
+func NewAbletonSetTrackInputRouting(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_track_input_routing", "Ableton Live: set track input routing type (e.g. Resampling)",
+		func(_ *ai.ToolContext, input SetInputRoutingInput) (SentOutput, error) {
+			if input.TrackIndex < 0 {
+				return SentOutput{}, errors.New("track_index must be >= 0")
+			}
+			if strings.TrimSpace(input.RoutingType) == "" {
+				return SentOutput{}, errors.New("routing_type is required")
+			}
+			if err := client.Send("/live/track/set/input_routing_type", int32(input.TrackIndex), input.RoutingType); err != nil {
+				return SentOutput{}, err
+			}
+			return SentOutput{Sent: true}, nil
+		},
+	)
+}
+
+func NewAbletonSetMonitoring(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_monitoring", "Ableton Live: set track monitoring state (0=In 1=Auto 2=Off)",
+		func(_ *ai.ToolContext, input SetMonitoringInput) (SentOutput, error) {
+			if input.TrackIndex < 0 {
+				return SentOutput{}, errors.New("track_index must be >= 0")
+			}
+			if input.State < 0 || input.State > 2 {
+				return SentOutput{}, errors.New("state must be 0 (In), 1 (Auto), or 2 (Off)")
+			}
+			if err := client.Send("/live/track/set/current_monitoring_state", int32(input.TrackIndex), int32(input.State)); err != nil {
+				return SentOutput{}, err
+			}
+			return SentOutput{Sent: true}, nil
+		},
+	)
+}
+
+func NewAbletonSetSessionRecord(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_session_record", "Ableton Live: enable or disable Session Record",
+		func(_ *ai.ToolContext, input SessionRecordInput) (SentOutput, error) {
+			val := int32(0)
+			if input.Enabled {
+				val = 1
+			}
+			if err := client.Send("/live/song/set/session_record", val); err != nil {
+				return SentOutput{}, err
+			}
+			return SentOutput{Sent: true}, nil
+		},
+	)
+}
+
+func NewAbletonGetSessionRecord(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_session_record", "Ableton Live: get Session Record enabled state",
+		func(_ *ai.ToolContext, _ EmptyInput) (SessionRecordOutput, error) {
+			res, err := client.Query("/live/song/get/session_record")
+			if err != nil {
+				return SessionRecordOutput{}, err
+			}
+			if err := ensureResponseLen(res, 1); err != nil {
+				return SessionRecordOutput{}, err
+			}
+			enabled, err := asBoolish(res[0])
+			if err != nil {
+				return SessionRecordOutput{}, err
+			}
+			return SessionRecordOutput{Enabled: enabled}, nil
+		},
+	)
+}
+
+func NewAbletonBounceSessionPass(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_bounce_session_pass",
+		"Ableton Live: record a scene pass onto a Bounce audio track via Resampling (does not export WAV; leaves a Session clip). Takes tens of seconds.",
+		func(_ *ai.ToolContext, input BounceSessionPassInput) (BounceSessionPassOutput, error) {
+			scenes := input.SceneIndices
+			if len(scenes) == 0 {
+				scenes = []int{2, 1, 0, 3, 0} // Intro, Verse, Hook, Bridge, Hook
+			}
+			bars := input.BarsPerScene
+			if bars <= 0 {
+				bars = 4
+			}
+			if bars > 64 {
+				return BounceSessionPassOutput{}, errors.New("bars_per_scene must be <= 64")
+			}
+			trackName := strings.TrimSpace(input.TrackName)
+			if trackName == "" {
+				trackName = "Bounce"
+			}
+
+			tempoRes, err := client.Query("/live/song/get/tempo")
+			if err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			if err := ensureResponseLen(tempoRes, 1); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			tempo, err := abletonosc.AsFloat64(tempoRes[0])
+			if err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			if tempo < 10 {
+				return BounceSessionPassOutput{}, fmt.Errorf("unexpected tempo: %v", tempo)
+			}
+			wait := time.Duration(float64(bars)*4.0*(60.0/tempo)*float64(time.Second) + 0.05*float64(time.Second))
+
+			trackIndex, err := ensureNamedAudioTrack(client, trackName)
+			if err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+
+			routing, err := pickResamplingRouting(client, trackIndex)
+			if err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			if err := client.Send("/live/track/set/input_routing_type", int32(trackIndex), routing); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			// Monitoring In (0), mute bounce to avoid feedback, arm.
+			if err := client.Send("/live/track/set/current_monitoring_state", int32(trackIndex), int32(0)); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			if err := client.Send("/live/track/set/mute", int32(trackIndex), int32(1)); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			if err := client.Send("/live/track/set/arm", int32(trackIndex), int32(1)); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+
+			// Session launch hygiene (lessons from mix sessions).
+			if err := client.Send("/live/song/set/back_to_arranger", int32(0)); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			if err := client.Send("/live/song/set/clip_trigger_quantization", int32(13)); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			if err := client.Send("/live/song/stop_all_clips"); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			time.Sleep(300 * time.Millisecond)
+
+			if err := client.Send("/live/song/set/session_record", int32(1)); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			time.Sleep(200 * time.Millisecond)
+
+			fired := make([]int, 0, len(scenes))
+			start := time.Now()
+			for _, scene := range scenes {
+				if scene < 0 {
+					_ = client.Send("/live/song/set/session_record", int32(0))
+					_ = client.Send("/live/track/set/arm", int32(trackIndex), int32(0))
+					return BounceSessionPassOutput{}, fmt.Errorf("invalid scene_index: %d", scene)
+				}
+				if err := client.Send("/live/song/set/back_to_arranger", int32(0)); err != nil {
+					return BounceSessionPassOutput{}, err
+				}
+				if err := client.Send("/live/scene/fire", int32(scene)); err != nil {
+					_ = client.Send("/live/song/set/session_record", int32(0))
+					return BounceSessionPassOutput{}, err
+				}
+				fired = append(fired, scene)
+				time.Sleep(wait)
+			}
+
+			if err := client.Send("/live/song/set/session_record", int32(0)); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			if err := client.Send("/live/track/set/arm", int32(trackIndex), int32(0)); err != nil {
+				return BounceSessionPassOutput{}, err
+			}
+			_ = client.Send("/live/song/stop_all_clips")
+
+			return BounceSessionPassOutput{
+				OK:           true,
+				TrackIndex:   trackIndex,
+				TrackName:    trackName,
+				ScenesFired:  fired,
+				BarsPerScene: bars,
+				DurationSec:  time.Since(start).Seconds(),
+				RoutingType:  routing,
+			}, nil
+		},
+	)
+}
+
+func ensureNamedAudioTrack(client *abletonosc.Client, name string) (int, error) {
+	namesRes, err := client.Query("/live/song/get/track_names")
+	if err != nil {
+		return -1, err
+	}
+	names := toStringSlice(namesRes)
+	for i, n := range names {
+		if n == name {
+			return i, nil
+		}
+	}
+	if err := client.Send("/live/song/create_audio_track", int32(-1)); err != nil {
+		return -1, err
+	}
+	time.Sleep(150 * time.Millisecond)
+	namesRes, err = client.Query("/live/song/get/track_names")
+	if err != nil {
+		return -1, err
+	}
+	names = toStringSlice(namesRes)
+	if len(names) == 0 {
+		return -1, errors.New("no tracks after create_audio_track")
+	}
+	idx := len(names) - 1
+	if err := client.Send("/live/track/set/name", int32(idx), name); err != nil {
+		return -1, err
+	}
+	return idx, nil
+}
+
+func pickResamplingRouting(client *abletonosc.Client, trackIndex int) (string, error) {
+	avail, err := client.Query("/live/track/get/available_input_routing_types", int32(trackIndex))
+	if err != nil {
+		return "", err
+	}
+	if err := ensureResponseLen(avail, 1); err != nil {
+		return "", err
+	}
+	types := toStringSlice(avail[1:])
+	for _, t := range types {
+		if strings.EqualFold(t, "Resampling") {
+			return t, nil
+		}
+	}
+	for _, t := range types {
+		if strings.Contains(strings.ToLower(t), "resampling") {
+			return t, nil
+		}
+	}
+	return "", fmt.Errorf("Resampling input not available on track %d; available=%v", trackIndex, types)
+}
+
+func asBoolish(v interface{}) (bool, error) {
+	switch x := v.(type) {
+	case bool:
+		return x, nil
+	case int32:
+		return x != 0, nil
+	case int64:
+		return x != 0, nil
+	case int:
+		return x != 0, nil
+	case float64:
+		return x != 0, nil
+	case float32:
+		return x != 0, nil
+	default:
+		s := strings.ToLower(fmt.Sprint(v))
+		if s == "true" || s == "1" {
+			return true, nil
+		}
+		if s == "false" || s == "0" {
+			return false, nil
+		}
+		return false, fmt.Errorf("cannot parse bool from %v (%T)", v, v)
+	}
+}

--- a/internal/tools/ableton_record.go
+++ b/internal/tools/ableton_record.go
@@ -370,7 +370,7 @@ func pickResamplingRouting(client *abletonosc.Client, trackIndex int) (string, e
 			return t, nil
 		}
 	}
-	return "", fmt.Errorf("Resampling input not available on track %d; available=%v", trackIndex, types)
+	return "", fmt.Errorf("resampling input not available on track %d; available=%v", trackIndex, types)
 }
 
 func asBoolish(v interface{}) (bool, error) {

--- a/main.go
+++ b/main.go
@@ -56,10 +56,15 @@ func main() {
 		tools.NewAbletonGetTrackNames(g, ableton),
 		tools.NewAbletonGetTrackDevices(g, ableton),
 		tools.NewAbletonCreateMidiTrack(g, ableton),
+		tools.NewAbletonCreateAudioTrack(g, ableton),
 		tools.NewAbletonSetTrackName(g, ableton),
 		tools.NewAbletonMuteTrack(g, ableton),
 		tools.NewAbletonSoloTrack(g, ableton),
 		tools.NewAbletonSetTrackVolume(g, ableton),
+		tools.NewAbletonArmTrack(g, ableton),
+		tools.NewAbletonGetTrackInputRouting(g, ableton),
+		tools.NewAbletonSetTrackInputRouting(g, ableton),
+		tools.NewAbletonSetMonitoring(g, ableton),
 
 		// Clips
 		tools.NewAbletonCreateClip(g, ableton),
@@ -80,6 +85,21 @@ func main() {
 		tools.NewAbletonFindBrowserItem(g, ableton),
 		tools.NewAbletonLoadBrowserItem(g, ableton),
 		tools.NewAbletonLoadDevicePreset(g, ableton),
+
+		// Mix bus / Master
+		tools.NewAbletonGetTrackMeter(g, ableton),
+		tools.NewAbletonGetMasterMeter(g, ableton),
+		tools.NewAbletonGetMasterVolume(g, ableton),
+		tools.NewAbletonSetMasterVolume(g, ableton),
+		tools.NewAbletonGetMasterDevices(g, ableton),
+		tools.NewAbletonGetMasterDeviceParameters(g, ableton),
+		tools.NewAbletonSetMasterDeviceParameter(g, ableton),
+		tools.NewAbletonLoadOnMaster(g, ableton),
+
+		// Bounce / Session Record
+		tools.NewAbletonGetSessionRecord(g, ableton),
+		tools.NewAbletonSetSessionRecord(g, ableton),
+		tools.NewAbletonBounceSessionPass(g, ableton),
 
 		// Raw OSC
 		tools.NewAbletonOscSend(g, ableton),

--- a/remote-script/README.md
+++ b/remote-script/README.md
@@ -1,6 +1,6 @@
-# AbletonOSC Browser Patch
+# AbletonOSC Browser + Master Patch
 
-Adds Live Browser `load_item()` support so MCP tools can load Drum Racks and presets without drag-and-drop.
+Adds Live Browser `load_item()` support and master-track mix helpers so MCP tools can load devices and adjust the mix bus without drag-and-drop.
 
 ## What it adds
 
@@ -10,8 +10,14 @@ Adds Live Browser `load_item()` support so MCP tools can load Drum Racks and pre
 | `/live/track/load/browser_item` | `track_index`, `item_name` | Load by name onto a track |
 | `/live/device/load/preset` | `track_index`, `device_index`, `preset_name` | Hotswap preset onto a device |
 | `/live/browser/list_folder` | `root_name`, `*path_parts` | List folder children |
-| `/live/browser/load_at_path` | `track_index`, `device_index`, `root_name`, `*path_parts`, `item_name` | Load by exact path |
+| `/live/browser/load_at_path` | `track_index` (`-1`=master), `device_index`, `root_name`, `*path_parts`, `item_name` | Load by exact path |
 | `/live/browser/debug` | _(none)_ | Dump browser roots (debug) |
+| `/live/master/get/volume` | — | Master volume |
+| `/live/master/set/volume` | `volume` | Set master volume |
+| `/live/master/get/output_meter_level` / `left` / `right` | — | Master meters |
+| `/live/master/get/devices/name` / `class_name` / `type` | — | Master devices |
+| `/live/master/device/get/parameters/{name,value,min,max}` | `device_index` | Master device params |
+| `/live/master/device/set/parameter/value` | `device_index`, `parameter_index`, `value` | Set master device param |
 
 ## Install (macOS)
 
@@ -24,24 +30,12 @@ From this repository root:
 ```bash
 ABLETONOSC="$HOME/Music/Ableton/User Library/Remote Scripts/AbletonOSC"
 
-# 1. Copy BrowserHandler
 cp remote-script/abletonosc/browser.py "$ABLETONOSC/abletonosc/browser.py"
-
-# 2. Register the handler (idempotent-ish — skip if already present)
-grep -q 'BrowserHandler' "$ABLETONOSC/abletonosc/__init__.py" || \
-  printf '\nfrom .browser import BrowserHandler\n' >> "$ABLETONOSC/abletonosc/__init__.py"
-
-# 3. Add BrowserHandler to manager.py handlers list and reload_imports
-#    See "Manual manager.py edits" below if you prefer editing by hand.
+cp remote-script/abletonosc/master.py "$ABLETONOSC/abletonosc/master.py"
 python3 remote-script/apply_manager_patch.py "$ABLETONOSC"
 ```
 
-Then in Ableton Live:
-
-1. Preferences → Link / Tempo / MIDI → Control Surface = **AbletonOSC**
-2. **Restart Ableton Live** (required the first time you apply this patch — `/live/api/reload` does not reload `manager.py`)
-
-After a full restart, `/live/browser/find` should respond.
+Then **fully restart Ableton Live** (hot-reload is not enough after `manager.py` changes).
 
 ## Manual manager.py edits
 
@@ -49,20 +43,19 @@ In `manager.py` `init_api` handlers list, add:
 
 ```python
 abletonosc.BrowserHandler(self),
+abletonosc.MasterHandler(self),
 ```
 
 In `reload_imports`, add:
 
 ```python
 importlib.reload(abletonosc.browser)
+importlib.reload(abletonosc.master)
 ```
 
-## Cleanup (optional)
+In `abletonosc/__init__.py`:
 
-If you previously patched browser logic into `device.py` / `track.py`, remove those inline handlers so only `browser.py` owns them. Stock AbletonOSC does not include them, so a fresh clone + this patch is enough.
-
-## Windows paths
-
-```text
-%USERPROFILE%\Documents\Ableton\User Library\Remote Scripts\AbletonOSC
+```python
+from .browser import BrowserHandler
+from .master import MasterHandler
 ```

--- a/remote-script/abletonosc/browser.py
+++ b/remote-script/abletonosc/browser.py
@@ -133,7 +133,8 @@ class BrowserHandler(AbletonOSCHandler):
 
         def browser_load_at_path_handler(params: Tuple[Any]):
             """Load browser item by path.
-            Params: track_index, hotswap_device_index (-1 to append), root_name, *path_parts, item_name
+            Params: track_index (-1 = master), hotswap_device_index (-1 to append),
+                    root_name, *path_parts, item_name
             """
             track_index = int(params[0])
             device_index = int(params[1])
@@ -141,7 +142,10 @@ class BrowserHandler(AbletonOSCHandler):
                 return ("error", "missing_path")
             root_name = str(params[2])
             *path_parts, item_name = [str(p) for p in params[3:]]
-            track = self.song.tracks[track_index]
+            if track_index == -1:
+                track = self.song.master_track
+            else:
+                track = self.song.tracks[track_index]
             browser = Live.Application.get_application().browser
             node = _resolve_path(browser, root_name, path_parts)
             if node is None:
@@ -222,3 +226,81 @@ class BrowserHandler(AbletonOSCHandler):
         self.osc_server.add_handler("/live/browser/load_at_path", browser_load_at_path_handler)
         self.osc_server.add_handler("/live/track/load/browser_item", track_load_browser_item_handler)
         self.osc_server.add_handler("/live/device/load/preset", device_load_preset_handler)
+
+        # Master-track helpers (also registered by MasterHandler; kept here so hot-reload
+        # of browser.py always restores them even if master.py fails to import).
+        def _master():
+            return self.song.master_track
+
+        def master_get_volume(_params):
+            return (_master().mixer_device.volume.value,)
+
+        def master_set_volume(params):
+            _master().mixer_device.volume.value = float(params[0])
+
+        def master_get_meter_level(_params):
+            return (_master().output_meter_level,)
+
+        def master_get_meter_left(_params):
+            return (_master().output_meter_left,)
+
+        def master_get_meter_right(_params):
+            return (_master().output_meter_right,)
+
+        def master_get_num_devices(_params):
+            return (len(_master().devices),)
+
+        def master_get_devices_name(_params):
+            return tuple(d.name for d in _master().devices)
+
+        def master_get_devices_class_name(_params):
+            return tuple(d.class_name for d in _master().devices)
+
+        def master_get_devices_type(_params):
+            return tuple(int(d.type) for d in _master().devices)
+
+        def master_get_device_parameters_name(params):
+            device_index = int(params[0])
+            device = _master().devices[device_index]
+            names = [p.name for p in device.parameters]
+            return tuple([device_index] + names)
+
+        def master_get_device_parameters_value(params):
+            device_index = int(params[0])
+            device = _master().devices[device_index]
+            values = [p.value for p in device.parameters]
+            return tuple([device_index] + values)
+
+        def master_get_device_parameters_min(params):
+            device_index = int(params[0])
+            device = _master().devices[device_index]
+            values = [p.min for p in device.parameters]
+            return tuple([device_index] + values)
+
+        def master_get_device_parameters_max(params):
+            device_index = int(params[0])
+            device = _master().devices[device_index]
+            values = [p.max for p in device.parameters]
+            return tuple([device_index] + values)
+
+        def master_set_device_parameter(params):
+            device_index = int(params[0])
+            parameter_index = int(params[1])
+            value = float(params[2])
+            _master().devices[device_index].parameters[parameter_index].value = value
+            return (device_index, parameter_index, value)
+
+        self.osc_server.add_handler("/live/master/get/volume", master_get_volume)
+        self.osc_server.add_handler("/live/master/set/volume", master_set_volume)
+        self.osc_server.add_handler("/live/master/get/output_meter_level", master_get_meter_level)
+        self.osc_server.add_handler("/live/master/get/output_meter_left", master_get_meter_left)
+        self.osc_server.add_handler("/live/master/get/output_meter_right", master_get_meter_right)
+        self.osc_server.add_handler("/live/master/get/num_devices", master_get_num_devices)
+        self.osc_server.add_handler("/live/master/get/devices/name", master_get_devices_name)
+        self.osc_server.add_handler("/live/master/get/devices/class_name", master_get_devices_class_name)
+        self.osc_server.add_handler("/live/master/get/devices/type", master_get_devices_type)
+        self.osc_server.add_handler("/live/master/device/get/parameters/name", master_get_device_parameters_name)
+        self.osc_server.add_handler("/live/master/device/get/parameters/value", master_get_device_parameters_value)
+        self.osc_server.add_handler("/live/master/device/get/parameters/min", master_get_device_parameters_min)
+        self.osc_server.add_handler("/live/master/device/get/parameters/max", master_get_device_parameters_max)
+        self.osc_server.add_handler("/live/master/device/set/parameter/value", master_set_device_parameter)

--- a/remote-script/abletonosc/master.py
+++ b/remote-script/abletonosc/master.py
@@ -1,0 +1,84 @@
+"""Master track OSC handlers for AbletonOSC (mix-bus helpers)."""
+
+from typing import Any, Tuple
+
+from .handler import AbletonOSCHandler
+
+
+class MasterHandler(AbletonOSCHandler):
+    def __init__(self, manager):
+        super().__init__(manager)
+        self.class_identifier = "master"
+
+    def init_api(self):
+        def master_track():
+            return self.song.master_track
+
+        def get_volume(_params: Tuple[Any]):
+            return (master_track().mixer_device.volume.value,)
+
+        def set_volume(params: Tuple[Any]):
+            master_track().mixer_device.volume.value = float(params[0])
+
+        def get_meter_level(_params: Tuple[Any]):
+            return (master_track().output_meter_level,)
+
+        def get_meter_left(_params: Tuple[Any]):
+            return (master_track().output_meter_left,)
+
+        def get_meter_right(_params: Tuple[Any]):
+            return (master_track().output_meter_right,)
+
+        def get_num_devices(_params: Tuple[Any]):
+            return (len(master_track().devices),)
+
+        def get_devices_name(_params: Tuple[Any]):
+            return tuple(d.name for d in master_track().devices)
+
+        def get_devices_class_name(_params: Tuple[Any]):
+            return tuple(d.class_name for d in master_track().devices)
+
+        def get_devices_type(_params: Tuple[Any]):
+            return tuple(int(d.type) for d in master_track().devices)
+
+        def get_device_parameters_name(params: Tuple[Any]):
+            device_index = int(params[0])
+            device = master_track().devices[device_index]
+            return tuple([device_index] + [p.name for p in device.parameters])
+
+        def get_device_parameters_value(params: Tuple[Any]):
+            device_index = int(params[0])
+            device = master_track().devices[device_index]
+            return tuple([device_index] + [p.value for p in device.parameters])
+
+        def get_device_parameters_min(params: Tuple[Any]):
+            device_index = int(params[0])
+            device = master_track().devices[device_index]
+            return tuple([device_index] + [p.min for p in device.parameters])
+
+        def get_device_parameters_max(params: Tuple[Any]):
+            device_index = int(params[0])
+            device = master_track().devices[device_index]
+            return tuple([device_index] + [p.max for p in device.parameters])
+
+        def set_device_parameter(params: Tuple[Any]):
+            device_index = int(params[0])
+            parameter_index = int(params[1])
+            value = float(params[2])
+            master_track().devices[device_index].parameters[parameter_index].value = value
+            return (device_index, parameter_index, value)
+
+        self.osc_server.add_handler("/live/master/get/volume", get_volume)
+        self.osc_server.add_handler("/live/master/set/volume", set_volume)
+        self.osc_server.add_handler("/live/master/get/output_meter_level", get_meter_level)
+        self.osc_server.add_handler("/live/master/get/output_meter_left", get_meter_left)
+        self.osc_server.add_handler("/live/master/get/output_meter_right", get_meter_right)
+        self.osc_server.add_handler("/live/master/get/num_devices", get_num_devices)
+        self.osc_server.add_handler("/live/master/get/devices/name", get_devices_name)
+        self.osc_server.add_handler("/live/master/get/devices/class_name", get_devices_class_name)
+        self.osc_server.add_handler("/live/master/get/devices/type", get_devices_type)
+        self.osc_server.add_handler("/live/master/device/get/parameters/name", get_device_parameters_name)
+        self.osc_server.add_handler("/live/master/device/get/parameters/value", get_device_parameters_value)
+        self.osc_server.add_handler("/live/master/device/get/parameters/min", get_device_parameters_min)
+        self.osc_server.add_handler("/live/master/device/get/parameters/max", get_device_parameters_max)
+        self.osc_server.add_handler("/live/master/device/set/parameter/value", set_device_parameter)

--- a/remote-script/apply_manager_patch.py
+++ b/remote-script/apply_manager_patch.py
@@ -18,12 +18,42 @@ def patch(manager_path: Path) -> None:
             1,
         )
 
+    if "abletonosc.MasterHandler(self)" not in text:
+        # Prefer registering after BrowserHandler when present.
+        if "abletonosc.BrowserHandler(self)," in text:
+            text = text.replace(
+                "abletonosc.BrowserHandler(self),",
+                "abletonosc.BrowserHandler(self),\n                abletonosc.MasterHandler(self),",
+                1,
+            )
+        else:
+            text = text.replace(
+                "abletonosc.DeviceHandler(self),",
+                "abletonosc.DeviceHandler(self),\n                abletonosc.MasterHandler(self),",
+                1,
+            )
+
     if "importlib.reload(abletonosc.browser)" not in text:
         text = text.replace(
             "importlib.reload(abletonosc.device)",
             "importlib.reload(abletonosc.device)\n            importlib.reload(abletonosc.browser)",
             1,
         )
+
+    if "importlib.reload(abletonosc.master)" not in text:
+        anchor = "importlib.reload(abletonosc.browser)"
+        if anchor in text:
+            text = text.replace(
+                anchor,
+                anchor + "\n            importlib.reload(abletonosc.master)",
+                1,
+            )
+        else:
+            text = text.replace(
+                "importlib.reload(abletonosc.device)",
+                "importlib.reload(abletonosc.device)\n            importlib.reload(abletonosc.master)",
+                1,
+            )
 
     if text == original:
         print("manager.py already patched (or pattern not found)")
@@ -35,12 +65,20 @@ def patch(manager_path: Path) -> None:
 
 def ensure_init_import(init_path: Path) -> None:
     text = init_path.read_text(encoding="utf-8")
-    if "from .browser import BrowserHandler" in text:
-        print("__init__.py already imports BrowserHandler")
+    changed = False
+    if "from .browser import BrowserHandler" not in text:
+        if not text.endswith("\n"):
+            text += "\n"
+        text += "from .browser import BrowserHandler\n"
+        changed = True
+    if "from .master import MasterHandler" not in text:
+        if not text.endswith("\n"):
+            text += "\n"
+        text += "from .master import MasterHandler\n"
+        changed = True
+    if not changed:
+        print("__init__.py already imports BrowserHandler/MasterHandler")
         return
-    if not text.endswith("\n"):
-        text += "\n"
-    text += "from .browser import BrowserHandler\n"
     init_path.write_text(text, encoding="utf-8")
     print(f"Updated {init_path}")
 


### PR DESCRIPTION
## Summary
- Add mix-bus MCP tools (track/master meters, master volume/devices, load on master)
- Add bounce/session-record tools and `ableton_bounce_session_pass` (Resampling → Bounce track)
- Unify OSC client send/receive on one UDP socket; AbletonOSC `master.py` + browser master helpers
- Docs: README + remote-script README

Intended release tag after merge: **v0.2.0-alpha**

## Test plan
- [x] `go test ./...` and `go build`
- [x] Apply remote-script patch; fully restart Live; reload MCP
- [x] `ableton_test`, `ableton_get_master_meter`, `ableton_load_on_master` (Limiter)
- [x] `ableton_bounce_session_pass` leaves a clip on the Bounce track
- [x] Confirm tool count ~46 after MCP reload