### PR TITLE
feat: add AbletonOSC connection and patch diagnose tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Load Drum Racks / presets from Live's Browser (with the included AbletonOSC patch)
 - Browse Live Browser folders by path and load items onto tracks
 - Set up a drum track with kit + clip + pattern in one recipe
+- Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots
 - Send raw OSC messages for advanced control
 
@@ -220,6 +221,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | Tool | Description |
 |------|-------------|
 | `ableton_test` | Test connection to AbletonOSC |
+| `ableton_diagnose` | Diagnose AbletonOSC connection and browser/master patch availability |
 | `ableton_get_tempo` / `ableton_set_tempo` | Get/set tempo (BPM) |
 | `ableton_play` / `ableton_stop` / `ableton_stop_all_clips` | Transport |
 | `ableton_set_song_key` | Set root note and scale |
@@ -267,6 +269,7 @@ Once configured, you can ask your AI assistant:
 - "List the Drums browser folder, then load Street Kit onto track 0"
 - "Add a kick drum pattern on beats 1, 2, 3, 4"
 - "What's the current tempo?"
+- "Diagnose the AbletonOSC connection and patches"
 
 ## Built With
 

--- a/internal/tools/ableton_diagnose.go
+++ b/internal/tools/ableton_diagnose.go
@@ -1,0 +1,204 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+type DiagnoseSettings struct {
+	Host       string
+	Port       int
+	ClientPort int
+	Timeout    time.Duration
+}
+
+type DiagnoseConfigOutput struct {
+	Host       string `json:"host"`
+	Port       int    `json:"port"`
+	ClientPort int    `json:"client_port"`
+	TimeoutMs  int    `json:"timeout_ms"`
+}
+
+type DiagnoseCheck struct {
+	Name   string `json:"name"`
+	OK     bool   `json:"ok"`
+	Detail string `json:"detail"`
+}
+
+type DiagnoseOutput struct {
+	Ready           bool                 `json:"ready" jsonschema:"description=true when AbletonOSC, browser patch, and master patch all respond"`
+	Connected       bool                 `json:"connected" jsonschema:"description=true when stock AbletonOSC /live/test responds"`
+	BrowserPatch    bool                 `json:"browser_patch"`
+	MasterPatch     bool                 `json:"master_patch"`
+	Config          DiagnoseConfigOutput `json:"config"`
+	Checks          []DiagnoseCheck      `json:"checks"`
+	Recommendations []string             `json:"recommendations"`
+}
+
+type diagnoseQuerier interface {
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+func NewAbletonDiagnose(g *genkit.Genkit, client *abletonosc.Client, settings DiagnoseSettings) ai.Tool {
+	return genkit.DefineTool(g, "ableton_diagnose",
+		"Ableton Live: diagnose AbletonOSC connection and browser/master patch availability",
+		func(_ *ai.ToolContext, _ EmptyInput) (DiagnoseOutput, error) {
+			return diagnoseAbleton(client, settings), nil
+		},
+	)
+}
+
+func diagnoseAbleton(client diagnoseQuerier, settings DiagnoseSettings) DiagnoseOutput {
+	timeout := settings.Timeout
+	if timeout <= 0 {
+		timeout = 500 * time.Millisecond
+	}
+
+	out := DiagnoseOutput{
+		Config: DiagnoseConfigOutput{
+			Host:       settings.Host,
+			Port:       settings.Port,
+			ClientPort: settings.ClientPort,
+			TimeoutMs:  int(timeout / time.Millisecond),
+		},
+		Checks:          make([]DiagnoseCheck, 0, 3),
+		Recommendations: []string{},
+	}
+
+	oscCheck := probeAbletonOSC(client)
+	out.Checks = append(out.Checks, oscCheck)
+	out.Connected = oscCheck.OK
+
+	browserCheck := probeBrowserPatch(client)
+	out.Checks = append(out.Checks, browserCheck)
+	out.BrowserPatch = browserCheck.OK
+
+	masterCheck := probeMasterPatch(client)
+	out.Checks = append(out.Checks, masterCheck)
+	out.MasterPatch = masterCheck.OK
+
+	out.Ready = out.Connected && out.BrowserPatch && out.MasterPatch
+	out.Recommendations = buildDiagnoseRecommendations(out)
+	return out
+}
+
+func probeAbletonOSC(client diagnoseQuerier) DiagnoseCheck {
+	res, err := client.Query("/live/test")
+	if err != nil {
+		return DiagnoseCheck{
+			Name:   "ableton_osc",
+			OK:     false,
+			Detail: formatProbeError(err),
+		}
+	}
+	detail := "ok"
+	if len(res) > 0 {
+		detail = fmt.Sprint(res[0])
+	}
+	return DiagnoseCheck{Name: "ableton_osc", OK: true, Detail: detail}
+}
+
+func probeBrowserPatch(client diagnoseQuerier) DiagnoseCheck {
+	res, err := client.Query("/live/browser/list_folder")
+	if err != nil {
+		return DiagnoseCheck{
+			Name:   "browser_patch",
+			OK:     false,
+			Detail: formatProbeError(err),
+		}
+	}
+	if len(res) == 0 {
+		return DiagnoseCheck{
+			Name:   "browser_patch",
+			OK:     false,
+			Detail: "empty reply from /live/browser/list_folder",
+		}
+	}
+	if fmt.Sprint(res[0]) != "roots" {
+		return DiagnoseCheck{
+			Name:   "browser_patch",
+			OK:     false,
+			Detail: fmt.Sprintf("unexpected reply: %v", res),
+		}
+	}
+	return DiagnoseCheck{
+		Name:   "browser_patch",
+		OK:     true,
+		Detail: fmt.Sprintf("roots=%d", len(res)-1),
+	}
+}
+
+func probeMasterPatch(client diagnoseQuerier) DiagnoseCheck {
+	res, err := client.Query("/live/master/get/volume")
+	if err != nil {
+		return DiagnoseCheck{
+			Name:   "master_patch",
+			OK:     false,
+			Detail: formatProbeError(err),
+		}
+	}
+	if err := ensureResponseLen(res, 1); err != nil {
+		return DiagnoseCheck{
+			Name:   "master_patch",
+			OK:     false,
+			Detail: err.Error(),
+		}
+	}
+	volume, err := abletonosc.AsFloat64(res[0])
+	if err != nil {
+		return DiagnoseCheck{
+			Name:   "master_patch",
+			OK:     false,
+			Detail: err.Error(),
+		}
+	}
+	return DiagnoseCheck{
+		Name:   "master_patch",
+		OK:     true,
+		Detail: fmt.Sprintf("volume=%.3f", volume),
+	}
+}
+
+func formatProbeError(err error) string {
+	msg := err.Error()
+	if strings.Contains(msg, "no response received to query") {
+		return "no response (timeout or endpoint missing)"
+	}
+	return msg
+}
+
+func buildDiagnoseRecommendations(out DiagnoseOutput) []string {
+	recs := make([]string, 0, 4)
+
+	if !out.Connected {
+		recs = append(recs,
+			"Enable AbletonOSC under Preferences → Link/Tempo/MIDI → Control Surface, then fully restart Ableton Live.",
+			fmt.Sprintf("Confirm Live is reachable at %s:%d (replies to client port %d).", out.Config.Host, out.Config.Port, out.Config.ClientPort),
+		)
+	}
+	if out.Connected && !out.BrowserPatch {
+		recs = append(recs,
+			"Install the browser patch from remote-script/ (copy browser.py and apply manager patch), then fully restart Ableton Live.",
+		)
+	}
+	if out.Connected && !out.MasterPatch {
+		recs = append(recs,
+			"Install the master patch from remote-script/ (copy master.py and apply manager patch), then fully restart Ableton Live.",
+		)
+	}
+	if (!out.Connected || !out.BrowserPatch || !out.MasterPatch) && out.Config.TimeoutMs <= 500 {
+		recs = append(recs,
+			"If the set is heavy, try raising ABLETON_OSC_TIMEOUT_MS (for example 2000).",
+		)
+	}
+	if out.Ready {
+		recs = append(recs, "AbletonOSC and both patches look ready.")
+	}
+	return recs
+}

--- a/internal/tools/ableton_diagnose_test.go
+++ b/internal/tools/ableton_diagnose_test.go
@@ -1,0 +1,141 @@
+package tools
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type diagnoseQuerierStub struct {
+	results map[string]struct {
+		values []interface{}
+		err    error
+	}
+}
+
+func (s diagnoseQuerierStub) Query(address string, _ ...interface{}) ([]interface{}, error) {
+	result, ok := s.results[address]
+	if !ok {
+		return nil, errors.New("unexpected query: " + address)
+	}
+	return result.values, result.err
+}
+
+func TestDiagnoseAbletonReady(t *testing.T) {
+	t.Parallel()
+
+	client := diagnoseQuerierStub{results: map[string]struct {
+		values []interface{}
+		err    error
+	}{
+		"/live/test": {values: []interface{}{"ok"}},
+		"/live/browser/list_folder": {values: []interface{}{
+			"roots",
+			"Drums|loadable=False|folder=True",
+			"Instruments|loadable=False|folder=True",
+		}},
+		"/live/master/get/volume": {values: []interface{}{float32(0.85)}},
+	}}
+
+	got := diagnoseAbleton(client, DiagnoseSettings{
+		Host:       "127.0.0.1",
+		Port:       11000,
+		ClientPort: 11001,
+		Timeout:    500 * time.Millisecond,
+	})
+
+	if !got.Ready || !got.Connected || !got.BrowserPatch || !got.MasterPatch {
+		t.Fatalf("diagnoseAbleton() flags = ready=%v connected=%v browser=%v master=%v",
+			got.Ready, got.Connected, got.BrowserPatch, got.MasterPatch)
+	}
+	if got.Config.TimeoutMs != 500 {
+		t.Errorf("TimeoutMs = %d, want 500", got.Config.TimeoutMs)
+	}
+	if len(got.Checks) != 3 {
+		t.Fatalf("Checks len = %d, want 3", len(got.Checks))
+	}
+	if len(got.Recommendations) == 0 || !strings.Contains(got.Recommendations[0], "ready") {
+		t.Errorf("Recommendations = %v, want ready message", got.Recommendations)
+	}
+}
+
+func TestDiagnoseAbletonReportsMissingPieces(t *testing.T) {
+	t.Parallel()
+
+	client := diagnoseQuerierStub{results: map[string]struct {
+		values []interface{}
+		err    error
+	}{
+		"/live/test": {values: []interface{}{"ok"}},
+		"/live/browser/list_folder": {
+			err: errors.New("no response received to query: /live/browser/list_folder"),
+		},
+		"/live/master/get/volume": {
+			err: errors.New("no response received to query: /live/master/get/volume"),
+		},
+	}}
+
+	got := diagnoseAbleton(client, DiagnoseSettings{
+		Host:       "127.0.0.1",
+		Port:       11000,
+		ClientPort: 11001,
+		Timeout:    500 * time.Millisecond,
+	})
+
+	if got.Ready {
+		t.Fatal("Ready = true, want false")
+	}
+	if !got.Connected {
+		t.Fatal("Connected = false, want true")
+	}
+	if got.BrowserPatch || got.MasterPatch {
+		t.Fatalf("patches should fail: browser=%v master=%v", got.BrowserPatch, got.MasterPatch)
+	}
+
+	joined := strings.Join(got.Recommendations, "\n")
+	if !strings.Contains(joined, "browser patch") {
+		t.Errorf("recommendations missing browser guidance: %s", joined)
+	}
+	if !strings.Contains(joined, "master patch") {
+		t.Errorf("recommendations missing master guidance: %s", joined)
+	}
+	if !strings.Contains(joined, "ABLETON_OSC_TIMEOUT_MS") {
+		t.Errorf("recommendations missing timeout guidance: %s", joined)
+	}
+}
+
+func TestDiagnoseAbletonConnectionFailure(t *testing.T) {
+	t.Parallel()
+
+	client := diagnoseQuerierStub{results: map[string]struct {
+		values []interface{}
+		err    error
+	}{
+		"/live/test": {err: errors.New("no response received to query: /live/test")},
+		"/live/browser/list_folder": {
+			err: errors.New("no response received to query: /live/browser/list_folder"),
+		},
+		"/live/master/get/volume": {
+			err: errors.New("no response received to query: /live/master/get/volume"),
+		},
+	}}
+
+	got := diagnoseAbleton(client, DiagnoseSettings{
+		Host:       "127.0.0.1",
+		Port:       11000,
+		ClientPort: 11001,
+		Timeout:    time.Second,
+	})
+
+	if got.Connected || got.Ready {
+		t.Fatalf("expected connection failure, got connected=%v ready=%v", got.Connected, got.Ready)
+	}
+	joined := strings.Join(got.Recommendations, "\n")
+	if !strings.Contains(joined, "Enable AbletonOSC") {
+		t.Errorf("recommendations missing AbletonOSC guidance: %s", joined)
+	}
+	if strings.Contains(joined, "ABLETON_OSC_TIMEOUT_MS") {
+		t.Errorf("timeout tip should be skipped when timeout > 500ms: %s", joined)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,12 @@ func main() {
 	toolList := []ai.Tool{
 		// Song / Transport
 		tools.NewAbletonTest(g, ableton),
+		tools.NewAbletonDiagnose(g, ableton, tools.DiagnoseSettings{
+			Host:       cfg.AbletonHost,
+			Port:       cfg.AbletonPort,
+			ClientPort: cfg.AbletonClientPort,
+			Timeout:    cfg.Timeout,
+		}),
 		tools.NewAbletonGetTempo(g, ableton),
 		tools.NewAbletonSetTempo(g, ableton),
 		tools.NewAbletonPlay(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ableton_diagnose` to probe AbletonOSC connectivity plus browser/master patch endpoints
- return readiness flags, current OSC config, and actionable setup recommendations
- document the new MCP tool

## Testing
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

