### PR TITLE
feat: add A/B drum variation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Browse Live Browser folders by path and load items onto tracks
 - Set up a drum track with kit + clip + pattern in one recipe
 - Humanize MIDI clips with microtiming, velocity variation, and swing
+- Create safe A/B drum variations that change only groove, density, or fills
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots
@@ -242,6 +243,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_create_clip` | Create a clip in a slot |
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
+| `ableton_create_drum_variation` | Duplicate a drum clip into an empty slot and change groove, density, or fill for A/B comparison |
 | `ableton_fire_clip_slot` / `ableton_stop_clip` | Fire/stop a clip |
 | `ableton_duplicate_clip_to` | Duplicate clip to another slot |
 | `ableton_set_clip_name` | Rename a clip |
@@ -270,6 +272,7 @@ Once configured, you can ask your AI assistant:
 - "Create a MIDI track, load Street Kit, and add a 4-bar clip"
 - "Set up a Street Kit drum track with a four-on-floor pattern"
 - "Humanize the drum clip with a bit of swing"
+- "Create a groove variation of clip 0 in empty slot 1 so I can compare them"
 - "Autogain the drum and bass tracks while the beat is playing"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"

--- a/internal/tools/ableton_variations.go
+++ b/internal/tools/ableton_variations.go
@@ -1,0 +1,309 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const (
+	defaultVariationStrength = 0.6
+	defaultVariationHatPitch = 42
+	defaultVariationSnare    = 38
+)
+
+type CreateDrumVariationInput struct {
+	TrackIndex      int      `json:"track_index" jsonschema:"minimum=0"`
+	SourceClipIndex int      `json:"source_clip_index" jsonschema:"minimum=0"`
+	TargetClipIndex int      `json:"target_clip_index" jsonschema:"description=Must be an empty clip slot for the A/B variation,minimum=0"`
+	Variation       string   `json:"variation" jsonschema:"description=One change only: groove, density, or fill"`
+	Strength        *float64 `json:"strength,omitempty" jsonschema:"description=Variation intensity 0-1 (default 0.6),minimum=0,maximum=1"`
+	HatPitch        *int     `json:"hat_pitch,omitempty" jsonschema:"description=Closed hat MIDI pitch for density variation (default 42),minimum=0,maximum=127"`
+	SnarePitch      *int     `json:"snare_pitch,omitempty" jsonschema:"description=Snare MIDI pitch for fill variation (default 38),minimum=0,maximum=127"`
+	Seed            *int64   `json:"seed,omitempty" jsonschema:"description=Optional RNG seed for reproducible groove or density variations"`
+	Fire            bool     `json:"fire,omitempty" jsonschema:"description=Fire the target clip after creating it"`
+}
+
+type CreateDrumVariationOutput struct {
+	TrackIndex      int     `json:"track_index"`
+	SourceClipIndex int     `json:"source_clip_index"`
+	TargetClipIndex int     `json:"target_clip_index"`
+	Variation       string  `json:"variation"`
+	Strength        float64 `json:"strength"`
+	NotesChanged    int     `json:"notes_changed"`
+	NotesAdded      int     `json:"notes_added"`
+	Seed            int64   `json:"seed"`
+	Fired           bool    `json:"fired"`
+}
+
+type variationOptions struct {
+	Strength   float64
+	HatPitch   int
+	SnarePitch int
+	Seed       int64
+}
+
+type variationClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+func NewAbletonCreateDrumVariation(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_create_drum_variation",
+		"Ableton Live: duplicate a drum clip into an empty slot and make one A/B variation: groove, density, or fill",
+		func(_ *ai.ToolContext, input CreateDrumVariationInput) (CreateDrumVariationOutput, error) {
+			return createDrumVariation(client, input)
+		},
+	)
+}
+
+func createDrumVariation(client variationClient, input CreateDrumVariationInput) (CreateDrumVariationOutput, error) {
+	if err := validateTrackClipIndices(input.TrackIndex, input.SourceClipIndex); err != nil {
+		return CreateDrumVariationOutput{}, err
+	}
+	if input.TargetClipIndex < 0 {
+		return CreateDrumVariationOutput{}, errors.New("target_clip_index must be >= 0")
+	}
+	if input.SourceClipIndex == input.TargetClipIndex {
+		return CreateDrumVariationOutput{}, errors.New("source_clip_index and target_clip_index must differ")
+	}
+
+	variation := strings.ToLower(strings.TrimSpace(input.Variation))
+	if variation != "groove" && variation != "density" && variation != "fill" {
+		return CreateDrumVariationOutput{}, errors.New("variation must be groove, density, or fill")
+	}
+	opts, err := resolveVariationOptions(input)
+	if err != nil {
+		return CreateDrumVariationOutput{}, err
+	}
+
+	targetHasClip, err := queryClipHasClip(client, input.TrackIndex, input.TargetClipIndex)
+	if err != nil {
+		return CreateDrumVariationOutput{}, fmt.Errorf("check target slot: %w", err)
+	}
+	if targetHasClip {
+		return CreateDrumVariationOutput{}, errors.New("target_clip_index must be an empty slot to preserve A/B comparison")
+	}
+
+	sourceRes, err := client.Query("/live/clip/get/notes", int32(input.TrackIndex), int32(input.SourceClipIndex))
+	if err != nil {
+		return CreateDrumVariationOutput{}, fmt.Errorf("get source notes: %w", err)
+	}
+	_, _, sourceNotes, err := parseClipNotesResponse(sourceRes)
+	if err != nil {
+		return CreateDrumVariationOutput{}, fmt.Errorf("get source notes: %w", err)
+	}
+	if len(sourceNotes) == 0 {
+		return CreateDrumVariationOutput{}, errors.New("source clip has no notes to vary")
+	}
+
+	clipLength := queryClipLength(client, input.TrackIndex, input.SourceClipIndex)
+	if clipLength <= 0 {
+		clipLength = inferredClipLength(sourceNotes)
+	}
+
+	if err := client.Send(
+		"/live/clip_slot/duplicate_clip_to",
+		int32(input.TrackIndex),
+		int32(input.SourceClipIndex),
+		int32(input.TargetClipIndex),
+	); err != nil {
+		return CreateDrumVariationOutput{}, fmt.Errorf("duplicate source clip: %w", err)
+	}
+
+	rng := rand.New(rand.NewSource(opts.Seed))
+	var notes []MidiNote
+	var notesChanged, notesAdded int
+	switch variation {
+	case "groove":
+		humanize := humanizeOptions{
+			TimingAmount:   0.025,
+			VelocityAmount: 12,
+			Swing:          0.15,
+			Strength:       opts.Strength,
+			Seed:           opts.Seed,
+		}
+		notes = humanizeNotes(sourceNotes, humanize, rng, clipLength)
+		notesChanged = len(notes)
+	case "density":
+		additions := densityNotes(sourceNotes, clipLength, opts.HatPitch, opts.Strength, rng)
+		notes = append(copyMidiNotes(sourceNotes), additions...)
+		notesAdded = len(additions)
+	case "fill":
+		additions := fillNotes(sourceNotes, clipLength, opts.SnarePitch, opts.Strength)
+		notes = append(copyMidiNotes(sourceNotes), additions...)
+		notesAdded = len(additions)
+	}
+
+	if variation == "groove" {
+		if err := replaceVariationNotes(client, input.TrackIndex, input.TargetClipIndex, sourceNotes, notes); err != nil {
+			return CreateDrumVariationOutput{}, err
+		}
+	} else if notesAdded > 0 {
+		if err := client.Send("/live/clip/add/notes", addNotesArgs(input.TrackIndex, input.TargetClipIndex, notes[len(sourceNotes):])...); err != nil {
+			return CreateDrumVariationOutput{}, fmt.Errorf("add variation notes: %w", err)
+		}
+	}
+
+	if err := client.Send(
+		"/live/clip/set/name",
+		int32(input.TrackIndex),
+		int32(input.TargetClipIndex),
+		"Variation: "+variation,
+	); err != nil {
+		return CreateDrumVariationOutput{}, fmt.Errorf("set variation clip name: %w", err)
+	}
+
+	fired := false
+	if input.Fire {
+		if err := client.Send("/live/clip_slot/fire", int32(input.TrackIndex), int32(input.TargetClipIndex)); err != nil {
+			return CreateDrumVariationOutput{}, fmt.Errorf("fire variation clip: %w", err)
+		}
+		fired = true
+	}
+
+	return CreateDrumVariationOutput{
+		TrackIndex:      input.TrackIndex,
+		SourceClipIndex: input.SourceClipIndex,
+		TargetClipIndex: input.TargetClipIndex,
+		Variation:       variation,
+		Strength:        opts.Strength,
+		NotesChanged:    notesChanged,
+		NotesAdded:      notesAdded,
+		Seed:            opts.Seed,
+		Fired:           fired,
+	}, nil
+}
+
+func resolveVariationOptions(input CreateDrumVariationInput) (variationOptions, error) {
+	opts := variationOptions{
+		Strength:   defaultVariationStrength,
+		HatPitch:   defaultVariationHatPitch,
+		SnarePitch: defaultVariationSnare,
+		Seed:       time.Now().UnixNano(),
+	}
+	if input.Strength != nil {
+		opts.Strength = *input.Strength
+	}
+	if input.HatPitch != nil {
+		opts.HatPitch = *input.HatPitch
+	}
+	if input.SnarePitch != nil {
+		opts.SnarePitch = *input.SnarePitch
+	}
+	if input.Seed != nil {
+		opts.Seed = *input.Seed
+	}
+	if opts.Strength < 0 || opts.Strength > 1 {
+		return variationOptions{}, errors.New("strength must be between 0 and 1")
+	}
+	if opts.HatPitch < 0 || opts.HatPitch > 127 {
+		return variationOptions{}, errors.New("hat_pitch must be 0..127")
+	}
+	if opts.SnarePitch < 0 || opts.SnarePitch > 127 {
+		return variationOptions{}, errors.New("snare_pitch must be 0..127")
+	}
+	return opts, nil
+}
+
+func queryClipHasClip(client variationClient, trackIndex, clipIndex int) (bool, error) {
+	res, err := client.Query("/live/clip_slot/get/has_clip", int32(trackIndex), int32(clipIndex))
+	if err != nil {
+		return false, err
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return false, err
+	}
+	return abletonosc.AsBool(res[2])
+}
+
+func replaceVariationNotes(client variationClient, trackIndex, clipIndex int, original, replacement []MidiNote) error {
+	if err := client.Send("/live/clip/remove/notes", int32(trackIndex), int32(clipIndex)); err != nil {
+		return fmt.Errorf("clear duplicated clip: %w", err)
+	}
+	if err := client.Send("/live/clip/add/notes", addNotesArgs(trackIndex, clipIndex, replacement)...); err != nil {
+		if restoreErr := client.Send("/live/clip/add/notes", addNotesArgs(trackIndex, clipIndex, original)...); restoreErr != nil {
+			return fmt.Errorf("add groove variation: %w; restore duplicate also failed: %v", err, restoreErr)
+		}
+		return fmt.Errorf("add groove variation: %w (duplicate restored)", err)
+	}
+	return nil
+}
+
+func densityNotes(notes []MidiNote, clipLength float64, hatPitch int, strength float64, rng *rand.Rand) []MidiNote {
+	additions := make([]MidiNote, 0)
+	for start := 0.25; start < clipLength; start += 0.5 {
+		if hasNoteAt(notes, hatPitch, start) || rng.Float64() > strength {
+			continue
+		}
+		additions = append(additions, MidiNote{
+			Pitch:     hatPitch,
+			StartTime: start,
+			Duration:  0.1,
+			Velocity:  55 + int(rng.Float64()*25),
+		})
+	}
+	return additions
+}
+
+func fillNotes(notes []MidiNote, clipLength float64, snarePitch int, strength float64) []MidiNote {
+	if clipLength < 1 || strength == 0 {
+		return []MidiNote{}
+	}
+	candidates := []float64{clipLength - 0.75, clipLength - 0.5, clipLength - 0.25}
+	count := int(math.Ceil(float64(len(candidates)) * strength))
+	additions := make([]MidiNote, 0, count)
+	for i, start := range candidates {
+		if i >= count || start < 0 || hasNoteAt(notes, snarePitch, start) {
+			continue
+		}
+		additions = append(additions, MidiNote{
+			Pitch:     snarePitch,
+			StartTime: start,
+			Duration:  0.12,
+			Velocity:  70 + i*12,
+		})
+	}
+	return additions
+}
+
+func hasNoteAt(notes []MidiNote, pitch int, start float64) bool {
+	for _, note := range notes {
+		if note.Pitch == pitch && math.Abs(note.StartTime-start) < 0.001 {
+			return true
+		}
+	}
+	return false
+}
+
+func inferredClipLength(notes []MidiNote) float64 {
+	end := 0.0
+	for _, note := range notes {
+		end = math.Max(end, note.StartTime+note.Duration)
+	}
+	if end <= 0 {
+		return 1
+	}
+	return math.Ceil(end)
+}
+
+func copyMidiNotes(notes []MidiNote) []MidiNote {
+	out := make([]MidiNote, 0, len(notes))
+	for _, note := range notes {
+		copied := note
+		if note.Mute != nil {
+			m := *note.Mute
+			copied.Mute = &m
+		}
+		out = append(out, copied)
+	}
+	return out
+}

--- a/internal/tools/ableton_variations_test.go
+++ b/internal/tools/ableton_variations_test.go
@@ -1,0 +1,212 @@
+package tools
+
+import (
+	"errors"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+type variationCall struct {
+	address string
+	args    []interface{}
+}
+
+type variationStub struct {
+	queries map[string][]interface{}
+	calls   []variationCall
+	sendErr map[string]error
+}
+
+func (s *variationStub) Query(address string, args ...interface{}) ([]interface{}, error) {
+	s.calls = append(s.calls, variationCall{address: "Query:" + address, args: append([]interface{}{}, args...)})
+	res, ok := s.queries[address]
+	if !ok {
+		return nil, errors.New("unexpected query: " + address)
+	}
+	return res, nil
+}
+
+func (s *variationStub) Send(address string, args ...interface{}) error {
+	s.calls = append(s.calls, variationCall{address: "Send:" + address, args: append([]interface{}{}, args...)})
+	return s.sendErr[address]
+}
+
+func TestDensityNotes(t *testing.T) {
+	t.Parallel()
+
+	seed := int64(1)
+	rng := newVariationRNG(seed)
+	notes := []MidiNote{{Pitch: 42, StartTime: 0.25, Duration: 0.1, Velocity: 80}}
+	got := densityNotes(notes, 2, 42, 1, rng)
+
+	// 0.25 already exists; 0.75, 1.25, 1.75 are added.
+	if len(got) != 3 {
+		t.Fatalf("densityNotes() len = %d, want 3", len(got))
+	}
+	for _, note := range got {
+		if note.Pitch != 42 || note.StartTime >= 2 {
+			t.Errorf("unexpected density note: %#v", note)
+		}
+	}
+}
+
+func TestFillNotes(t *testing.T) {
+	t.Parallel()
+
+	got := fillNotes(nil, 4, 38, 1)
+	if len(got) != 3 {
+		t.Fatalf("fillNotes() len = %d, want 3", len(got))
+	}
+	if math.Abs(got[0].StartTime-3.25) > 1e-9 || math.Abs(got[2].StartTime-3.75) > 1e-9 {
+		t.Errorf("fill notes = %#v, want final three 16ths", got)
+	}
+
+	existing := []MidiNote{{Pitch: 38, StartTime: 3.5, Duration: 0.25, Velocity: 100}}
+	got = fillNotes(existing, 4, 38, 1)
+	if len(got) != 2 {
+		t.Errorf("fillNotes() with existing snare len = %d, want 2", len(got))
+	}
+}
+
+func TestCreateDrumVariationGroovePreservesSource(t *testing.T) {
+	t.Parallel()
+
+	strength := 0.5
+	seed := int64(42)
+	client := &variationStub{
+		queries: map[string][]interface{}{
+			"/live/clip_slot/get/has_clip": {int32(1), int32(2), false},
+			"/live/clip/get/notes": {
+				int32(1), int32(0),
+				int32(36), float32(0), float32(0.25), int32(100), false,
+				int32(42), float32(0.5), float32(0.1), int32(80), false,
+			},
+			"/live/clip/get/length": {int32(1), int32(0), float32(4)},
+		},
+		sendErr: map[string]error{},
+	}
+
+	got, err := createDrumVariation(client, CreateDrumVariationInput{
+		TrackIndex:      1,
+		SourceClipIndex: 0,
+		TargetClipIndex: 2,
+		Variation:       "groove",
+		Strength:        &strength,
+		Seed:            &seed,
+	})
+	if err != nil {
+		t.Fatalf("createDrumVariation() error = %v", err)
+	}
+	if got.NotesChanged != 2 || got.NotesAdded != 0 {
+		t.Errorf("result = %#v, want two changed and zero added", got)
+	}
+	if hasVariationSend(client.calls, "/live/clip_slot/duplicate_clip_to") == false {
+		t.Error("expected clip duplication")
+	}
+	if hasVariationSend(client.calls, "/live/clip/remove/notes") == false {
+		t.Error("expected only the duplicated clip to be cleared")
+	}
+	if hasVariationSendWithClip(client.calls, "/live/clip/remove/notes", 0) {
+		t.Error("source clip must not be cleared")
+	}
+}
+
+func TestCreateDrumVariationDensityFiresTarget(t *testing.T) {
+	t.Parallel()
+
+	seed := int64(1)
+	strength := 1.0
+	client := &variationStub{
+		queries: map[string][]interface{}{
+			"/live/clip_slot/get/has_clip": {int32(0), int32(1), false},
+			"/live/clip/get/notes": {
+				int32(0), int32(0),
+				int32(36), float32(0), float32(0.25), int32(100), false,
+			},
+			"/live/clip/get/length": {int32(0), int32(0), float32(2)},
+		},
+		sendErr: map[string]error{},
+	}
+
+	got, err := createDrumVariation(client, CreateDrumVariationInput{
+		TrackIndex:      0,
+		SourceClipIndex: 0,
+		TargetClipIndex: 1,
+		Variation:       "density",
+		Strength:        &strength,
+		Seed:            &seed,
+		Fire:            true,
+	})
+	if err != nil {
+		t.Fatalf("createDrumVariation() error = %v", err)
+	}
+	if got.NotesAdded == 0 {
+		t.Error("density variation should add notes")
+	}
+	if !got.Fired || !hasVariationSend(client.calls, "/live/clip_slot/fire") {
+		t.Error("expected target clip to fire")
+	}
+}
+
+func TestCreateDrumVariationRejectsOccupiedTarget(t *testing.T) {
+	t.Parallel()
+
+	client := &variationStub{
+		queries: map[string][]interface{}{
+			"/live/clip_slot/get/has_clip": {int32(0), int32(1), true},
+		},
+		sendErr: map[string]error{},
+	}
+	_, err := createDrumVariation(client, CreateDrumVariationInput{
+		TrackIndex:      0,
+		SourceClipIndex: 0,
+		TargetClipIndex: 1,
+		Variation:       "fill",
+	})
+	if err == nil {
+		t.Fatal("createDrumVariation() error = nil, want occupied-target error")
+	}
+	if hasVariationSend(client.calls, "/live/clip_slot/duplicate_clip_to") {
+		t.Error("should not duplicate onto an occupied target")
+	}
+}
+
+func TestCreateDrumVariationRejectsSameSlot(t *testing.T) {
+	t.Parallel()
+
+	_, err := createDrumVariation(&variationStub{}, CreateDrumVariationInput{
+		TrackIndex:      0,
+		SourceClipIndex: 1,
+		TargetClipIndex: 1,
+		Variation:       "groove",
+	})
+	if err == nil {
+		t.Fatal("createDrumVariation() error = nil, want same-slot error")
+	}
+}
+
+func newVariationRNG(seed int64) *rand.Rand {
+	return rand.New(rand.NewSource(seed))
+}
+
+func hasVariationSend(calls []variationCall, address string) bool {
+	for _, call := range calls {
+		if call.address == "Send:"+address {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVariationSendWithClip(calls []variationCall, address string, clipIndex int32) bool {
+	for _, call := range calls {
+		if call.address != "Send:"+address || len(call.args) < 2 {
+			continue
+		}
+		if call.args[1] == clipIndex {
+			return true
+		}
+	}
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ func main() {
 		tools.NewAbletonHumanizeClip(g, ableton),
 		tools.NewAbletonDuplicateClipTo(g, ableton),
 		tools.NewAbletonSetClipName(g, ableton),
+		tools.NewAbletonCreateDrumVariation(g, ableton),
 
 		// Scenes
 		tools.NewAbletonFireScene(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ableton_create_drum_variation` to duplicate a drum clip into an empty target slot
- create one controlled variation at a time: `groove`, `density`, or `fill`
- keep the source clip unchanged for safe A/B comparison
- reject occupied target slots and document the new MCP tool

## Testing
- `go test ./internal/tools/ -run 'Variation|Density|Fill' -count=1 -v`
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

