### PR TITLE
feat: add session snapshot tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Create MIDI tracks and clips
 - Add, read, and clear MIDI notes
 - Get/set tempo
+- Inspect tempo, playback state, scenes, and indexed tracks in one snapshot
 - List devices on a track
 - Load Drum Racks / presets from Live's Browser (with the included AbletonOSC patch)
 - Fire clip slots
@@ -219,6 +220,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_play` / `ableton_stop` / `ableton_stop_all_clips` | Transport |
 | `ableton_set_song_key` | Set root note and scale |
 | `ableton_set_metronome` | Enable/disable metronome |
+| `ableton_get_session_snapshot` | Get tempo, playback state, scene count, and indexed track names |
 | `ableton_get_track_names` | List track names |
 | `ableton_get_track_devices` | List devices on a track |
 | `ableton_create_midi_track` | Create a MIDI track |

--- a/internal/tools/ableton_session.go
+++ b/internal/tools/ableton_session.go
@@ -1,0 +1,89 @@
+package tools
+
+import (
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+type SessionTrack struct {
+	Index int    `json:"index"`
+	Name  string `json:"name"`
+}
+
+type SessionSnapshotOutput struct {
+	TempoBPM  float64        `json:"tempo_bpm"`
+	IsPlaying bool           `json:"is_playing"`
+	NumScenes int            `json:"num_scenes"`
+	Tracks    []SessionTrack `json:"tracks"`
+}
+
+type sessionQuerier interface {
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+func NewAbletonGetSessionSnapshot(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_session_snapshot", "Ableton Live: get tempo, playback state, scenes, and indexed track names",
+		func(_ *ai.ToolContext, _ EmptyInput) (SessionSnapshotOutput, error) {
+			return getSessionSnapshot(client)
+		},
+	)
+}
+
+func getSessionSnapshot(client sessionQuerier) (SessionSnapshotOutput, error) {
+	tempoRes, err := client.Query("/live/song/get/tempo")
+	if err != nil {
+		return SessionSnapshotOutput{}, fmt.Errorf("get tempo: %w", err)
+	}
+	if err := ensureResponseLen(tempoRes, 1); err != nil {
+		return SessionSnapshotOutput{}, fmt.Errorf("get tempo: %w", err)
+	}
+	tempo, err := abletonosc.AsFloat64(tempoRes[0])
+	if err != nil {
+		return SessionSnapshotOutput{}, fmt.Errorf("get tempo: %w", err)
+	}
+
+	playingRes, err := client.Query("/live/song/get/is_playing")
+	if err != nil {
+		return SessionSnapshotOutput{}, fmt.Errorf("get playback state: %w", err)
+	}
+	if err := ensureResponseLen(playingRes, 1); err != nil {
+		return SessionSnapshotOutput{}, fmt.Errorf("get playback state: %w", err)
+	}
+	isPlaying, err := abletonosc.AsBool(playingRes[0])
+	if err != nil {
+		return SessionSnapshotOutput{}, fmt.Errorf("get playback state: %w", err)
+	}
+
+	scenesRes, err := client.Query("/live/song/get/num_scenes")
+	if err != nil {
+		return SessionSnapshotOutput{}, fmt.Errorf("get scene count: %w", err)
+	}
+	if err := ensureResponseLen(scenesRes, 1); err != nil {
+		return SessionSnapshotOutput{}, fmt.Errorf("get scene count: %w", err)
+	}
+	numScenes, err := abletonosc.AsInt(scenesRes[0])
+	if err != nil {
+		return SessionSnapshotOutput{}, fmt.Errorf("get scene count: %w", err)
+	}
+
+	trackNamesRes, err := client.Query("/live/song/get/track_names")
+	if err != nil {
+		return SessionSnapshotOutput{}, fmt.Errorf("get track names: %w", err)
+	}
+	trackNames := toStringSlice(trackNamesRes)
+	tracks := make([]SessionTrack, 0, len(trackNames))
+	for index, name := range trackNames {
+		tracks = append(tracks, SessionTrack{Index: index, Name: name})
+	}
+
+	return SessionSnapshotOutput{
+		TempoBPM:  tempo,
+		IsPlaying: isPlaying,
+		NumScenes: numScenes,
+		Tracks:    tracks,
+	}, nil
+}

--- a/internal/tools/ableton_session_test.go
+++ b/internal/tools/ableton_session_test.go
@@ -1,0 +1,94 @@
+package tools
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type snapshotQueryResult struct {
+	values []interface{}
+	err    error
+}
+
+type snapshotQuerierStub struct {
+	results map[string]snapshotQueryResult
+}
+
+func (s snapshotQuerierStub) Query(address string, _ ...interface{}) ([]interface{}, error) {
+	result, ok := s.results[address]
+	if !ok {
+		return nil, errors.New("unexpected query")
+	}
+	return result.values, result.err
+}
+
+func TestGetSessionSnapshot(t *testing.T) {
+	t.Parallel()
+
+	client := snapshotQuerierStub{results: map[string]snapshotQueryResult{
+		"/live/song/get/tempo":      {values: []interface{}{float32(128)}},
+		"/live/song/get/is_playing": {values: []interface{}{int32(1)}},
+		"/live/song/get/num_scenes": {values: []interface{}{int32(8)}},
+		"/live/song/get/track_names": {
+			values: []interface{}{"Drums", "Bass"},
+		},
+	}}
+
+	got, err := getSessionSnapshot(client)
+	if err != nil {
+		t.Fatalf("getSessionSnapshot() error = %v", err)
+	}
+
+	want := SessionSnapshotOutput{
+		TempoBPM:  128,
+		IsPlaying: true,
+		NumScenes: 8,
+		Tracks: []SessionTrack{
+			{Index: 0, Name: "Drums"},
+			{Index: 1, Name: "Bass"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("getSessionSnapshot() = %#v, want %#v", got, want)
+	}
+}
+
+func TestGetSessionSnapshotReturnsContextualError(t *testing.T) {
+	t.Parallel()
+
+	client := snapshotQuerierStub{results: map[string]snapshotQueryResult{
+		"/live/song/get/tempo": {err: errors.New("timeout")},
+	}}
+
+	_, err := getSessionSnapshot(client)
+	if err == nil {
+		t.Fatal("getSessionSnapshot() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "get tempo") {
+		t.Errorf("getSessionSnapshot() error = %q, want tempo context", err)
+	}
+}
+
+func TestGetSessionSnapshotReturnsEmptyTrackList(t *testing.T) {
+	t.Parallel()
+
+	client := snapshotQuerierStub{results: map[string]snapshotQueryResult{
+		"/live/song/get/tempo":       {values: []interface{}{float64(120)}},
+		"/live/song/get/is_playing":  {values: []interface{}{false}},
+		"/live/song/get/num_scenes":  {values: []interface{}{0}},
+		"/live/song/get/track_names": {values: []interface{}{}},
+	}}
+
+	got, err := getSessionSnapshot(client)
+	if err != nil {
+		t.Fatalf("getSessionSnapshot() error = %v", err)
+	}
+	if got.Tracks == nil {
+		t.Fatal("getSessionSnapshot() Tracks = nil, want empty list")
+	}
+	if len(got.Tracks) != 0 {
+		t.Errorf("getSessionSnapshot() Tracks = %v, want empty list", got.Tracks)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 		tools.NewAbletonStopAllClips(g, ableton),
 		tools.NewAbletonSetSongKey(g, ableton),
 		tools.NewAbletonSetMetronome(g, ableton),
+		tools.NewAbletonGetSessionSnapshot(g, ableton),
 
 		// Tracks
 		tools.NewAbletonGetTrackNames(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ableton_get_session_snapshot` for tempo, playback state, scene count, and indexed track names
- add focused tests for snapshot parsing and errors
- document the new MCP tool

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

