### PR TITLE
feat: add A/B bass variation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Set up a drum track with kit + clip + pattern in one recipe
 - Humanize MIDI clips with microtiming, velocity variation, and swing
 - Create safe A/B drum variations that change only groove, density, or fills
+- Create safe A/B bass variations that change only octave, note length, or groove
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots
@@ -244,6 +245,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
 | `ableton_create_drum_variation` | Duplicate a drum clip into an empty slot and change groove, density, or fill for A/B comparison |
+| `ableton_create_bass_variation` | Duplicate a bass clip into an empty slot and change octave, note length, or groove for A/B comparison |
 | `ableton_fire_clip_slot` / `ableton_stop_clip` | Fire/stop a clip |
 | `ableton_duplicate_clip_to` | Duplicate clip to another slot |
 | `ableton_set_clip_name` | Rename a clip |
@@ -273,6 +275,7 @@ Once configured, you can ask your AI assistant:
 - "Set up a Street Kit drum track with a four-on-floor pattern"
 - "Humanize the drum clip with a bit of swing"
 - "Create a groove variation of clip 0 in empty slot 1 so I can compare them"
+- "Create an octave-up variation of the bass clip in empty slot 1"
 - "Autogain the drum and bass tracks while the beat is playing"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"

--- a/internal/tools/ableton_bass_variations.go
+++ b/internal/tools/ableton_bass_variations.go
@@ -1,0 +1,233 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const defaultBassVariationStrength = 0.6
+
+type CreateBassVariationInput struct {
+	TrackIndex      int      `json:"track_index" jsonschema:"minimum=0"`
+	SourceClipIndex int      `json:"source_clip_index" jsonschema:"minimum=0"`
+	TargetClipIndex int      `json:"target_clip_index" jsonschema:"description=Must be an empty clip slot for the A/B variation,minimum=0"`
+	Variation       string   `json:"variation" jsonschema:"description=One change only: octave_up, octave_down, staccato, or groove"`
+	Strength        *float64 `json:"strength,omitempty" jsonschema:"description=Variation intensity 0-1 (default 0.6),minimum=0,maximum=1"`
+	Seed            *int64   `json:"seed,omitempty" jsonschema:"description=Optional RNG seed for reproducible groove variations"`
+	Fire            bool     `json:"fire,omitempty" jsonschema:"description=Fire the target clip after creating it"`
+}
+
+type CreateBassVariationOutput struct {
+	TrackIndex      int     `json:"track_index"`
+	SourceClipIndex int     `json:"source_clip_index"`
+	TargetClipIndex int     `json:"target_clip_index"`
+	Variation       string  `json:"variation"`
+	Strength        float64 `json:"strength"`
+	NotesChanged    int     `json:"notes_changed"`
+	NotesSkipped    int     `json:"notes_skipped"`
+	Seed            int64   `json:"seed"`
+	Fired           bool    `json:"fired"`
+}
+
+type bassVariationOptions struct {
+	Strength float64
+	Seed     int64
+}
+
+func NewAbletonCreateBassVariation(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_create_bass_variation",
+		"Ableton Live: duplicate a bass MIDI clip into an empty slot and make one A/B variation: octave, staccato, or groove",
+		func(_ *ai.ToolContext, input CreateBassVariationInput) (CreateBassVariationOutput, error) {
+			return createBassVariation(client, input)
+		},
+	)
+}
+
+func createBassVariation(client variationClient, input CreateBassVariationInput) (CreateBassVariationOutput, error) {
+	if err := validateTrackClipIndices(input.TrackIndex, input.SourceClipIndex); err != nil {
+		return CreateBassVariationOutput{}, err
+	}
+	if input.TargetClipIndex < 0 {
+		return CreateBassVariationOutput{}, errors.New("target_clip_index must be >= 0")
+	}
+	if input.SourceClipIndex == input.TargetClipIndex {
+		return CreateBassVariationOutput{}, errors.New("source_clip_index and target_clip_index must differ")
+	}
+
+	variation := strings.ToLower(strings.TrimSpace(input.Variation))
+	if !isBassVariation(variation) {
+		return CreateBassVariationOutput{}, errors.New("variation must be octave_up, octave_down, staccato, or groove")
+	}
+	opts, err := resolveBassVariationOptions(input)
+	if err != nil {
+		return CreateBassVariationOutput{}, err
+	}
+
+	targetHasClip, err := queryClipHasClip(client, input.TrackIndex, input.TargetClipIndex)
+	if err != nil {
+		return CreateBassVariationOutput{}, fmt.Errorf("check target slot: %w", err)
+	}
+	if targetHasClip {
+		return CreateBassVariationOutput{}, errors.New("target_clip_index must be an empty slot to preserve A/B comparison")
+	}
+
+	sourceRes, err := client.Query("/live/clip/get/notes", int32(input.TrackIndex), int32(input.SourceClipIndex))
+	if err != nil {
+		return CreateBassVariationOutput{}, fmt.Errorf("get source notes: %w", err)
+	}
+	_, _, sourceNotes, err := parseClipNotesResponse(sourceRes)
+	if err != nil {
+		return CreateBassVariationOutput{}, fmt.Errorf("get source notes: %w", err)
+	}
+	if len(sourceNotes) == 0 {
+		return CreateBassVariationOutput{}, errors.New("source clip has no notes to vary")
+	}
+
+	clipLength := queryClipLength(client, input.TrackIndex, input.SourceClipIndex)
+	if clipLength <= 0 {
+		clipLength = inferredClipLength(sourceNotes)
+	}
+	varied, changed, skipped := varyBassNotes(
+		sourceNotes,
+		clipLength,
+		variation,
+		opts,
+		rand.New(rand.NewSource(opts.Seed)),
+	)
+	if changed == 0 {
+		return CreateBassVariationOutput{}, errors.New("variation would not change any source notes")
+	}
+
+	if err := client.Send(
+		"/live/clip_slot/duplicate_clip_to",
+		int32(input.TrackIndex),
+		int32(input.SourceClipIndex),
+		int32(input.TargetClipIndex),
+	); err != nil {
+		return CreateBassVariationOutput{}, fmt.Errorf("duplicate source clip: %w", err)
+	}
+	if err := replaceVariationNotes(client, input.TrackIndex, input.TargetClipIndex, sourceNotes, varied); err != nil {
+		return CreateBassVariationOutput{}, err
+	}
+	if err := client.Send(
+		"/live/clip/set/name",
+		int32(input.TrackIndex),
+		int32(input.TargetClipIndex),
+		"Variation: bass "+variation,
+	); err != nil {
+		return CreateBassVariationOutput{}, fmt.Errorf("set variation clip name: %w", err)
+	}
+
+	fired := false
+	if input.Fire {
+		if err := client.Send("/live/clip_slot/fire", int32(input.TrackIndex), int32(input.TargetClipIndex)); err != nil {
+			return CreateBassVariationOutput{}, fmt.Errorf("fire variation clip: %w", err)
+		}
+		fired = true
+	}
+
+	return CreateBassVariationOutput{
+		TrackIndex:      input.TrackIndex,
+		SourceClipIndex: input.SourceClipIndex,
+		TargetClipIndex: input.TargetClipIndex,
+		Variation:       variation,
+		Strength:        opts.Strength,
+		NotesChanged:    changed,
+		NotesSkipped:    skipped,
+		Seed:            opts.Seed,
+		Fired:           fired,
+	}, nil
+}
+
+func isBassVariation(variation string) bool {
+	switch variation {
+	case "octave_up", "octave_down", "staccato", "groove":
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveBassVariationOptions(input CreateBassVariationInput) (bassVariationOptions, error) {
+	opts := bassVariationOptions{
+		Strength: defaultBassVariationStrength,
+		Seed:     time.Now().UnixNano(),
+	}
+	if input.Strength != nil {
+		opts.Strength = *input.Strength
+	}
+	if input.Seed != nil {
+		opts.Seed = *input.Seed
+	}
+	if opts.Strength < 0 || opts.Strength > 1 {
+		return bassVariationOptions{}, errors.New("strength must be between 0 and 1")
+	}
+	return opts, nil
+}
+
+func varyBassNotes(
+	notes []MidiNote,
+	clipLength float64,
+	variation string,
+	opts bassVariationOptions,
+	rng *rand.Rand,
+) ([]MidiNote, int, int) {
+	switch variation {
+	case "octave_up":
+		return shiftBassOctave(notes, 12)
+	case "octave_down":
+		return shiftBassOctave(notes, -12)
+	case "staccato":
+		return shortenBassNotes(notes, opts.Strength)
+	case "groove":
+		humanize := humanizeOptions{
+			TimingAmount:   0.018,
+			VelocityAmount: 7,
+			Swing:          0.08,
+			Strength:       opts.Strength,
+			Seed:           opts.Seed,
+		}
+		return humanizeNotes(notes, humanize, rng, clipLength), len(notes), 0
+	default:
+		return copyMidiNotes(notes), 0, 0
+	}
+}
+
+func shiftBassOctave(notes []MidiNote, semitones int) ([]MidiNote, int, int) {
+	out := copyMidiNotes(notes)
+	changed, skipped := 0, 0
+	for i := range out {
+		pitch := out[i].Pitch + semitones
+		if pitch < 0 || pitch > 127 {
+			skipped++
+			continue
+		}
+		out[i].Pitch = pitch
+		changed++
+	}
+	return out, changed, skipped
+}
+
+func shortenBassNotes(notes []MidiNote, strength float64) ([]MidiNote, int, int) {
+	out := copyMidiNotes(notes)
+	changed := 0
+	for i := range out {
+		original := out[i].Duration
+		// At full strength, leave 35% of the original note length, not less than 50 ms.
+		shortened := math.Max(0.05, original*(1-0.65*strength))
+		if shortened < original {
+			out[i].Duration = shortened
+			changed++
+		}
+	}
+	return out, changed, 0
+}

--- a/internal/tools/ableton_bass_variations_test.go
+++ b/internal/tools/ableton_bass_variations_test.go
@@ -1,0 +1,126 @@
+package tools
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestShiftBassOctave(t *testing.T) {
+	t.Parallel()
+
+	notes := []MidiNote{
+		{Pitch: 36, StartTime: 0, Duration: 1, Velocity: 100},
+		{Pitch: 120, StartTime: 1, Duration: 1, Velocity: 100},
+	}
+	got, changed, skipped := shiftBassOctave(notes, 12)
+	if changed != 1 || skipped != 1 {
+		t.Fatalf("changed=%d skipped=%d, want 1/1", changed, skipped)
+	}
+	if got[0].Pitch != 48 || got[1].Pitch != 120 {
+		t.Errorf("pitches = %d, %d; want 48, 120", got[0].Pitch, got[1].Pitch)
+	}
+	if notes[0].Pitch != 36 {
+		t.Error("source notes were mutated")
+	}
+}
+
+func TestShortenBassNotes(t *testing.T) {
+	t.Parallel()
+
+	notes := []MidiNote{{Pitch: 36, StartTime: 0, Duration: 1, Velocity: 100}}
+	got, changed, skipped := shortenBassNotes(notes, 1)
+	if changed != 1 || skipped != 0 {
+		t.Fatalf("changed=%d skipped=%d, want 1/0", changed, skipped)
+	}
+	if math.Abs(got[0].Duration-0.35) > 1e-9 {
+		t.Errorf("duration = %v, want 0.35", got[0].Duration)
+	}
+}
+
+func TestVaryBassNotesGroove(t *testing.T) {
+	t.Parallel()
+
+	notes := []MidiNote{{Pitch: 36, StartTime: 0.5, Duration: 0.5, Velocity: 100}}
+	opts := bassVariationOptions{Strength: 1, Seed: 42}
+	got, changed, skipped := varyBassNotes(notes, 4, "groove", opts, rand.New(rand.NewSource(opts.Seed)))
+	if changed != 1 || skipped != 0 {
+		t.Fatalf("changed=%d skipped=%d, want 1/0", changed, skipped)
+	}
+	if got[0].StartTime == notes[0].StartTime && got[0].Velocity == notes[0].Velocity {
+		t.Error("groove variation did not alter timing or velocity")
+	}
+}
+
+func TestCreateBassVariation(t *testing.T) {
+	t.Parallel()
+
+	seed := int64(7)
+	strength := 1.0
+	client := &variationStub{
+		queries: map[string][]interface{}{
+			"/live/clip_slot/get/has_clip": {int32(2), int32(1), false},
+			"/live/clip/get/notes": {
+				int32(2), int32(0),
+				int32(36), float32(0), float32(1), int32(100), false,
+			},
+			"/live/clip/get/length": {int32(2), int32(0), float32(4)},
+		},
+		sendErr: map[string]error{},
+	}
+
+	got, err := createBassVariation(client, CreateBassVariationInput{
+		TrackIndex:      2,
+		SourceClipIndex: 0,
+		TargetClipIndex: 1,
+		Variation:       "octave_up",
+		Strength:        &strength,
+		Seed:            &seed,
+		Fire:            true,
+	})
+	if err != nil {
+		t.Fatalf("createBassVariation() error = %v", err)
+	}
+	if got.NotesChanged != 1 || got.NotesSkipped != 0 {
+		t.Errorf("result = %#v, want one changed / no skipped", got)
+	}
+	if !got.Fired {
+		t.Error("Fired = false, want true")
+	}
+	if !hasVariationSend(client.calls, "/live/clip_slot/duplicate_clip_to") {
+		t.Error("expected source clip duplication")
+	}
+	if hasVariationSendWithClip(client.calls, "/live/clip/remove/notes", 0) {
+		t.Error("source clip must not be cleared")
+	}
+}
+
+func TestCreateBassVariationRejectsNoChange(t *testing.T) {
+	t.Parallel()
+
+	strength := 0.0
+	client := &variationStub{
+		queries: map[string][]interface{}{
+			"/live/clip_slot/get/has_clip": {int32(0), int32(1), false},
+			"/live/clip/get/notes": {
+				int32(0), int32(0),
+				int32(36), float32(0), float32(1), int32(100), false,
+			},
+			"/live/clip/get/length": {int32(0), int32(0), float32(4)},
+		},
+		sendErr: map[string]error{},
+	}
+	_, err := createBassVariation(client, CreateBassVariationInput{
+		TrackIndex:      0,
+		SourceClipIndex: 0,
+		TargetClipIndex: 1,
+		Variation:       "staccato",
+		Strength:        &strength,
+	})
+	if err == nil {
+		t.Fatal("createBassVariation() error = nil, want no-change error")
+	}
+	if hasVariationSend(client.calls, "/live/clip_slot/duplicate_clip_to") {
+		t.Error("must not duplicate when no variation can be made")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -84,6 +84,7 @@ func main() {
 		tools.NewAbletonDuplicateClipTo(g, ableton),
 		tools.NewAbletonSetClipName(g, ableton),
 		tools.NewAbletonCreateDrumVariation(g, ableton),
+		tools.NewAbletonCreateBassVariation(g, ableton),
 
 		// Scenes
 		tools.NewAbletonFireScene(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ableton_create_bass_variation` for safe A/B comparison in an empty clip slot
- support one controlled change at a time: `octave_up`, `octave_down`, `staccato`, or `groove`
- preserve the source clip and reject occupied target slots
- document the new MCP tool

## Testing
- `go test ./internal/tools/ -run 'Bass|Variation' -count=1 -v`
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

