### PR TITLE
feat: add MIDI clip humanize tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Load Drum Racks / presets from Live's Browser (with the included AbletonOSC patch)
 - Browse Live Browser folders by path and load items onto tracks
 - Set up a drum track with kit + clip + pattern in one recipe
+- Humanize MIDI clips with microtiming, velocity variation, and swing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots
 - Send raw OSC messages for advanced control
@@ -239,6 +240,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_set_track_volume` | Set track volume |
 | `ableton_create_clip` | Create a clip in a slot |
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
+| `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
 | `ableton_fire_clip_slot` / `ableton_stop_clip` | Fire/stop a clip |
 | `ableton_duplicate_clip_to` | Duplicate clip to another slot |
 | `ableton_set_clip_name` | Rename a clip |
@@ -265,6 +267,7 @@ Once configured, you can ask your AI assistant:
 - "Set the tempo to 140 BPM"
 - "Create a MIDI track, load Street Kit, and add a 4-bar clip"
 - "Set up a Street Kit drum track with a four-on-floor pattern"
+- "Humanize the drum clip with a bit of swing"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"
 - "Add a kick drum pattern on beats 1, 2, 3, 4"

--- a/internal/tools/ableton_clips.go
+++ b/internal/tools/ableton_clips.go
@@ -151,55 +151,10 @@ func NewAbletonGetClipNotes(g *genkit.Genkit, client *abletonosc.Client) ai.Tool
 			if err != nil {
 				return ClipNotesOutput{}, err
 			}
-			if err := ensureResponseLen(res, 2); err != nil {
-				return ClipNotesOutput{}, err
-			}
-			trackIndex, err := abletonosc.AsInt(res[0])
+			trackIndex, clipIndex, notes, err := parseClipNotesResponse(res)
 			if err != nil {
 				return ClipNotesOutput{}, err
 			}
-			clipIndex, err := abletonosc.AsInt(res[1])
-			if err != nil {
-				return ClipNotesOutput{}, err
-			}
-
-			payload := res[2:]
-			if len(payload)%5 != 0 {
-				return ClipNotesOutput{}, fmt.Errorf("unexpected notes payload: %v", payload)
-			}
-
-			notes := make([]MidiNote, 0, len(payload)/5)
-			for i := 0; i < len(payload); i += 5 {
-				pitch, err := abletonosc.AsInt(payload[i])
-				if err != nil {
-					return ClipNotesOutput{}, err
-				}
-				startTime, err := abletonosc.AsFloat64(payload[i+1])
-				if err != nil {
-					return ClipNotesOutput{}, err
-				}
-				duration, err := abletonosc.AsFloat64(payload[i+2])
-				if err != nil {
-					return ClipNotesOutput{}, err
-				}
-				velocity, err := abletonosc.AsInt(payload[i+3])
-				if err != nil {
-					return ClipNotesOutput{}, err
-				}
-				mute, err := abletonosc.AsBool(payload[i+4])
-				if err != nil {
-					return ClipNotesOutput{}, err
-				}
-				m := mute
-				notes = append(notes, MidiNote{
-					Pitch:     pitch,
-					StartTime: startTime,
-					Duration:  duration,
-					Velocity:  velocity,
-					Mute:      &m,
-				})
-			}
-
 			return ClipNotesOutput{
 				TrackIndex: trackIndex,
 				ClipIndex:  clipIndex,
@@ -207,6 +162,58 @@ func NewAbletonGetClipNotes(g *genkit.Genkit, client *abletonosc.Client) ai.Tool
 			}, nil
 		},
 	)
