### PR TITLE
feat: add drum track setup recipe tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - List devices on a track
 - Load Drum Racks / presets from Live's Browser (with the included AbletonOSC patch)
 - Browse Live Browser folders by path and load items onto tracks
+- Set up a drum track with kit + clip + pattern in one recipe
 - Fire clip slots
 - Send raw OSC messages for advanced control
 
@@ -252,6 +253,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_load_on_master` | Load Browser item onto master (requires browser+master patch) |
 | `ableton_get_session_record` / `ableton_set_session_record` | Session Record on/off |
 | `ableton_bounce_session_pass` | Record a scene pass onto a Bounce track via Resampling (tens of seconds; does not export WAV) |
+| `ableton_setup_drum_track` | Create MIDI drum track, load kit, fill clip with preset pattern (requires browser patch) |
 | `ableton_osc_send` | Send raw OSC message |
 
 ## Example Usage
@@ -260,6 +262,7 @@ Once configured, you can ask your AI assistant:
 
 - "Set the tempo to 140 BPM"
 - "Create a MIDI track, load Street Kit, and add a 4-bar clip"
+- "Set up a Street Kit drum track with a four-on-floor pattern"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"
 - "Add a kick drum pattern on beats 1, 2, 3, 4"

--- a/internal/tools/ableton_recipes.go
+++ b/internal/tools/ableton_recipes.go
@@ -1,0 +1,271 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const (
+	drumPitchKick  = 36 // C1
+	drumPitchSnare = 38 // D1
+	drumPitchHat   = 42 // F#1
+
+	defaultDrumLengthBeats = 16.0
+	defaultDrumPattern     = "basic_backbeat"
+)
+
+type SetupDrumTrackInput struct {
+	KitName     string   `json:"kit_name,omitempty" jsonschema:"description=Browser kit name to load by search (e.g. Street Kit). Use this or root_name+item_name"`
+	RootName    string   `json:"root_name,omitempty" jsonschema:"description=Browser root for path load (e.g. Drums)"`
+	PathParts   []string `json:"path_parts,omitempty" jsonschema:"description=Optional folder path under root for path load"`
+	ItemName    string   `json:"item_name,omitempty" jsonschema:"description=Loadable item name for path load"`
+	TrackName   string   `json:"track_name,omitempty" jsonschema:"description=Optional track name (defaults to loaded kit name)"`
+	ClipIndex   *int     `json:"clip_index,omitempty" jsonschema:"description=Clip slot index (default 0),minimum=0"`
+	LengthBeats float64  `json:"length_beats,omitempty" jsonschema:"description=Clip length in beats (default 16 = 4 bars),minimum=1,maximum=128"`
+	Pattern     string   `json:"pattern,omitempty" jsonschema:"description=Preset pattern: basic_backbeat, four_on_floor, or kick_only (default basic_backbeat)"`
+	Fire        bool     `json:"fire,omitempty" jsonschema:"description=Fire the clip after setup"`
+}
+
+type SetupDrumTrackOutput struct {
+	TrackIndex  int     `json:"track_index"`
+	TrackName   string  `json:"track_name"`
+	ClipIndex   int     `json:"clip_index"`
+	Loaded      string  `json:"loaded"`
+	Pattern     string  `json:"pattern"`
+	LengthBeats float64 `json:"length_beats"`
+	NotesAdded  int     `json:"notes_added"`
+	Fired       bool    `json:"fired"`
+}
+
+type drumSetupClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+	QueryWithTimeout(timeout time.Duration, address string, args ...interface{}) ([]interface{}, error)
+}
+
+func NewAbletonSetupDrumTrack(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_setup_drum_track",
+		"Ableton Live: create a MIDI drum track, load a kit, and fill a clip with a preset pattern (requires browser patch)",
+		func(_ *ai.ToolContext, input SetupDrumTrackInput) (SetupDrumTrackOutput, error) {
+			return setupDrumTrack(client, input)
+		},
+	)
+}
+
+func setupDrumTrack(client drumSetupClient, input SetupDrumTrackInput) (SetupDrumTrackOutput, error) {
+	kitName := strings.TrimSpace(input.KitName)
+	rootName := strings.TrimSpace(input.RootName)
+	itemName := strings.TrimSpace(input.ItemName)
+	pathParts := make([]string, 0, len(input.PathParts))
+	for _, part := range input.PathParts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			return SetupDrumTrackOutput{}, errors.New("path_parts must not contain empty strings")
+		}
+		pathParts = append(pathParts, trimmed)
+	}
+
+	usePath := rootName != "" || itemName != "" || len(pathParts) > 0
+	useName := kitName != ""
+	if usePath == useName {
+		return SetupDrumTrackOutput{}, errors.New("provide either kit_name or root_name+item_name (not both)")
+	}
+	if usePath && (rootName == "" || itemName == "") {
+		return SetupDrumTrackOutput{}, errors.New("root_name and item_name are required for path load")
+	}
+
+	clipIndex := 0
+	if input.ClipIndex != nil {
+		clipIndex = *input.ClipIndex
+		if clipIndex < 0 {
+			return SetupDrumTrackOutput{}, errors.New("clip_index must be >= 0")
+		}
+	}
+
+	lengthBeats := input.LengthBeats
+	if lengthBeats == 0 {
+		lengthBeats = defaultDrumLengthBeats
+	}
+	if lengthBeats < 1 || lengthBeats > 128 {
+		return SetupDrumTrackOutput{}, errors.New("length_beats must be between 1 and 128")
+	}
+
+	pattern := strings.TrimSpace(input.Pattern)
+	if pattern == "" {
+		pattern = defaultDrumPattern
+	}
+	notes, err := buildDrumPattern(pattern, lengthBeats)
+	if err != nil {
+		return SetupDrumTrackOutput{}, err
+	}
+
+	if err := client.Send("/live/song/create_midi_track", int32(-1)); err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("create midi track: %w", err)
+	}
+	numTracksRes, err := client.Query("/live/song/get/num_tracks")
+	if err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("get num tracks: %w", err)
+	}
+	if err := ensureResponseLen(numTracksRes, 1); err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("get num tracks: %w", err)
+	}
+	numTracks, err := abletonosc.AsInt(numTracksRes[0])
+	if err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("get num tracks: %w", err)
+	}
+	if numTracks < 1 {
+		return SetupDrumTrackOutput{}, errors.New("no tracks available after create")
+	}
+	trackIndex := numTracks - 1
+
+	var loaded string
+	if useName {
+		res, err := client.Query("/live/track/load/browser_item", int32(trackIndex), kitName)
+		if err != nil {
+			return SetupDrumTrackOutput{}, fmt.Errorf("load kit by name (abletonosc browser patch required): %w", err)
+		}
+		parsed, err := parseLoadBrowserItemResponse(res)
+		if err != nil {
+			return SetupDrumTrackOutput{}, err
+		}
+		loaded = parsed.ItemName
+	} else {
+		res, err := client.QueryWithTimeout(
+			10*time.Second,
+			"/live/browser/load_at_path",
+			loadAtPathArgs(trackIndex, rootName, pathParts, itemName)...,
+		)
+		if err != nil {
+			return SetupDrumTrackOutput{}, fmt.Errorf("load kit by path (abletonosc browser patch required): %w", err)
+		}
+		parsed, err := parseLoadAtPathResponse(res)
+		if err != nil {
+			return SetupDrumTrackOutput{}, err
+		}
+		loaded = parsed.Loaded
+	}
+
+	trackName := strings.TrimSpace(input.TrackName)
+	if trackName == "" {
+		trackName = loaded
+	}
+	if trackName == "" {
+		trackName = "Drums"
+	}
+	if err := client.Send("/live/track/set/name", int32(trackIndex), trackName); err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("set track name: %w", err)
+	}
+
+	if err := client.Send("/live/clip_slot/create_clip",
+		int32(trackIndex),
+		int32(clipIndex),
+		float32(lengthBeats),
+	); err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("create clip: %w", err)
+	}
+	hasClipRes, err := client.Query("/live/clip_slot/get/has_clip", int32(trackIndex), int32(clipIndex))
+	if err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("verify clip: %w", err)
+	}
+	if err := ensureResponseLen(hasClipRes, 3); err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("verify clip: %w", err)
+	}
+	hasClip, err := abletonosc.AsBool(hasClipRes[2])
+	if err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("verify clip: %w", err)
+	}
+	if !hasClip {
+		return SetupDrumTrackOutput{}, errors.New("clip was not created")
+	}
+
+	if err := client.Send("/live/clip/set/name", int32(trackIndex), int32(clipIndex), pattern); err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("set clip name: %w", err)
+	}
+
+	noteArgs := []interface{}{int32(trackIndex), int32(clipIndex)}
+	for _, n := range notes {
+		noteArgs = append(noteArgs,
+			int32(n.Pitch),
+			float32(n.StartTime),
+			float32(n.Duration),
+			int32(n.Velocity),
+			false,
+		)
+	}
+	if err := client.Send("/live/clip/add/notes", noteArgs...); err != nil {
+		return SetupDrumTrackOutput{}, fmt.Errorf("add notes: %w", err)
+	}
+
+	fired := false
+	if input.Fire {
+		if err := client.Send("/live/clip_slot/fire", int32(trackIndex), int32(clipIndex)); err != nil {
+			return SetupDrumTrackOutput{}, fmt.Errorf("fire clip: %w", err)
+		}
+		fired = true
+	}
+
+	return SetupDrumTrackOutput{
+		TrackIndex:  trackIndex,
+		TrackName:   trackName,
+		ClipIndex:   clipIndex,
+		Loaded:      loaded,
+		Pattern:     pattern,
+		LengthBeats: lengthBeats,
+		NotesAdded:  len(notes),
+		Fired:       fired,
+	}, nil
+}
+
+func buildDrumPattern(pattern string, lengthBeats float64) ([]MidiNote, error) {
+	bars := int(lengthBeats / 4)
+	if bars < 1 {
+		bars = 1
+	}
+	// Keep notes inside the clip even when length is not a multiple of 4.
+	end := lengthBeats
+
+	switch strings.ToLower(pattern) {
+	case "basic_backbeat":
+		return drumNotesForBars(bars, end, []float64{0, 2}, []float64{1, 3}, 0.5), nil
+	case "four_on_floor":
+		return drumNotesForBars(bars, end, []float64{0, 1, 2, 3}, []float64{1, 3}, 0.5), nil
+	case "kick_only":
+		return drumNotesForBars(bars, end, []float64{0, 1, 2, 3}, nil, 0), nil
+	default:
+		return nil, fmt.Errorf("unsupported pattern %q (use basic_backbeat, four_on_floor, or kick_only)", pattern)
+	}
+}
+
+func drumNotesForBars(bars int, end float64, kickBeats, snareBeats []float64, hatStep float64) []MidiNote {
+	notes := make([]MidiNote, 0, bars*32)
+	for bar := 0; bar < bars; bar++ {
+		base := float64(bar * 4)
+		for _, beat := range kickBeats {
+			start := base + beat
+			if start >= end {
+				continue
+			}
+			notes = append(notes, MidiNote{Pitch: drumPitchKick, StartTime: start, Duration: 0.25, Velocity: 110})
+		}
+		for _, beat := range snareBeats {
+			start := base + beat
+			if start >= end {
+				continue
+			}
+			notes = append(notes, MidiNote{Pitch: drumPitchSnare, StartTime: start, Duration: 0.25, Velocity: 100})
+		}
+		if hatStep > 0 {
+			for t := base; t < base+4 && t < end; t += hatStep {
+				notes = append(notes, MidiNote{Pitch: drumPitchHat, StartTime: t, Duration: 0.125, Velocity: 80})
+			}
+		}
+	}
+	return notes
+}

--- a/internal/tools/ableton_recipes_test.go
+++ b/internal/tools/ableton_recipes_test.go
@@ -1,0 +1,223 @@
+package tools
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type recipeCall struct {
+	method  string
+	address string
+	args    []interface{}
+}
+
+type recipeClientStub struct {
+	calls   []recipeCall
+	queries map[string][]interface{}
+	sendErr map[string]error
+}
+
+func (s *recipeClientStub) Send(address string, args ...interface{}) error {
+	s.calls = append(s.calls, recipeCall{method: "Send", address: address, args: append([]interface{}{}, args...)})
+	if err, ok := s.sendErr[address]; ok {
+		return err
+	}
+	return nil
+}
+
+func (s *recipeClientStub) Query(address string, args ...interface{}) ([]interface{}, error) {
+	s.calls = append(s.calls, recipeCall{method: "Query", address: address, args: append([]interface{}{}, args...)})
+	res, ok := s.queries[address]
+	if !ok {
+		return nil, errors.New("unexpected query: " + address)
+	}
+	return res, nil
+}
+
+func (s *recipeClientStub) QueryWithTimeout(_ time.Duration, address string, args ...interface{}) ([]interface{}, error) {
+	s.calls = append(s.calls, recipeCall{method: "QueryWithTimeout", address: address, args: append([]interface{}{}, args...)})
+	res, ok := s.queries[address]
+	if !ok {
+		return nil, errors.New("unexpected query: " + address)
+	}
+	return res, nil
+}
+
+func TestBuildDrumPattern(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic_backbeat_one_bar", func(t *testing.T) {
+		t.Parallel()
+		notes, err := buildDrumPattern("basic_backbeat", 4)
+		if err != nil {
+			t.Fatalf("buildDrumPattern() error = %v", err)
+		}
+		if countPitch(notes, drumPitchKick) != 2 {
+			t.Errorf("kick count = %d, want 2", countPitch(notes, drumPitchKick))
+		}
+		if countPitch(notes, drumPitchSnare) != 2 {
+			t.Errorf("snare count = %d, want 2", countPitch(notes, drumPitchSnare))
+		}
+		if countPitch(notes, drumPitchHat) != 8 {
+			t.Errorf("hat count = %d, want 8", countPitch(notes, drumPitchHat))
+		}
+	})
+
+	t.Run("four_on_floor_two_bars", func(t *testing.T) {
+		t.Parallel()
+		notes, err := buildDrumPattern("four_on_floor", 8)
+		if err != nil {
+			t.Fatalf("buildDrumPattern() error = %v", err)
+		}
+		if countPitch(notes, drumPitchKick) != 8 {
+			t.Errorf("kick count = %d, want 8", countPitch(notes, drumPitchKick))
+		}
+	})
+
+	t.Run("kick_only", func(t *testing.T) {
+		t.Parallel()
+		notes, err := buildDrumPattern("kick_only", 4)
+		if err != nil {
+			t.Fatalf("buildDrumPattern() error = %v", err)
+		}
+		if countPitch(notes, drumPitchKick) != 4 {
+			t.Errorf("kick count = %d, want 4", countPitch(notes, drumPitchKick))
+		}
+		if countPitch(notes, drumPitchSnare) != 0 || countPitch(notes, drumPitchHat) != 0 {
+			t.Errorf("kick_only should not include snare/hat")
+		}
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildDrumPattern("latin", 16)
+		if err == nil {
+			t.Fatal("buildDrumPattern() error = nil, want error")
+		}
+	})
+}
+
+func TestSetupDrumTrackByKitName(t *testing.T) {
+	t.Parallel()
+
+	client := &recipeClientStub{
+		queries: map[string][]interface{}{
+			"/live/song/get/num_tracks":     {int32(3)},
+			"/live/track/load/browser_item": {int32(2), "loaded", "Street Kit", int32(0), int32(1)},
+			"/live/clip_slot/get/has_clip":  {int32(2), int32(0), int32(1)},
+		},
+	}
+
+	got, err := setupDrumTrack(client, SetupDrumTrackInput{
+		KitName: "Street Kit",
+		Pattern: "kick_only",
+		Fire:    true,
+	})
+	if err != nil {
+		t.Fatalf("setupDrumTrack() error = %v", err)
+	}
+	if got.TrackIndex != 2 {
+		t.Errorf("TrackIndex = %d, want 2", got.TrackIndex)
+	}
+	if got.TrackName != "Street Kit" {
+		t.Errorf("TrackName = %q, want Street Kit", got.TrackName)
+	}
+	if got.Loaded != "Street Kit" {
+		t.Errorf("Loaded = %q, want Street Kit", got.Loaded)
+	}
+	if got.NotesAdded != 16 {
+		t.Errorf("NotesAdded = %d, want 16", got.NotesAdded)
+	}
+	if !got.Fired {
+		t.Error("Fired = false, want true")
+	}
+
+	if !hasCall(client.calls, "Send", "/live/song/create_midi_track") {
+		t.Error("expected create_midi_track")
+	}
+	if !hasCall(client.calls, "Query", "/live/track/load/browser_item") {
+		t.Error("expected load/browser_item")
+	}
+	if !hasCall(client.calls, "Send", "/live/clip/add/notes") {
+		t.Error("expected add/notes")
+	}
+	if !hasCall(client.calls, "Send", "/live/clip_slot/fire") {
+		t.Error("expected fire")
+	}
+}
+
+func TestSetupDrumTrackByPath(t *testing.T) {
+	t.Parallel()
+
+	client := &recipeClientStub{
+		queries: map[string][]interface{}{
+			"/live/song/get/num_tracks":    {int32(1)},
+			"/live/browser/load_at_path":   {int32(0), "loaded", "Core Kit", int32(0), int32(1)},
+			"/live/clip_slot/get/has_clip": {int32(0), int32(1), int32(1)},
+		},
+	}
+	clipIndex := 1
+	got, err := setupDrumTrack(client, SetupDrumTrackInput{
+		RootName:    "Drums",
+		PathParts:   []string{"Kits"},
+		ItemName:    "Core Kit",
+		TrackName:   "Beat",
+		ClipIndex:   &clipIndex,
+		LengthBeats: 4,
+		Pattern:     "basic_backbeat",
+	})
+	if err != nil {
+		t.Fatalf("setupDrumTrack() error = %v", err)
+	}
+	if got.TrackName != "Beat" {
+		t.Errorf("TrackName = %q, want Beat", got.TrackName)
+	}
+	if got.ClipIndex != 1 {
+		t.Errorf("ClipIndex = %d, want 1", got.ClipIndex)
+	}
+	if !hasCall(client.calls, "QueryWithTimeout", "/live/browser/load_at_path") {
+		t.Error("expected load_at_path")
+	}
+	if hasCall(client.calls, "Send", "/live/clip_slot/fire") {
+		t.Error("did not expect fire")
+	}
+}
+
+func TestSetupDrumTrackValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := setupDrumTrack(&recipeClientStub{}, SetupDrumTrackInput{})
+	if err == nil || !strings.Contains(err.Error(), "either kit_name or root_name") {
+		t.Fatalf("setupDrumTrack() error = %v, want mutual exclusion error", err)
+	}
+
+	_, err = setupDrumTrack(&recipeClientStub{}, SetupDrumTrackInput{
+		KitName:  "Street Kit",
+		RootName: "Drums",
+		ItemName: "Street Kit",
+	})
+	if err == nil || !strings.Contains(err.Error(), "either kit_name or root_name") {
+		t.Fatalf("setupDrumTrack() error = %v, want mutual exclusion error", err)
+	}
+}
+
+func countPitch(notes []MidiNote, pitch int) int {
+	n := 0
+	for _, note := range notes {
+		if note.Pitch == pitch {
+			n++
+		}
+	}
+	return n
+}
+
+func hasCall(calls []recipeCall, method, address string) bool {
+	for _, c := range calls {
+		if c.method == method && c.address == address {
+			return true
+		}
+	}
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -104,6 +104,9 @@ func main() {
 		tools.NewAbletonSetSessionRecord(g, ableton),
 		tools.NewAbletonBounceSessionPass(g, ableton),
 
+		// Recipes
+		tools.NewAbletonSetupDrumTrack(g, ableton),
+
 		// Raw OSC
 		tools.NewAbletonOscSend(g, ableton),
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ableton_setup_drum_track` recipe that creates a MIDI track, loads a drum kit, and fills a clip with a preset pattern
- support kit load by name (`kit_name`) or exact browser path (`root_name` + `item_name`)
- include patterns: `basic_backbeat`, `four_on_floor`, `kick_only`
- document the new MCP tool

## Testing
- `go test ./internal/tools/ -count=1`
- `go vet ./...`
- `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

