### PR TITLE
feat: add track autogain tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Browse Live Browser folders by path and load items onto tracks
 - Set up a drum track with kit + clip + pattern in one recipe
 - Humanize MIDI clips with microtiming, velocity variation, and swing
+- Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots
 - Send raw OSC messages for advanced control
@@ -252,6 +253,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_load_browser_path` | Load Browser item onto a track by exact path (requires patch) |
 | `ableton_load_device_preset` | Hotswap a preset onto a device |
 | `ableton_get_track_meter` | Track output meter levels |
+| `ableton_autogain_tracks` | Iteratively adjust track volumes toward a target meter level |
 | `ableton_get_master_meter` / `ableton_get_master_volume` / `ableton_set_master_volume` | Master meter/volume (requires master patch) |
 | `ableton_get_master_devices` / `ableton_get_master_device_parameters` / `ableton_set_master_device_parameter` | Master devices (requires master patch) |
 | `ableton_load_on_master` | Load Browser item onto master (requires browser+master patch) |
@@ -268,6 +270,7 @@ Once configured, you can ask your AI assistant:
 - "Create a MIDI track, load Street Kit, and add a 4-bar clip"
 - "Set up a Street Kit drum track with a four-on-floor pattern"
 - "Humanize the drum clip with a bit of swing"
+- "Autogain the drum and bass tracks while the beat is playing"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"
 - "Add a kick drum pattern on beats 1, 2, 3, 4"

--- a/internal/tools/ableton_autogain.go
+++ b/internal/tools/ableton_autogain.go
@@ -1,0 +1,295 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const (
+	defaultAutogainTargetLevel  = 0.45
+	defaultAutogainTolerance    = 0.05
+	defaultAutogainMaxIters     = 6
+	defaultAutogainSettleMs     = 150
+	defaultAutogainMeterSamples = 3
+	autogainSilentThreshold     = 0.01
+	autogainMaxVolumeStep       = 0.12
+)
+
+type AutogainTracksInput struct {
+	TrackIndices  []int    `json:"track_indices,omitempty" jsonschema:"description=Tracks to adjust; omit to include all regular tracks"`
+	TargetLevel   *float64 `json:"target_level,omitempty" jsonschema:"description=Target output meter level 0-1 (default 0.45),minimum=0.05,maximum=0.95"`
+	Tolerance     *float64 `json:"tolerance,omitempty" jsonschema:"description=Acceptable meter error (default 0.05),minimum=0.01,maximum=0.3"`
+	MaxIterations *int     `json:"max_iterations,omitempty" jsonschema:"description=Max adjust loops per track (default 6),minimum=1,maximum=20"`
+	SettleMs      *int     `json:"settle_ms,omitempty" jsonschema:"description=Wait after each volume change in ms (default 150),minimum=0,maximum=2000"`
+}
+
+type AutogainTrackResult struct {
+	TrackIndex   int     `json:"track_index"`
+	Status       string  `json:"status" jsonschema:"description=ok, silent, unchanged, capped, or partial"`
+	VolumeBefore float64 `json:"volume_before"`
+	VolumeAfter  float64 `json:"volume_after"`
+	MeterBefore  float64 `json:"meter_before"`
+	MeterAfter   float64 `json:"meter_after"`
+	Iterations   int     `json:"iterations"`
+}
+
+type AutogainTracksOutput struct {
+	TargetLevel float64               `json:"target_level"`
+	Tolerance   float64               `json:"tolerance"`
+	Results     []AutogainTrackResult `json:"results"`
+}
+
+type autogainClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+type sleeperFunc func(time.Duration)
+
+func NewAbletonAutogainTracks(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_autogain_tracks",
+		"Ableton Live: iteratively adjust track volumes toward a target meter level while audio is playing",
+		func(_ *ai.ToolContext, input AutogainTracksInput) (AutogainTracksOutput, error) {
+			return autogainTracks(client, input, time.Sleep)
+		},
+	)
+}
+
+func autogainTracks(client autogainClient, input AutogainTracksInput, sleep sleeperFunc) (AutogainTracksOutput, error) {
+	target := defaultAutogainTargetLevel
+	if input.TargetLevel != nil {
+		target = *input.TargetLevel
+	}
+	tolerance := defaultAutogainTolerance
+	if input.Tolerance != nil {
+		tolerance = *input.Tolerance
+	}
+	maxIters := defaultAutogainMaxIters
+	if input.MaxIterations != nil {
+		maxIters = *input.MaxIterations
+	}
+	settleMs := defaultAutogainSettleMs
+	if input.SettleMs != nil {
+		settleMs = *input.SettleMs
+	}
+
+	if target < 0.05 || target > 0.95 {
+		return AutogainTracksOutput{}, errors.New("target_level must be between 0.05 and 0.95")
+	}
+	if tolerance < 0.01 || tolerance > 0.3 {
+		return AutogainTracksOutput{}, errors.New("tolerance must be between 0.01 and 0.3")
+	}
+	if maxIters < 1 || maxIters > 20 {
+		return AutogainTracksOutput{}, errors.New("max_iterations must be between 1 and 20")
+	}
+	if settleMs < 0 || settleMs > 2000 {
+		return AutogainTracksOutput{}, errors.New("settle_ms must be between 0 and 2000")
+	}
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+
+	indices, err := resolveAutogainTracks(client, input.TrackIndices)
+	if err != nil {
+		return AutogainTracksOutput{}, err
+	}
+
+	results := make([]AutogainTrackResult, 0, len(indices))
+	for _, trackIndex := range indices {
+		result, err := autogainOneTrack(client, trackIndex, target, tolerance, maxIters, settleMs, sleep)
+		if err != nil {
+			return AutogainTracksOutput{}, fmt.Errorf("track %d: %w", trackIndex, err)
+		}
+		results = append(results, result)
+	}
+
+	return AutogainTracksOutput{
+		TargetLevel: target,
+		Tolerance:   tolerance,
+		Results:     results,
+	}, nil
+}
+
+func resolveAutogainTracks(client autogainClient, requested []int) ([]int, error) {
+	if len(requested) > 0 {
+		out := make([]int, 0, len(requested))
+		seen := make(map[int]bool, len(requested))
+		for _, idx := range requested {
+			if idx < 0 {
+				return nil, errors.New("track_indices must be >= 0")
+			}
+			if seen[idx] {
+				continue
+			}
+			seen[idx] = true
+			out = append(out, idx)
+		}
+		return out, nil
+	}
+
+	namesRes, err := client.Query("/live/song/get/track_names")
+	if err != nil {
+		return nil, fmt.Errorf("list tracks: %w", err)
+	}
+	n := len(namesRes)
+	if n == 0 {
+		return nil, errors.New("no tracks available")
+	}
+	out := make([]int, n)
+	for i := 0; i < n; i++ {
+		out[i] = i
+	}
+	return out, nil
+}
+
+func autogainOneTrack(
+	client autogainClient,
+	trackIndex int,
+	target, tolerance float64,
+	maxIters, settleMs int,
+	sleep sleeperFunc,
+) (AutogainTrackResult, error) {
+	volume, err := queryTrackVolume(client, trackIndex)
+	if err != nil {
+		return AutogainTrackResult{}, err
+	}
+	meterBefore, err := sampleTrackMeter(client, trackIndex, defaultAutogainMeterSamples)
+	if err != nil {
+		return AutogainTrackResult{}, err
+	}
+
+	result := AutogainTrackResult{
+		TrackIndex:   trackIndex,
+		VolumeBefore: volume,
+		MeterBefore:  meterBefore,
+		VolumeAfter:  volume,
+		MeterAfter:   meterBefore,
+	}
+
+	if meterBefore < autogainSilentThreshold {
+		result.Status = "silent"
+		return result, nil
+	}
+	if math.Abs(meterBefore-target) <= tolerance {
+		result.Status = "unchanged"
+		return result, nil
+	}
+
+	currentVol := volume
+	currentMeter := meterBefore
+	capped := false
+	for i := 0; i < maxIters; i++ {
+		nextVol, hitCap := nextAutogainVolume(currentVol, currentMeter, target, autogainMaxVolumeStep)
+		capped = capped || hitCap
+		if math.Abs(nextVol-currentVol) < 1e-4 {
+			break
+		}
+		if err := client.Send("/live/track/set/volume", int32(trackIndex), float32(nextVol)); err != nil {
+			return AutogainTrackResult{}, fmt.Errorf("set volume: %w", err)
+		}
+		currentVol = nextVol
+		result.Iterations++
+		if settleMs > 0 {
+			sleep(time.Duration(settleMs) * time.Millisecond)
+		}
+		currentMeter, err = sampleTrackMeter(client, trackIndex, defaultAutogainMeterSamples)
+		if err != nil {
+			return AutogainTrackResult{}, err
+		}
+		if currentMeter < autogainSilentThreshold {
+			break
+		}
+		if math.Abs(currentMeter-target) <= tolerance {
+			break
+		}
+	}
+
+	result.VolumeAfter = currentVol
+	result.MeterAfter = currentMeter
+	switch {
+	case math.Abs(currentMeter-target) <= tolerance:
+		result.Status = "ok"
+	case capped:
+		result.Status = "capped"
+	default:
+		result.Status = "partial"
+	}
+	return result, nil
+}
+
+func queryTrackVolume(client autogainClient, trackIndex int) (float64, error) {
+	res, err := client.Query("/live/track/get/volume", int32(trackIndex))
+	if err != nil {
+		return 0, fmt.Errorf("get volume: %w", err)
+	}
+	if err := ensureResponseLen(res, 2); err != nil {
+		return 0, fmt.Errorf("get volume: %w", err)
+	}
+	return abletonosc.AsFloat64(res[1])
+}
+
+func sampleTrackMeter(client autogainClient, trackIndex, samples int) (float64, error) {
+	if samples < 1 {
+		samples = 1
+	}
+	peak := 0.0
+	for i := 0; i < samples; i++ {
+		level, err := queryMeterInterface(client, "/live/track/get/output_meter_level", int32(trackIndex))
+		if err != nil {
+			return 0, fmt.Errorf("get meter: %w", err)
+		}
+		if level > peak {
+			peak = level
+		}
+	}
+	return peak, nil
+}
+
+func queryMeterInterface(client autogainClient, address string, args ...interface{}) (float64, error) {
+	res, err := client.Query(address, args...)
+	if err != nil {
+		return 0, err
+	}
+	if len(res) >= 2 {
+		return abletonosc.AsFloat64(res[1])
+	}
+	if len(res) >= 1 {
+		return abletonosc.AsFloat64(res[0])
+	}
+	return 0, errors.New("empty meter response")
+}
+
+// nextAutogainVolume scales volume toward the target meter reading, limiting one-step change.
+// Returns the next volume and whether the step limit was hit.
+func nextAutogainVolume(currentVol, meterLevel, target, maxStep float64) (float64, bool) {
+	if meterLevel <= 0 || currentVol <= 0 {
+		return currentVol, false
+	}
+	desired := currentVol * (target / meterLevel)
+	delta := desired - currentVol
+	hitCap := false
+	if delta > maxStep {
+		delta = maxStep
+		hitCap = true
+	} else if delta < -maxStep {
+		delta = -maxStep
+		hitCap = true
+	}
+	next := currentVol + delta
+	if next < 0 {
+		next = 0
+		hitCap = true
+	}
+	if next > 1 {
+		next = 1
+		hitCap = true
+	}
+	return next, hitCap
+}

--- a/internal/tools/ableton_autogain_test.go
+++ b/internal/tools/ableton_autogain_test.go
@@ -1,0 +1,173 @@
+package tools
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+)
+
+type autogainStub struct {
+	volumes map[int]float64
+	meters  map[int][]float64
+	meterAt map[int]int
+	calls   []string
+}
+
+func (s *autogainStub) Query(address string, args ...interface{}) ([]interface{}, error) {
+	s.calls = append(s.calls, "Query:"+address)
+	switch address {
+	case "/live/song/get/track_names":
+		return []interface{}{"Drums", "Bass"}, nil
+	case "/live/track/get/volume":
+		idx := int(args[0].(int32))
+		v, ok := s.volumes[idx]
+		if !ok {
+			return nil, errors.New("missing volume")
+		}
+		return []interface{}{int32(idx), float32(v)}, nil
+	case "/live/track/get/output_meter_level":
+		idx := int(args[0].(int32))
+		seq, ok := s.meters[idx]
+		if !ok || len(seq) == 0 {
+			return nil, errors.New("missing meter")
+		}
+		i := s.meterAt[idx]
+		if i >= len(seq) {
+			i = len(seq) - 1
+		}
+		s.meterAt[idx] = i + 1
+		return []interface{}{int32(idx), float32(seq[i])}, nil
+	default:
+		return nil, errors.New("unexpected query: " + address)
+	}
+}
+
+func (s *autogainStub) Send(address string, args ...interface{}) error {
+	s.calls = append(s.calls, "Send:"+address)
+	if address == "/live/track/set/volume" {
+		idx := int(args[0].(int32))
+		s.volumes[idx] = float64(args[1].(float32))
+	}
+	return nil
+}
+
+func TestNextAutogainVolume(t *testing.T) {
+	t.Parallel()
+
+	got, capped := nextAutogainVolume(0.5, 0.2, 0.4, 0.12)
+	if !capped {
+		t.Fatal("expected step cap")
+	}
+	if math.Abs(got-0.62) > 1e-9 {
+		t.Errorf("next = %v, want 0.62", got)
+	}
+
+	got, capped = nextAutogainVolume(0.5, 0.5, 0.45, 0.12)
+	if capped {
+		t.Fatal("did not expect cap for small move")
+	}
+	want := 0.5 * (0.45 / 0.5)
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("next = %v, want %v", got, want)
+	}
+}
+
+func TestAutogainTracksRaisesQuietTrack(t *testing.T) {
+	t.Parallel()
+
+	client := &autogainStub{
+		volumes: map[int]float64{0: 0.4},
+		meters: map[int][]float64{
+			// sampleTrackMeter takes 3 samples per call
+			0: {
+				0.20, 0.20, 0.20, // before
+				0.32, 0.32, 0.32, // after first bump
+				0.44, 0.44, 0.44, // after second bump (within 0.45±0.05)
+			},
+		},
+		meterAt: map[int]int{},
+	}
+	settle := 0
+	got, err := autogainTracks(client, AutogainTracksInput{
+		TrackIndices: []int{0},
+		SettleMs:     &settle,
+	}, func(time.Duration) {})
+	if err != nil {
+		t.Fatalf("autogainTracks() error = %v", err)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results len = %d", len(got.Results))
+	}
+	r := got.Results[0]
+	if r.Status != "ok" {
+		t.Errorf("Status = %q, want ok", r.Status)
+	}
+	if r.VolumeAfter <= r.VolumeBefore {
+		t.Errorf("volume did not rise: before=%v after=%v", r.VolumeBefore, r.VolumeAfter)
+	}
+	if r.Iterations < 1 {
+		t.Errorf("Iterations = %d, want >= 1", r.Iterations)
+	}
+}
+
+func TestAutogainTracksSkipsSilent(t *testing.T) {
+	t.Parallel()
+
+	client := &autogainStub{
+		volumes: map[int]float64{1: 0.7},
+		meters: map[int][]float64{
+			1: {0.0, 0.0, 0.0},
+		},
+		meterAt: map[int]int{},
+	}
+	settle := 0
+	got, err := autogainTracks(client, AutogainTracksInput{
+		TrackIndices: []int{1},
+		SettleMs:     &settle,
+	}, func(time.Duration) {})
+	if err != nil {
+		t.Fatalf("autogainTracks() error = %v", err)
+	}
+	if got.Results[0].Status != "silent" {
+		t.Errorf("Status = %q, want silent", got.Results[0].Status)
+	}
+	if got.Results[0].VolumeAfter != got.Results[0].VolumeBefore {
+		t.Errorf("silent track volume changed: before=%v after=%v",
+			got.Results[0].VolumeBefore, got.Results[0].VolumeAfter)
+	}
+}
+
+func TestAutogainTracksResolvesAllTracks(t *testing.T) {
+	t.Parallel()
+
+	client := &autogainStub{
+		volumes: map[int]float64{0: 0.5, 1: 0.5},
+		meters: map[int][]float64{
+			0: {0.45, 0.45, 0.45},
+			1: {0.45, 0.45, 0.45},
+		},
+		meterAt: map[int]int{},
+	}
+	settle := 0
+	got, err := autogainTracks(client, AutogainTracksInput{SettleMs: &settle}, func(time.Duration) {})
+	if err != nil {
+		t.Fatalf("autogainTracks() error = %v", err)
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("results len = %d, want 2", len(got.Results))
+	}
+	if got.Results[0].Status != "unchanged" || got.Results[1].Status != "unchanged" {
+		t.Errorf("statuses = %q, %q want unchanged", got.Results[0].Status, got.Results[1].Status)
+	}
+}
+
+func TestAutogainTracksValidation(t *testing.T) {
+	t.Parallel()
+
+	bad := 0.01
+	_, err := autogainTracks(&autogainStub{}, AutogainTracksInput{TargetLevel: &bad}, func(time.Duration) {})
+	if err == nil {
+		t.Fatal("expected target_level validation error")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func main() {
 		tools.NewAbletonGetMasterDeviceParameters(g, ableton),
 		tools.NewAbletonSetMasterDeviceParameter(g, ableton),
 		tools.NewAbletonLoadOnMaster(g, ableton),
+		tools.NewAbletonAutogainTracks(g, ableton),
 
 		// Bounce / Session Record
 		tools.NewAbletonGetSessionRecord(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ableton_autogain_tracks` to iteratively adjust track volumes toward a target meter level
- skip silent tracks, limit per-step gain changes, and report per-track status
- document the new MCP tool

## Notes
- Audio should be playing while this runs; meters are sampled live
- Defaults: target meter `0.45`, tolerance `0.05`, up to 6 iterations with 150ms settle

## Testing
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