+}
+
+func parseClipNotesResponse(res []interface{}) (int, int, []MidiNote, error) {
+	if err := ensureResponseLen(res, 2); err != nil {
+		return 0, 0, nil, err
+	}
+	trackIndex, err := abletonosc.AsInt(res[0])
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	clipIndex, err := abletonosc.AsInt(res[1])
+	if err != nil {
+		return 0, 0, nil, err
+	}
+
+	payload := res[2:]
+	if len(payload)%5 != 0 {
+		return 0, 0, nil, fmt.Errorf("unexpected notes payload: %v", payload)
+	}
+
+	notes := make([]MidiNote, 0, len(payload)/5)
+	for i := 0; i < len(payload); i += 5 {
+		pitch, err := abletonosc.AsInt(payload[i])
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		startTime, err := abletonosc.AsFloat64(payload[i+1])
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		duration, err := abletonosc.AsFloat64(payload[i+2])
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		velocity, err := abletonosc.AsInt(payload[i+3])
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		mute, err := abletonosc.AsBool(payload[i+4])
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		m := mute
+		notes = append(notes, MidiNote{
+			Pitch:     pitch,
+			StartTime: startTime,
+			Duration:  duration,
+			Velocity:  velocity,
+			Mute:      &m,
+		})
+	}
+	return trackIndex, clipIndex, notes, nil
 }
 
 func NewAbletonFireClipSlot(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {

--- a/internal/tools/ableton_humanize.go
+++ b/internal/tools/ableton_humanize.go
@@ -86,29 +86,22 @@ func humanizeClip(client humanizeClient, input HumanizeClipInput) (HumanizeClipO
 		return HumanizeClipOutput{}, errors.New("clip has no notes to humanize")
 	}
 
+	// Best-effort clip length so timing offsets never push notes past the loop.
+	clipLength := queryClipLength(client, input.TrackIndex, input.ClipIndex)
+
 	rng := rand.New(rand.NewSource(opts.Seed))
-	humanized := humanizeNotes(notes, opts, rng)
+	humanized := humanizeNotes(notes, opts, rng, clipLength)
 
 	if err := client.Send("/live/clip/remove/notes", int32(input.TrackIndex), int32(input.ClipIndex)); err != nil {
 		return HumanizeClipOutput{}, fmt.Errorf("clear notes: %w", err)
 	}
 
-	args := []interface{}{int32(input.TrackIndex), int32(input.ClipIndex)}
-	for _, n := range humanized {
-		mute := false
-		if n.Mute != nil {
-			mute = *n.Mute
+	if err := client.Send("/live/clip/add/notes", addNotesArgs(input.TrackIndex, input.ClipIndex, humanized)...); err != nil {
+		// Adding failed after clearing; restore the original notes so the clip is not left empty.
+		if restoreErr := client.Send("/live/clip/add/notes", addNotesArgs(input.TrackIndex, input.ClipIndex, notes)...); restoreErr != nil {
+			return HumanizeClipOutput{}, fmt.Errorf("add humanized notes: %w; restore original notes also failed: %v", err, restoreErr)
 		}
-		args = append(args,
-			int32(n.Pitch),
-			float32(n.StartTime),
-			float32(n.Duration),
-			int32(n.Velocity),
-			mute,
-		)
-	}
-	if err := client.Send("/live/clip/add/notes", args...); err != nil {
-		return HumanizeClipOutput{}, fmt.Errorf("add humanized notes: %w", err)
+		return HumanizeClipOutput{}, fmt.Errorf("add humanized notes: %w (original notes restored)", err)
 	}
 
 	return HumanizeClipOutput{
@@ -161,7 +154,7 @@ func resolveHumanizeOptions(input HumanizeClipInput) (humanizeOptions, error) {
 	return opts, nil
 }
 
-func humanizeNotes(notes []MidiNote, opts humanizeOptions, rng *rand.Rand) []MidiNote {
+func humanizeNotes(notes []MidiNote, opts humanizeOptions, rng *rand.Rand, clipLength float64) []MidiNote {
 	timingMax := opts.TimingAmount * opts.Strength
 	velocityMax := float64(opts.VelocityAmount) * opts.Strength
 	swing := opts.Swing * opts.Strength
@@ -177,6 +170,13 @@ func humanizeNotes(notes []MidiNote, opts humanizeOptions, rng *rand.Rand) []Mid
 		}
 		if start < 0 {
 			start = 0
+		}
+		// Keep notes inside the clip loop; never move a note earlier than its origin bar.
+		if clipLength > 0 && start >= clipLength {
+			start = math.Max(n.StartTime, clipLength-timingMax)
+			if start < 0 {
+				start = 0
+			}
 		}
 
 		velocity := n.Velocity
@@ -209,6 +209,38 @@ func humanizeNotes(notes []MidiNote, opts humanizeOptions, rng *rand.Rand) []Mid
 		out = append(out, note)
 	}
 	return out
+}
+
+func addNotesArgs(trackIndex, clipIndex int, notes []MidiNote) []interface{} {
+	args := []interface{}{int32(trackIndex), int32(clipIndex)}
+	for _, n := range notes {
+		mute := false
+		if n.Mute != nil {
+			mute = *n.Mute
+		}
+		args = append(args,
+			int32(n.Pitch),
+			float32(n.StartTime),
+			float32(n.Duration),
+			int32(n.Velocity),
+			mute,
+		)
+	}
+	return args
+}
+
+// queryClipLength returns the clip loop length in beats, or 0 when unavailable.
+func queryClipLength(client humanizeClient, trackIndex, clipIndex int) float64 {
+	res, err := client.Query("/live/clip/get/length", int32(trackIndex), int32(clipIndex))
+	if err != nil || len(res) == 0 {
+		return 0
+	}
+	// Reply is (track_index, clip_index, length); fall back to the last value otherwise.
+	length, err := abletonosc.AsFloat64(res[len(res)-1])
+	if err != nil || length <= 0 {
+		return 0
+	}
+	return length
 }
 
 // applyEighthSwing delays offbeat eighth notes toward the next onbeat.

--- a/internal/tools/ableton_humanize.go
+++ b/internal/tools/ableton_humanize.go
@@ -1,0 +1,223 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const (
+	defaultHumanizeTimingAmount   = 0.02
+	defaultHumanizeVelocityAmount = 10
+	defaultHumanizeStrength       = 0.6
+	maxHumanizeTimingAmount       = 0.08
+	maxHumanizeVelocityAmount     = 40
+)
+
+type HumanizeClipInput struct {
+	TrackIndex     int      `json:"track_index" jsonschema:"minimum=0"`
+	ClipIndex      int      `json:"clip_index" jsonschema:"minimum=0"`
+	TimingAmount   *float64 `json:"timing_amount,omitempty" jsonschema:"description=Max timing offset in beats (default 0.02),minimum=0,maximum=0.08"`
+	VelocityAmount *int     `json:"velocity_amount,omitempty" jsonschema:"description=Max velocity offset (default 10),minimum=0,maximum=40"`
+	Swing          *float64 `json:"swing,omitempty" jsonschema:"description=8th-note swing amount 0-1 (default 0),minimum=0,maximum=1"`
+	Strength       *float64 `json:"strength,omitempty" jsonschema:"description=Overall humanize intensity 0-1 (default 0.6),minimum=0,maximum=1"`
+	Seed           *int64   `json:"seed,omitempty" jsonschema:"description=Optional RNG seed for reproducible results"`
+}
+
+type HumanizeClipOutput struct {
+	TrackIndex     int     `json:"track_index"`
+	ClipIndex      int     `json:"clip_index"`
+	NotesUpdated   int     `json:"notes_updated"`
+	TimingAmount   float64 `json:"timing_amount"`
+	VelocityAmount int     `json:"velocity_amount"`
+	Swing          float64 `json:"swing"`
+	Strength       float64 `json:"strength"`
+	Seed           int64   `json:"seed"`
+}
+
+type humanizeOptions struct {
+	TimingAmount   float64
+	VelocityAmount int
+	Swing          float64
+	Strength       float64
+	Seed           int64
+}
+
+type humanizeClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+func NewAbletonHumanizeClip(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_humanize_clip",
+		"Ableton Live: add microtiming, velocity variation, and optional swing to MIDI notes in a clip",
+		func(_ *ai.ToolContext, input HumanizeClipInput) (HumanizeClipOutput, error) {
+			return humanizeClip(client, input)
+		},
+	)
+}
+
+func humanizeClip(client humanizeClient, input HumanizeClipInput) (HumanizeClipOutput, error) {
+	if err := validateTrackClipIndices(input.TrackIndex, input.ClipIndex); err != nil {
+		return HumanizeClipOutput{}, err
+	}
+
+	opts, err := resolveHumanizeOptions(input)
+	if err != nil {
+		return HumanizeClipOutput{}, err
+	}
+
+	res, err := client.Query("/live/clip/get/notes", int32(input.TrackIndex), int32(input.ClipIndex))
+	if err != nil {
+		return HumanizeClipOutput{}, fmt.Errorf("get notes: %w", err)
+	}
+	_, _, notes, err := parseClipNotesResponse(res)
+	if err != nil {
+		return HumanizeClipOutput{}, fmt.Errorf("get notes: %w", err)
+	}
+	if len(notes) == 0 {
+		return HumanizeClipOutput{}, errors.New("clip has no notes to humanize")
+	}
+
+	rng := rand.New(rand.NewSource(opts.Seed))
+	humanized := humanizeNotes(notes, opts, rng)
+
+	if err := client.Send("/live/clip/remove/notes", int32(input.TrackIndex), int32(input.ClipIndex)); err != nil {
+		return HumanizeClipOutput{}, fmt.Errorf("clear notes: %w", err)
+	}
+
+	args := []interface{}{int32(input.TrackIndex), int32(input.ClipIndex)}
+	for _, n := range humanized {
+		mute := false
+		if n.Mute != nil {
+			mute = *n.Mute
+		}
+		args = append(args,
+			int32(n.Pitch),
+			float32(n.StartTime),
+			float32(n.Duration),
+			int32(n.Velocity),
+			mute,
+		)
+	}
+	if err := client.Send("/live/clip/add/notes", args...); err != nil {
+		return HumanizeClipOutput{}, fmt.Errorf("add humanized notes: %w", err)
+	}
+
+	return HumanizeClipOutput{
+		TrackIndex:     input.TrackIndex,
+		ClipIndex:      input.ClipIndex,
+		NotesUpdated:   len(humanized),
+		TimingAmount:   opts.TimingAmount,
+		VelocityAmount: opts.VelocityAmount,
+		Swing:          opts.Swing,
+		Strength:       opts.Strength,
+		Seed:           opts.Seed,
+	}, nil
+}
+
+func resolveHumanizeOptions(input HumanizeClipInput) (humanizeOptions, error) {
+	opts := humanizeOptions{
+		TimingAmount:   defaultHumanizeTimingAmount,
+		VelocityAmount: defaultHumanizeVelocityAmount,
+		Strength:       defaultHumanizeStrength,
+		Seed:           time.Now().UnixNano(),
+	}
+	if input.TimingAmount != nil {
+		opts.TimingAmount = *input.TimingAmount
+	}
+	if input.VelocityAmount != nil {
+		opts.VelocityAmount = *input.VelocityAmount
+	}
+	if input.Swing != nil {
+		opts.Swing = *input.Swing
+	}
+	if input.Strength != nil {
+		opts.Strength = *input.Strength
+	}
+	if input.Seed != nil {
+		opts.Seed = *input.Seed
+	}
+
+	if opts.TimingAmount < 0 || opts.TimingAmount > maxHumanizeTimingAmount {
+		return humanizeOptions{}, fmt.Errorf("timing_amount must be between 0 and %.2f", maxHumanizeTimingAmount)
+	}
+	if opts.VelocityAmount < 0 || opts.VelocityAmount > maxHumanizeVelocityAmount {
+		return humanizeOptions{}, fmt.Errorf("velocity_amount must be between 0 and %d", maxHumanizeVelocityAmount)
+	}
+	if opts.Swing < 0 || opts.Swing > 1 {
+		return humanizeOptions{}, errors.New("swing must be between 0 and 1")
+	}
+	if opts.Strength < 0 || opts.Strength > 1 {
+		return humanizeOptions{}, errors.New("strength must be between 0 and 1")
+	}
+	return opts, nil
+}
+
+func humanizeNotes(notes []MidiNote, opts humanizeOptions, rng *rand.Rand) []MidiNote {
+	timingMax := opts.TimingAmount * opts.Strength
+	velocityMax := float64(opts.VelocityAmount) * opts.Strength
+	swing := opts.Swing * opts.Strength
+
+	out := make([]MidiNote, 0, len(notes))
+	for _, n := range notes {
+		start := n.StartTime
+		if swing > 0 {
+			start = applyEighthSwing(start, swing)
+		}
+		if timingMax > 0 {
+			start += (rng.Float64()*2 - 1) * timingMax
+		}
+		if start < 0 {
+			start = 0
+		}
+
+		velocity := n.Velocity
+		if velocityMax > 0 {
+			delta := int(math.Round((rng.Float64()*2 - 1) * velocityMax))
+			velocity += delta
+		}
+		if velocity < 1 {
+			velocity = 1
+		}
+		if velocity > 127 {
+			velocity = 127
+		}
+
+		duration := n.Duration
+		if duration < 0.01 {
+			duration = 0.01
+		}
+
+		note := MidiNote{
+			Pitch:     n.Pitch,
+			StartTime: start,
+			Duration:  duration,
+			Velocity:  velocity,
+		}
+		if n.Mute != nil {
+			m := *n.Mute
+			note.Mute = &m
+		}
+		out = append(out, note)
+	}
+	return out
+}
+
+// applyEighthSwing delays offbeat eighth notes toward the next onbeat.
+// swing=0 keeps even 8ths; swing=1 delays by one third of an 8th (triplet-ish feel).
+func applyEighthSwing(start, swing float64) float64 {
+	const unit = 0.5
+	slot := math.Floor((start + 1e-9) / unit)
+	if int(slot)%2 == 0 {
+		return start
+	}
+	return start + swing*unit/3
+}

--- a/internal/tools/ableton_humanize_test.go
+++ b/internal/tools/ableton_humanize_test.go
@@ -4,24 +4,45 @@ import (
 	"errors"
 	"math"
 	"math/rand"
+	"strings"
 	"testing"
 )
 
 type humanizeClientStub struct {
-	notesRes []interface{}
-	calls    []string
+	notesRes    []interface{}
+	lengthRes   []interface{}
+	calls       []string
+	sendErr     map[string]error
+	failAddOnce bool
+	addCalls    [][]interface{}
 }
 
 func (s *humanizeClientStub) Query(address string, _ ...interface{}) ([]interface{}, error) {
 	s.calls = append(s.calls, "Query:"+address)
-	if address != "/live/clip/get/notes" {
+	switch address {
+	case "/live/clip/get/notes":
+		return s.notesRes, nil
+	case "/live/clip/get/length":
+		if s.lengthRes == nil {
+			return nil, errors.New("no length")
+		}
+		return s.lengthRes, nil
+	default:
 		return nil, errors.New("unexpected query")
 	}
-	return s.notesRes, nil
 }
 
-func (s *humanizeClientStub) Send(address string, _ ...interface{}) error {
+func (s *humanizeClientStub) Send(address string, args ...interface{}) error {
 	s.calls = append(s.calls, "Send:"+address)
+	if address == "/live/clip/add/notes" {
+		s.addCalls = append(s.addCalls, args)
+		if s.failAddOnce && len(s.addCalls) == 1 {
+			return errors.New("add failed")
+		}
+	}
+	if err, ok := s.sendErr[address]; ok {
+		return err
+	}
 	return nil
 }
 
@@ -41,8 +62,8 @@ func TestHumanizeNotesIsDeterministicWithSeed(t *testing.T) {
 		Seed:           42,
 	}
 
-	a := humanizeNotes(notes, opts, rand.New(rand.NewSource(opts.Seed)))
-	b := humanizeNotes(notes, opts, rand.New(rand.NewSource(opts.Seed)))
+	a := humanizeNotes(notes, opts, rand.New(rand.NewSource(opts.Seed)), 0)
+	b := humanizeNotes(notes, opts, rand.New(rand.NewSource(opts.Seed)), 0)
 	if len(a) != len(b) {
 		t.Fatalf("len mismatch: %d vs %d", len(a), len(b))
 	}
@@ -67,7 +88,7 @@ func TestHumanizeNotesAppliesSwingAndBounds(t *testing.T) {
 		Strength:       1,
 		Seed:           7,
 	}
-	got := humanizeNotes(notes, opts, rand.New(rand.NewSource(opts.Seed)))
+	got := humanizeNotes(notes, opts, rand.New(rand.NewSource(opts.Seed)), 0)
 
 	if math.Abs(got[0].StartTime-applyEighthSwing(0.5, 1)) > 1e-9 {
 		t.Errorf("offbeat start = %v, want swung value", got[0].StartTime)
@@ -105,6 +126,7 @@ func TestHumanizeClip(t *testing.T) {
 			int32(36), float32(0), float32(0.25), int32(100), false,
 			int32(38), float32(1), float32(0.25), int32(100), false,
 		},
+		lengthRes: []interface{}{int32(1), int32(0), float32(4)},
 	}
 
 	got, err := humanizeClip(client, HumanizeClipInput{
@@ -128,6 +150,7 @@ func TestHumanizeClip(t *testing.T) {
 
 	wantCalls := []string{
 		"Query:/live/clip/get/notes",
+		"Query:/live/clip/get/length",
 		"Send:/live/clip/remove/notes",
 		"Send:/live/clip/add/notes",
 	}
@@ -138,6 +161,58 @@ func TestHumanizeClip(t *testing.T) {
 		if client.calls[i] != wantCalls[i] {
 			t.Errorf("calls[%d] = %q, want %q", i, client.calls[i], wantCalls[i])
 		}
+	}
+}
+
+func TestHumanizeNotesClampsToClipLength(t *testing.T) {
+	t.Parallel()
+
+	notes := []MidiNote{
+		{Pitch: 42, StartTime: 3.98, Duration: 0.125, Velocity: 80},
+	}
+	opts := humanizeOptions{
+		TimingAmount:   0.08,
+		VelocityAmount: 0,
+		Strength:       1,
+		Seed:           1,
+	}
+	got := humanizeNotes(notes, opts, rand.New(rand.NewSource(opts.Seed)), 4.0)
+	if got[0].StartTime >= 4.0 {
+		t.Errorf("start = %v, want < clip length 4.0", got[0].StartTime)
+	}
+	if got[0].StartTime < 0 {
+		t.Errorf("start = %v, want >= 0", got[0].StartTime)
+	}
+}
+
+func TestHumanizeClipRestoresOnAddFailure(t *testing.T) {
+	t.Parallel()
+
+	seed := int64(5)
+	client := &humanizeClientStub{
+		notesRes: []interface{}{
+			int32(0), int32(0),
+			int32(36), float32(0), float32(0.25), int32(100), false,
+		},
+		failAddOnce: true,
+	}
+	_, err := humanizeClip(client, HumanizeClipInput{TrackIndex: 0, ClipIndex: 0, Seed: &seed})
+	if err == nil {
+		t.Fatal("humanizeClip() error = nil, want add-failure error")
+	}
+	if !strings.Contains(err.Error(), "restored") {
+		t.Errorf("error = %q, want restore note", err)
+	}
+	if len(client.addCalls) != 2 {
+		t.Fatalf("add/notes called %d times, want 2 (humanized + restore)", len(client.addCalls))
+	}
+	// The restore call must carry the original note payload (start time 0, velocity 100).
+	restore := client.addCalls[1]
+	if len(restore) != 7 {
+		t.Fatalf("restore args len = %d, want 7", len(restore))
+	}
+	if restore[3] != float32(0) || restore[5] != int32(100) {
+		t.Errorf("restore payload = %v, want original note", restore)
 	}
 }
 

--- a/internal/tools/ableton_humanize_test.go
+++ b/internal/tools/ableton_humanize_test.go
@@ -1,0 +1,170 @@
+package tools
+
+import (
+	"errors"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+type humanizeClientStub struct {
+	notesRes []interface{}
+	calls    []string
+}
+
+func (s *humanizeClientStub) Query(address string, _ ...interface{}) ([]interface{}, error) {
+	s.calls = append(s.calls, "Query:"+address)
+	if address != "/live/clip/get/notes" {
+		return nil, errors.New("unexpected query")
+	}
+	return s.notesRes, nil
+}
+
+func (s *humanizeClientStub) Send(address string, _ ...interface{}) error {
+	s.calls = append(s.calls, "Send:"+address)
+	return nil
+}
+
+func TestHumanizeNotesIsDeterministicWithSeed(t *testing.T) {
+	t.Parallel()
+
+	notes := []MidiNote{
+		{Pitch: 36, StartTime: 0, Duration: 0.25, Velocity: 100},
+		{Pitch: 38, StartTime: 1, Duration: 0.25, Velocity: 100},
+		{Pitch: 42, StartTime: 0.5, Duration: 0.125, Velocity: 80},
+	}
+	opts := humanizeOptions{
+		TimingAmount:   0.03,
+		VelocityAmount: 12,
+		Swing:          0.4,
+		Strength:       0.8,
+		Seed:           42,
+	}
+
+	a := humanizeNotes(notes, opts, rand.New(rand.NewSource(opts.Seed)))
+	b := humanizeNotes(notes, opts, rand.New(rand.NewSource(opts.Seed)))
+	if len(a) != len(b) {
+		t.Fatalf("len mismatch: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("note[%d] differs: %#v vs %#v", i, a[i], b[i])
+		}
+	}
+}
+
+func TestHumanizeNotesAppliesSwingAndBounds(t *testing.T) {
+	t.Parallel()
+
+	notes := []MidiNote{
+		{Pitch: 42, StartTime: 0.5, Duration: 0.125, Velocity: 80},
+		{Pitch: 36, StartTime: 0, Duration: 0.25, Velocity: 1},
+	}
+	opts := humanizeOptions{
+		TimingAmount:   0,
+		VelocityAmount: 40,
+		Swing:          1,
+		Strength:       1,
+		Seed:           7,
+	}
+	got := humanizeNotes(notes, opts, rand.New(rand.NewSource(opts.Seed)))
+
+	if math.Abs(got[0].StartTime-applyEighthSwing(0.5, 1)) > 1e-9 {
+		t.Errorf("offbeat start = %v, want swung value", got[0].StartTime)
+	}
+	if got[1].StartTime != 0 {
+		t.Errorf("onbeat start = %v, want 0", got[1].StartTime)
+	}
+	for _, n := range got {
+		if n.Velocity < 1 || n.Velocity > 127 {
+			t.Errorf("velocity out of range: %d", n.Velocity)
+		}
+	}
+}
+
+func TestApplyEighthSwing(t *testing.T) {
+	t.Parallel()
+
+	if got := applyEighthSwing(0, 1); got != 0 {
+		t.Errorf("onbeat swing = %v, want 0", got)
+	}
+	want := 0.5 + 0.5/3
+	if got := applyEighthSwing(0.5, 1); math.Abs(got-want) > 1e-9 {
+		t.Errorf("offbeat swing = %v, want %v", got, want)
+	}
+}
+
+func TestHumanizeClip(t *testing.T) {
+	t.Parallel()
+
+	seed := int64(99)
+	strength := 0.5
+	client := &humanizeClientStub{
+		notesRes: []interface{}{
+			int32(1), int32(0),
+			int32(36), float32(0), float32(0.25), int32(100), false,
+			int32(38), float32(1), float32(0.25), int32(100), false,
+		},
+	}
+
+	got, err := humanizeClip(client, HumanizeClipInput{
+		TrackIndex: 1,
+		ClipIndex:  0,
+		Strength:   &strength,
+		Seed:       &seed,
+	})
+	if err != nil {
+		t.Fatalf("humanizeClip() error = %v", err)
+	}
+	if got.NotesUpdated != 2 {
+		t.Errorf("NotesUpdated = %d, want 2", got.NotesUpdated)
+	}
+	if got.Seed != seed {
+		t.Errorf("Seed = %d, want %d", got.Seed, seed)
+	}
+	if got.Strength != strength {
+		t.Errorf("Strength = %v, want %v", got.Strength, strength)
+	}
+
+	wantCalls := []string{
+		"Query:/live/clip/get/notes",
+		"Send:/live/clip/remove/notes",
+		"Send:/live/clip/add/notes",
+	}
+	if len(client.calls) != len(wantCalls) {
+		t.Fatalf("calls = %v, want %v", client.calls, wantCalls)
+	}
+	for i := range wantCalls {
+		if client.calls[i] != wantCalls[i] {
+			t.Errorf("calls[%d] = %q, want %q", i, client.calls[i], wantCalls[i])
+		}
+	}
+}
+
+func TestHumanizeClipRejectsEmptyClip(t *testing.T) {
+	t.Parallel()
+
+	client := &humanizeClientStub{
+		notesRes: []interface{}{int32(0), int32(0)},
+	}
+	_, err := humanizeClip(client, HumanizeClipInput{TrackIndex: 0, ClipIndex: 0})
+	if err == nil {
+		t.Fatal("humanizeClip() error = nil, want empty-clip error")
+	}
+}
+
+func TestResolveHumanizeOptionsValidation(t *testing.T) {
+	t.Parallel()
+
+	badTiming := 1.0
+	_, err := resolveHumanizeOptions(HumanizeClipInput{TimingAmount: &badTiming})
+	if err == nil {
+		t.Fatal("expected timing_amount validation error")
+	}
+
+	badSwing := 1.5
+	_, err = resolveHumanizeOptions(HumanizeClipInput{Swing: &badSwing})
+	if err == nil {
+		t.Fatal("expected swing validation error")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 		tools.NewAbletonStopClip(g, ableton),
 		tools.NewAbletonClearClipNotes(g, ableton),
 		tools.NewAbletonAddMidiNotes(g, ableton),
+		tools.NewAbletonHumanizeClip(g, ableton),
 		tools.NewAbletonDuplicateClipTo(g, ableton),
 		tools.NewAbletonSetClipName(g, ableton),
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ableton_humanize_clip` to apply microtiming, velocity variation, and optional 8th-note swing
- support strength/seed controls for reproducible groove tweaks
- non-destructive: if re-adding humanized notes fails, the original notes are restored
- clamp timing offsets to the queried clip length so notes stay inside the loop
- share clip-note response parsing between get-notes and humanize
- document the new MCP tool

## Testing
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

