### PR TITLE
feat: add browser folder list and path load tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Inspect tempo, playback state, scenes, and indexed tracks in one snapshot
 - List devices on a track
 - Load Drum Racks / presets from Live's Browser (with the included AbletonOSC patch)
+- Browse Live Browser folders by path and load items onto tracks
 - Fire clip slots
 - Send raw OSC messages for advanced control
 
@@ -24,6 +25,8 @@ Stock [AbletonOSC](https://github.com/ideoforms/AbletonOSC) does not expose Live
 This repo ships a small Remote Script patch under [`remote-script/`](remote-script/) that adds:
 
 - `/live/browser/find`
+- `/live/browser/list_folder`
+- `/live/browser/load_at_path`
 - `/live/track/load/browser_item`
 - `/live/device/load/preset`
 
@@ -239,7 +242,9 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_fire_scene` | Fire a scene |
 | `ableton_get_device_parameters` / `ableton_set_device_parameter` | Device parameters |
 | `ableton_find_browser_item` | Search Live Browser (requires patch) |
-| `ableton_load_browser_item` | Load Drum Rack / instrument onto a track |
+| `ableton_list_browser_folder` | List Browser roots or folder children (requires patch) |
+| `ableton_load_browser_item` | Load Drum Rack / instrument onto a track by name |
+| `ableton_load_browser_path` | Load Browser item onto a track by exact path (requires patch) |
 | `ableton_load_device_preset` | Hotswap a preset onto a device |
 | `ableton_get_track_meter` | Track output meter levels |
 | `ableton_get_master_meter` / `ableton_get_master_volume` / `ableton_set_master_volume` | Master meter/volume (requires master patch) |
@@ -256,6 +261,7 @@ Once configured, you can ask your AI assistant:
 - "Set the tempo to 140 BPM"
 - "Create a MIDI track, load Street Kit, and add a 4-bar clip"
 - "Find drum kits named Street in the browser"
+- "List the Drums browser folder, then load Street Kit onto track 0"
 - "Add a kick drum pattern on beats 1, 2, 3, 4"
 - "What's the current tempo?"
 

--- a/internal/tools/ableton_browser.go
+++ b/internal/tools/ableton_browser.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
@@ -43,6 +44,45 @@ type LoadDevicePresetOutput struct {
 	DeviceIndex int    `json:"device_index"`
 	Status      string `json:"status" jsonschema:"description=loaded, not_found, or invalid_device_index"`
 	PresetName  string `json:"preset_name"`
+}
+
+type ListBrowserFolderInput struct {
+	RootName  string   `json:"root_name,omitempty" jsonschema:"description=Browser root name; omit to list roots"`
+	PathParts []string `json:"path_parts,omitempty" jsonschema:"description=Optional folder path under root"`
+}
+
+type BrowserFolderItem struct {
+	Name     string `json:"name"`
+	Loadable bool   `json:"loadable"`
+	Folder   bool   `json:"folder"`
+}
+
+type ListBrowserFolderOutput struct {
+	RootName  string              `json:"root_name,omitempty" jsonschema:"description=Empty when listing roots"`
+	PathParts []string            `json:"path_parts,omitempty"`
+	Items     []BrowserFolderItem `json:"items"`
+}
+
+type LoadBrowserPathInput struct {
+	TrackIndex int      `json:"track_index" jsonschema:"minimum=0"`
+	RootName   string   `json:"root_name" jsonschema:"description=Browser root (e.g. Drums)"`
+	PathParts  []string `json:"path_parts,omitempty" jsonschema:"description=Optional folder path under root"`
+	ItemName   string   `json:"item_name" jsonschema:"description=Loadable item name under the folder"`
+}
+
+type LoadBrowserPathOutput struct {
+	TrackIndex    int    `json:"track_index"`
+	Loaded        string `json:"loaded"`
+	DevicesBefore int    `json:"devices_before"`
+	DevicesAfter  int    `json:"devices_after"`
+}
+
+type loadAtPathResult struct {
+	TrackIndex    int
+	Status        string
+	Loaded        string
+	DevicesBefore int
+	DevicesAfter  int
 }
 
 func parseLoadBrowserItemResponse(res []interface{}) (LoadBrowserItemOutput, error) {
@@ -98,6 +138,116 @@ func parseLoadDevicePresetResponse(res []interface{}) (LoadDevicePresetOutput, e
 	return out, nil
 }
 
+func parseBrowserListEntry(raw string) BrowserFolderItem {
+	parts := strings.Split(raw, "|")
+	item := BrowserFolderItem{Name: parts[0]}
+	for _, part := range parts[1:] {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "loadable":
+			item.Loadable = parsePythonBool(value)
+		case "folder":
+			item.Folder = parsePythonBool(value)
+		}
+	}
+	return item
+}
+
+func parsePythonBool(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "1":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseListBrowserFolderResponse(res []interface{}, rootName string, pathParts []string) (ListBrowserFolderOutput, error) {
+	if len(res) == 0 {
+		return ListBrowserFolderOutput{Items: []BrowserFolderItem{}}, nil
+	}
+
+	first := fmt.Sprint(res[0])
+	switch first {
+	case "root_not_found", "path_not_found":
+		return ListBrowserFolderOutput{}, fmt.Errorf("browser folder list failed: status=%s reply=%v", first, res)
+	case "roots":
+		items := make([]BrowserFolderItem, 0, len(res)-1)
+		for _, v := range res[1:] {
+			items = append(items, parseBrowserListEntry(fmt.Sprint(v)))
+		}
+		return ListBrowserFolderOutput{Items: items}, nil
+	}
+
+	prefixLen := 1 + len(pathParts)
+	if len(res) < prefixLen {
+		return ListBrowserFolderOutput{}, fmt.Errorf("unexpected browser folder reply: %v", res)
+	}
+	if fmt.Sprint(res[0]) != rootName {
+		return ListBrowserFolderOutput{}, fmt.Errorf("unexpected browser folder root: got %q want %q", res[0], rootName)
+	}
+	for i, part := range pathParts {
+		if fmt.Sprint(res[1+i]) != part {
+			return ListBrowserFolderOutput{}, fmt.Errorf("unexpected browser folder path at %d: got %q want %q", i, res[1+i], part)
+		}
+	}
+
+	items := make([]BrowserFolderItem, 0, len(res)-prefixLen)
+	for _, v := range res[prefixLen:] {
+		items = append(items, parseBrowserListEntry(fmt.Sprint(v)))
+	}
+	return ListBrowserFolderOutput{
+		RootName:  rootName,
+		PathParts: append([]string(nil), pathParts...),
+		Items:     items,
+	}, nil
+}
+
+func parseLoadAtPathResponse(res []interface{}) (loadAtPathResult, error) {
+	if err := ensureResponseLen(res, 3); err != nil {
+		return loadAtPathResult{}, err
+	}
+	trackIndex, err := abletonosc.AsInt(res[0])
+	if err != nil {
+		return loadAtPathResult{}, fmt.Errorf("parse track_index: %w", err)
+	}
+	status := fmt.Sprint(res[1])
+	out := loadAtPathResult{
+		TrackIndex: trackIndex,
+		Status:     status,
+		Loaded:     fmt.Sprint(res[2]),
+	}
+	if status != "loaded" {
+		return out, fmt.Errorf("load failed: status=%s reply=%v", status, res)
+	}
+	if err := ensureResponseLen(res, 5); err != nil {
+		return out, err
+	}
+	before, err := abletonosc.AsInt(res[3])
+	if err != nil {
+		return out, fmt.Errorf("parse devices_before: %w", err)
+	}
+	after, err := abletonosc.AsInt(res[4])
+	if err != nil {
+		return out, fmt.Errorf("parse devices_after: %w", err)
+	}
+	out.DevicesBefore = before
+	out.DevicesAfter = after
+	return out, nil
+}
+
+func loadAtPathArgs(trackIndex int, rootName string, pathParts []string, itemName string) []interface{} {
+	args := []interface{}{int32(trackIndex), int32(-1), rootName}
+	for _, p := range pathParts {
+		args = append(args, p)
+	}
+	args = append(args, itemName)
+	return args
+}
+
 func NewAbletonFindBrowserItem(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	return genkit.DefineTool(g, "ableton_find_browser_item", "Ableton Live: search Browser for loadable items (requires browser patch)",
 		func(_ *ai.ToolContext, input FindBrowserItemInput) (FindBrowserItemOutput, error) {
@@ -110,6 +260,39 @@ func NewAbletonFindBrowserItem(g *genkit.Genkit, client *abletonosc.Client) ai.T
 				return FindBrowserItemOutput{}, fmt.Errorf("browser find failed (abletonosc browser patch required): %w", err)
 			}
 			return FindBrowserItemOutput{Matches: toStringSlice(res)}, nil
+		},
+	)
+}
+
+func NewAbletonListBrowserFolder(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_list_browser_folder", "Ableton Live: list Browser roots or folder children (requires browser patch)",
+		func(_ *ai.ToolContext, input ListBrowserFolderInput) (ListBrowserFolderOutput, error) {
+			rootName := strings.TrimSpace(input.RootName)
+			pathParts := make([]string, 0, len(input.PathParts))
+			for _, part := range input.PathParts {
+				trimmed := strings.TrimSpace(part)
+				if trimmed == "" {
+					return ListBrowserFolderOutput{}, errors.New("path_parts must not contain empty strings")
+				}
+				pathParts = append(pathParts, trimmed)
+			}
+			if rootName == "" && len(pathParts) > 0 {
+				return ListBrowserFolderOutput{}, errors.New("root_name is required when path_parts is set")
+			}
+
+			var args []interface{}
+			if rootName != "" {
+				args = append(args, rootName)
+				for _, part := range pathParts {
+					args = append(args, part)
+				}
+			}
+
+			res, err := client.Query("/live/browser/list_folder", args...)
+			if err != nil {
+				return ListBrowserFolderOutput{}, fmt.Errorf("browser list failed (abletonosc browser patch required): %w", err)
+			}
+			return parseListBrowserFolderResponse(res, rootName, pathParts)
 		},
 	)
 }
@@ -129,6 +312,48 @@ func NewAbletonLoadBrowserItem(g *genkit.Genkit, client *abletonosc.Client) ai.T
 				return LoadBrowserItemOutput{}, fmt.Errorf("browser load failed (abletonosc browser patch required): %w", err)
 			}
 			return parseLoadBrowserItemResponse(res)
+		},
+	)
+}
+
+func NewAbletonLoadBrowserPath(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_load_browser_path", "Ableton Live: load a Browser item onto a track by exact path (requires browser patch)",
+		func(_ *ai.ToolContext, input LoadBrowserPathInput) (LoadBrowserPathOutput, error) {
+			if input.TrackIndex < 0 {
+				return LoadBrowserPathOutput{}, errors.New("track_index must be >= 0")
+			}
+			rootName := strings.TrimSpace(input.RootName)
+			itemName := strings.TrimSpace(input.ItemName)
+			if rootName == "" || itemName == "" {
+				return LoadBrowserPathOutput{}, errors.New("root_name and item_name are required")
+			}
+			pathParts := make([]string, 0, len(input.PathParts))
+			for _, part := range input.PathParts {
+				trimmed := strings.TrimSpace(part)
+				if trimmed == "" {
+					return LoadBrowserPathOutput{}, errors.New("path_parts must not contain empty strings")
+				}
+				pathParts = append(pathParts, trimmed)
+			}
+
+			res, err := client.QueryWithTimeout(
+				10*time.Second,
+				"/live/browser/load_at_path",
+				loadAtPathArgs(input.TrackIndex, rootName, pathParts, itemName)...,
+			)
+			if err != nil {
+				return LoadBrowserPathOutput{}, fmt.Errorf("browser path load failed (abletonosc browser patch required): %w", err)
+			}
+			parsed, err := parseLoadAtPathResponse(res)
+			if err != nil {
+				return LoadBrowserPathOutput{}, err
+			}
+			return LoadBrowserPathOutput{
+				TrackIndex:    parsed.TrackIndex,
+				Loaded:        parsed.Loaded,
+				DevicesBefore: parsed.DevicesBefore,
+				DevicesAfter:  parsed.DevicesAfter,
+			}, nil
 		},
 	)
 }

--- a/internal/tools/ableton_browser_test.go
+++ b/internal/tools/ableton_browser_test.go
@@ -1,6 +1,8 @@
 package tools
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -132,5 +134,118 @@ func TestParseLoadDevicePresetResponse(t *testing.T) {
 				t.Errorf("PresetName = %q, want %q", got.PresetName, tt.wantPreset)
 			}
 		})
+	}
+}
+
+func TestParseBrowserListEntry(t *testing.T) {
+	t.Parallel()
+
+	got := parseBrowserListEntry("Street Kit|loadable=True|folder=False")
+	want := BrowserFolderItem{Name: "Street Kit", Loadable: true, Folder: false}
+	if got != want {
+		t.Errorf("parseBrowserListEntry() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseListBrowserFolderResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("roots", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseListBrowserFolderResponse([]interface{}{
+			"roots",
+			"Drums|loadable=False|folder=True",
+			"Instruments|loadable=False|folder=True",
+		}, "", nil)
+		if err != nil {
+			t.Fatalf("parseListBrowserFolderResponse() error = %v", err)
+		}
+		want := ListBrowserFolderOutput{
+			Items: []BrowserFolderItem{
+				{Name: "Drums", Loadable: false, Folder: true},
+				{Name: "Instruments", Loadable: false, Folder: true},
+			},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("parseListBrowserFolderResponse() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("folder_children", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseListBrowserFolderResponse([]interface{}{
+			"Drums",
+			"Kits",
+			"Street Kit|loadable=True|folder=False",
+			"Core Kit|loadable=True|folder=False",
+		}, "Drums", []string{"Kits"})
+		if err != nil {
+			t.Fatalf("parseListBrowserFolderResponse() error = %v", err)
+		}
+		want := ListBrowserFolderOutput{
+			RootName:  "Drums",
+			PathParts: []string{"Kits"},
+			Items: []BrowserFolderItem{
+				{Name: "Street Kit", Loadable: true, Folder: false},
+				{Name: "Core Kit", Loadable: true, Folder: false},
+			},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("parseListBrowserFolderResponse() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("root_not_found", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseListBrowserFolderResponse([]interface{}{"root_not_found", "Missing"}, "Missing", nil)
+		if err == nil {
+			t.Fatal("parseListBrowserFolderResponse() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "root_not_found") {
+			t.Errorf("parseListBrowserFolderResponse() error = %q, want root_not_found", err)
+		}
+	})
+}
+
+func TestParseLoadAtPathResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("loaded", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseLoadAtPathResponse([]interface{}{int32(3), "loaded", "Street Kit", int32(0), int32(1)})
+		if err != nil {
+			t.Fatalf("parseLoadAtPathResponse() error = %v", err)
+		}
+		want := loadAtPathResult{
+			TrackIndex:    3,
+			Status:        "loaded",
+			Loaded:        "Street Kit",
+			DevicesBefore: 0,
+			DevicesAfter:  1,
+		}
+		if got != want {
+			t.Errorf("parseLoadAtPathResponse() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("item_not_found", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseLoadAtPathResponse([]interface{}{int32(0), "item_not_found", "Missing"})
+		if err == nil {
+			t.Fatal("parseLoadAtPathResponse() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "item_not_found") {
+			t.Errorf("parseLoadAtPathResponse() error = %q, want item_not_found", err)
+		}
+	})
+}
+
+func TestLoadAtPathArgs(t *testing.T) {
+	t.Parallel()
+
+	got := loadAtPathArgs(2, "Drums", []string{"Kits"}, "Street Kit")
+	want := []interface{}{int32(2), int32(-1), "Drums", "Kits", "Street Kit"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("loadAtPathArgs() = %#v, want %#v", got, want)
 	}
 }

--- a/internal/tools/ableton_mix.go
+++ b/internal/tools/ableton_mix.go
@@ -266,34 +266,22 @@ func NewAbletonLoadOnMaster(g *genkit.Genkit, client *abletonosc.Client) ai.Tool
 			if input.RootName == "" || input.ItemName == "" {
 				return LoadOnMasterOutput{}, errors.New("root_name and item_name are required")
 			}
-			args := []interface{}{int32(-1), int32(-1), input.RootName}
-			for _, p := range input.PathParts {
-				args = append(args, p)
-			}
-			args = append(args, input.ItemName)
-			res, err := client.QueryWithTimeout(10*time.Second, "/live/browser/load_at_path", args...)
+			res, err := client.QueryWithTimeout(
+				10*time.Second,
+				"/live/browser/load_at_path",
+				loadAtPathArgs(-1, input.RootName, input.PathParts, input.ItemName)...,
+			)
 			if err != nil {
 				return LoadOnMasterOutput{}, err
 			}
-			if err := ensureResponseLen(res, 5); err != nil {
-				return LoadOnMasterOutput{}, err
-			}
-			status := fmt.Sprint(res[1])
-			if status != "loaded" {
-				return LoadOnMasterOutput{}, fmt.Errorf("load failed: status=%s reply=%v", status, res)
-			}
-			before, err := abletonosc.AsInt(res[3])
-			if err != nil {
-				return LoadOnMasterOutput{}, err
-			}
-			after, err := abletonosc.AsInt(res[4])
+			parsed, err := parseLoadAtPathResponse(res)
 			if err != nil {
 				return LoadOnMasterOutput{}, err
 			}
 			return LoadOnMasterOutput{
-				Loaded:        fmt.Sprint(res[2]),
-				DevicesBefore: before,
-				DevicesAfter:  after,
+				Loaded:        parsed.Loaded,
+				DevicesBefore: parsed.DevicesBefore,
+				DevicesAfter:  parsed.DevicesAfter,
 			}, nil
 		},
 	)

--- a/main.go
+++ b/main.go
@@ -84,7 +84,9 @@ func main() {
 		tools.NewAbletonGetDeviceParameters(g, ableton),
 		tools.NewAbletonSetDeviceParameter(g, ableton),
 		tools.NewAbletonFindBrowserItem(g, ableton),
+		tools.NewAbletonListBrowserFolder(g, ableton),
 		tools.NewAbletonLoadBrowserItem(g, ableton),
+		tools.NewAbletonLoadBrowserPath(g, ableton),
 		tools.NewAbletonLoadDevicePreset(g, ableton),
 
 		// Mix bus / Master

--- a/remote-script/README.md
+++ b/remote-script/README.md
@@ -9,7 +9,7 @@ Adds Live Browser `load_item()` support and master-track mix helpers so MCP tool
 | `/live/browser/find` | `query` | Search loadable items (up to 20 paths) |
 | `/live/track/load/browser_item` | `track_index`, `item_name` | Load by name onto a track |
 | `/live/device/load/preset` | `track_index`, `device_index`, `preset_name` | Hotswap preset onto a device |
-| `/live/browser/list_folder` | `root_name`, `*path_parts` | List folder children |
+| `/live/browser/list_folder` | _(none)_ or `root_name`, `*path_parts` | List roots, or children under a folder |
 | `/live/browser/load_at_path` | `track_index` (`-1`=master), `device_index`, `root_name`, `*path_parts`, `item_name` | Load by exact path |
 | `/live/browser/debug` | _(none)_ | Dump browser roots (debug) |
 | `/live/master/get/volume` | — | Master volume |

--- a/remote-script/abletonosc/browser.py
+++ b/remote-script/abletonosc/browser.py
@@ -111,8 +111,21 @@ class BrowserHandler(AbletonOSCHandler):
             return tuple(infos[:40])
 
         def browser_list_folder_handler(params: Tuple[Any]):
-            """Params: root_name, *path_parts. Lists child names under a browser folder."""
+            """Params: (none) lists browser roots; otherwise root_name, *path_parts."""
             browser = Live.Application.get_application().browser
+            if not params:
+                names = []
+                for root in _browser_roots(browser):
+                    try:
+                        loadable = bool(getattr(root, "is_loadable", False))
+                        names.append(
+                            "%s|loadable=%s|folder=%s"
+                            % (root.name, loadable, True)
+                        )
+                    except Exception:
+                        names.append("%s|loadable=False|folder=True" % root.name)
+                return ("roots", *names[:30])
+
             root_name = str(params[0])
             path_parts = [str(p) for p in params[1:]]
             node = _resolve_path(browser, root_name, path_parts)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- extend `/live/browser/list_folder` so no args returns Browser roots
- add `ableton_list_browser_folder` and `ableton_load_browser_path` for regular tracks
- share `load_at_path` response parsing with `ableton_load_on_master`
- document the new MCP tools and Remote Script behavior

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Note: Ableton Live live verification is still needed after reinstalling the browser patch and restarting Live.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

