### PR TITLE
feat: record A/B variation preferences locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Humanize MIDI clips with microtiming, velocity variation, and swing
 - Create safe A/B drum variations that change only groove, density, or fills
 - Create safe A/B bass variations that change only octave, note length, or groove
+- Save A/B choices locally to build a taste profile and guide the next comparison
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots
@@ -246,6 +247,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
 | `ableton_create_drum_variation` | Duplicate a drum clip into an empty slot and change groove, density, or fill for A/B comparison |
 | `ableton_create_bass_variation` | Duplicate a bass clip into an empty slot and change octave, note length, or groove for A/B comparison |
+| `ableton_record_variation_preference` | Save whether the source or variation matched your taste |
+| `ableton_get_taste_profile` | Summarize saved A/B choices and suggest the next comparison |
 | `ableton_fire_clip_slot` / `ableton_stop_clip` | Fire/stop a clip |
 | `ableton_duplicate_clip_to` | Duplicate clip to another slot |
 | `ableton_set_clip_name` | Rename a clip |
@@ -276,6 +279,7 @@ Once configured, you can ask your AI assistant:
 - "Humanize the drum clip with a bit of swing"
 - "Create a groove variation of clip 0 in empty slot 1 so I can compare them"
 - "Create an octave-up variation of the bass clip in empty slot 1"
+- "I prefer the drum groove variation; save that choice and suggest what to compare next"
 - "Autogain the drum and bass tracks while the beat is playing"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"
@@ -315,6 +319,7 @@ In most cases, the default settings work fine. Change these only if:
 | `ABLETON_OSC_PORT` | `11000` | AbletonOSC listen port |
 | `ABLETON_OSC_CLIENT_PORT` | `11001` | Port for receiving replies |
 | `ABLETON_OSC_TIMEOUT_MS` | `500` | Query timeout in milliseconds |
+| `ABLETON_OSC_TASTE_PROFILE_PATH` | OS user config directory / `ableton-osc-mcp/taste-profile.json` | Local path for saved A/B preferences |
 
 </details>
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -20,6 +21,7 @@ type Config struct {
 	AbletonPort       int
 	AbletonClientPort int
 	Timeout           time.Duration
+	TasteProfilePath  string
 }
 
 // Load reads configuration from environment variables with defaults.
@@ -33,7 +35,24 @@ func Load() Config {
 		AbletonPort:       envInt("ABLETON_OSC_PORT", defaultAbletonPort),
 		AbletonClientPort: envInt("ABLETON_OSC_CLIENT_PORT", defaultAbletonClientPort),
 		Timeout:           envDurationMs("ABLETON_OSC_TIMEOUT_MS", defaultTimeoutMs),
+		TasteProfilePath:  envString("ABLETON_OSC_TASTE_PROFILE_PATH", defaultTasteProfilePath()),
 	}
+}
+
+func defaultTasteProfilePath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil || dir == "" {
+		dir = os.TempDir()
+	}
+	return filepath.Join(dir, "ableton-osc-mcp", "taste-profile.json")
+}
+
+func envString(key string, def string) string {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	return v
 }
 
 func envInt(key string, def int) int {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestLoadDefaults(t *testing.T) {
 	// Clear any env vars that might be set.
-	for _, key := range []string{"ABLETON_OSC_HOST", "ABLETON_OSC_PORT", "ABLETON_OSC_CLIENT_PORT", "ABLETON_OSC_TIMEOUT_MS"} {
+	for _, key := range []string{"ABLETON_OSC_HOST", "ABLETON_OSC_PORT", "ABLETON_OSC_CLIENT_PORT", "ABLETON_OSC_TIMEOUT_MS", "ABLETON_OSC_TASTE_PROFILE_PATH"} {
 		t.Setenv(key, "")
 	}
 
@@ -25,6 +25,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Timeout != 500*time.Millisecond {
 		t.Errorf("Timeout = %v, want %v", cfg.Timeout, 500*time.Millisecond)
 	}
+	if cfg.TasteProfilePath == "" {
+		t.Error("TasteProfilePath is empty")
+	}
 }
 
 func TestLoadFromEnv(t *testing.T) {
@@ -32,6 +35,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("ABLETON_OSC_PORT", "12000")
 	t.Setenv("ABLETON_OSC_CLIENT_PORT", "12001")
 	t.Setenv("ABLETON_OSC_TIMEOUT_MS", "1000")
+	t.Setenv("ABLETON_OSC_TASTE_PROFILE_PATH", "/tmp/taste-profile.json")
 
 	cfg := Load()
 
@@ -46,6 +50,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.Timeout != 1000*time.Millisecond {
 		t.Errorf("Timeout = %v, want %v", cfg.Timeout, 1000*time.Millisecond)
+	}
+	if cfg.TasteProfilePath != "/tmp/taste-profile.json" {
+		t.Errorf("TasteProfilePath = %q, want custom path", cfg.TasteProfilePath)
 	}
 }
 

--- a/internal/taste/profile.go
+++ b/internal/taste/profile.go
@@ -1,0 +1,122 @@
+package taste
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const profileVersion = 1
+
+type Preference struct {
+	Instrument string    `json:"instrument"`
+	Variation  string    `json:"variation"`
+	Preferred  string    `json:"preferred"`
+	Note       string    `json:"note,omitempty"`
+	RecordedAt time.Time `json:"recorded_at"`
+}
+
+type Profile struct {
+	Version     int          `json:"version"`
+	Preferences []Preference `json:"preferences"`
+}
+
+type Store struct {
+	path string
+	mu   sync.Mutex
+}
+
+func NewStore(path string) (*Store, error) {
+	if path == "" {
+		return nil, errors.New("taste profile path is required")
+	}
+	return &Store{path: path}, nil
+}
+
+func (s *Store) Path() string {
+	return s.path
+}
+
+func (s *Store) Record(preference Preference) (Profile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	profile, err := s.load()
+	if err != nil {
+		return Profile{}, err
+	}
+	if preference.RecordedAt.IsZero() {
+		preference.RecordedAt = time.Now().UTC()
+	}
+	profile.Preferences = append(profile.Preferences, preference)
+	if err := s.save(profile); err != nil {
+		return Profile{}, err
+	}
+	return profile, nil
+}
+
+func (s *Store) Load() (Profile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.load()
+}
+
+func (s *Store) load() (Profile, error) {
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return Profile{Version: profileVersion, Preferences: []Preference{}}, nil
+	}
+	if err != nil {
+		return Profile{}, fmt.Errorf("read taste profile: %w", err)
+	}
+
+	var profile Profile
+	if err := json.Unmarshal(data, &profile); err != nil {
+		return Profile{}, fmt.Errorf("parse taste profile: %w", err)
+	}
+	if profile.Version != profileVersion {
+		return Profile{}, fmt.Errorf("unsupported taste profile version: %d", profile.Version)
+	}
+	if profile.Preferences == nil {
+		profile.Preferences = []Preference{}
+	}
+	return profile, nil
+}
+
+func (s *Store) save(profile Profile) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create taste profile directory: %w", err)
+	}
+	data, err := json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode taste profile: %w", err)
+	}
+	data = append(data, '\n')
+
+	temp, err := os.CreateTemp(filepath.Dir(s.path), ".taste-profile-*.json")
+	if err != nil {
+		return fmt.Errorf("create taste profile temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("write taste profile: %w", err)
+	}
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("set taste profile permissions: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close taste profile: %w", err)
+	}
+	if err := os.Rename(tempPath, s.path); err != nil {
+		return fmt.Errorf("replace taste profile: %w", err)
+	}
+	return nil
+}

--- a/internal/taste/profile.go
+++ b/internal/taste/profile.go
@@ -102,7 +102,9 @@ func (s *Store) save(profile Profile) error {
 		return fmt.Errorf("create taste profile temp file: %w", err)
 	}
 	tempPath := temp.Name()
-	defer os.Remove(tempPath)
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
 
 	if _, err := temp.Write(data); err != nil {
 		_ = temp.Close()

--- a/internal/taste/profile_test.go
+++ b/internal/taste/profile_test.go
@@ -1,0 +1,67 @@
+package taste
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStoreRecordAndLoad(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nested", "taste-profile.json")
+	store, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	recordedAt := time.Date(2026, time.July, 18, 7, 0, 0, 0, time.UTC)
+	profile, err := store.Record(Preference{
+		Instrument: "drum",
+		Variation:  "groove",
+		Preferred:  "variation",
+		Note:       "More relaxed",
+		RecordedAt: recordedAt,
+	})
+	if err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+	if profile.Version != profileVersion || len(profile.Preferences) != 1 {
+		t.Fatalf("Record() profile = %#v", profile)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded.Preferences) != 1 {
+		t.Fatalf("Load() preferences = %v, want one", loaded.Preferences)
+	}
+	if got := loaded.Preferences[0]; got.Instrument != "drum" || got.Variation != "groove" || got.Preferred != "variation" || !got.RecordedAt.Equal(recordedAt) {
+		t.Errorf("loaded preference = %#v", got)
+	}
+}
+
+func TestStoreLoadMissingReturnsEmptyProfile(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewStore(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	profile, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if profile.Version != profileVersion || len(profile.Preferences) != 0 {
+		t.Errorf("Load() = %#v, want empty current profile", profile)
+	}
+}
+
+func TestNewStoreRejectsEmptyPath(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewStore(""); err == nil {
+		t.Fatal("NewStore(\"\") error = nil, want error")
+	}
+}

--- a/internal/tools/ableton_taste.go
+++ b/internal/tools/ableton_taste.go
@@ -1,0 +1,207 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/taste"
+)
+
+type RecordVariationPreferenceInput struct {
+	Instrument string `json:"instrument" jsonschema:"description=Instrument family: drum or bass"`
+	Variation  string `json:"variation" jsonschema:"description=Variation that was compared (e.g. groove, density, octave_up)"`
+	Preferred  string `json:"preferred" jsonschema:"description=Which version you preferred: source or variation"`
+	Note       string `json:"note,omitempty" jsonschema:"description=Optional short reason for the choice (max 500 characters)"`
+}
+
+type TastePreferenceOutput struct {
+	Instrument string `json:"instrument"`
+	Variation  string `json:"variation"`
+	Preferred  string `json:"preferred"`
+	Note       string `json:"note,omitempty"`
+}
+
+type TasteSummary struct {
+	Instrument string `json:"instrument"`
+	Variation  string `json:"variation"`
+	Accepted   int    `json:"accepted"`
+	Rejected   int    `json:"rejected"`
+}
+
+type TasteProfileOutput struct {
+	ProfilePath         string                 `json:"profile_path"`
+	PreferencesRecorded int                    `json:"preferences_recorded"`
+	Summaries           []TasteSummary         `json:"summaries"`
+	NextSuggestions     []string               `json:"next_suggestions"`
+	RecordedPreference  *TastePreferenceOutput `json:"recorded_preference,omitempty"`
+}
+
+type tasteStore interface {
+	Record(preference taste.Preference) (taste.Profile, error)
+	Load() (taste.Profile, error)
+	Path() string
+}
+
+func NewAbletonRecordVariationPreference(g *genkit.Genkit, store tasteStore) ai.Tool {
+	return genkit.DefineTool(g, "ableton_record_variation_preference",
+		"Ableton Live: record whether an A/B drum or bass variation matched your taste",
+		func(_ *ai.ToolContext, input RecordVariationPreferenceInput) (TasteProfileOutput, error) {
+			preference, err := validateTastePreference(input)
+			if err != nil {
+				return TasteProfileOutput{}, err
+			}
+			profile, err := store.Record(preference)
+			if err != nil {
+				return TasteProfileOutput{}, err
+			}
+			out := tasteProfileOutput(profile, store.Path())
+			out.RecordedPreference = &TastePreferenceOutput{
+				Instrument: preference.Instrument,
+				Variation:  preference.Variation,
+				Preferred:  preference.Preferred,
+				Note:       preference.Note,
+			}
+			return out, nil
+		},
+	)
+}
+
+func NewAbletonGetTasteProfile(g *genkit.Genkit, store tasteStore) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_taste_profile",
+		"Ableton Live: summarize saved A/B variation preferences and suggest the next comparison",
+		func(_ *ai.ToolContext, _ EmptyInput) (TasteProfileOutput, error) {
+			profile, err := store.Load()
+			if err != nil {
+				return TasteProfileOutput{}, err
+			}
+			return tasteProfileOutput(profile, store.Path()), nil
+		},
+	)
+}
+
+func validateTastePreference(input RecordVariationPreferenceInput) (taste.Preference, error) {
+	instrument := strings.ToLower(strings.TrimSpace(input.Instrument))
+	variation := strings.ToLower(strings.TrimSpace(input.Variation))
+	preferred := strings.ToLower(strings.TrimSpace(input.Preferred))
+	note := strings.TrimSpace(input.Note)
+
+	switch instrument {
+	case "drum":
+		if !isDrumVariation(variation) {
+			return taste.Preference{}, errors.New("drum variation must be groove, density, or fill")
+		}
+	case "bass":
+		if !isBassVariation(variation) {
+			return taste.Preference{}, errors.New("bass variation must be octave_up, octave_down, staccato, or groove")
+		}
+	default:
+		return taste.Preference{}, errors.New("instrument must be drum or bass")
+	}
+	if preferred != "source" && preferred != "variation" {
+		return taste.Preference{}, errors.New("preferred must be source or variation")
+	}
+	if len(note) > 500 {
+		return taste.Preference{}, errors.New("note must be 500 characters or fewer")
+	}
+	return taste.Preference{
+		Instrument: instrument,
+		Variation:  variation,
+		Preferred:  preferred,
+		Note:       note,
+	}, nil
+}
+
+func tasteProfileOutput(profile taste.Profile, path string) TasteProfileOutput {
+	type counter struct {
+		instrument string
+		variation  string
+		accepted   int
+		rejected   int
+	}
+
+	counts := make(map[string]*counter)
+	for _, preference := range profile.Preferences {
+		key := preference.Instrument + "\x00" + preference.Variation
+		item, ok := counts[key]
+		if !ok {
+			item = &counter{instrument: preference.Instrument, variation: preference.Variation}
+			counts[key] = item
+		}
+		if preference.Preferred == "variation" {
+			item.accepted++
+		} else {
+			item.rejected++
+		}
+	}
+
+	summaries := make([]TasteSummary, 0, len(counts))
+	for _, item := range counts {
+		summaries = append(summaries, TasteSummary{
+			Instrument: item.instrument,
+			Variation:  item.variation,
+			Accepted:   item.accepted,
+			Rejected:   item.rejected,
+		})
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].Instrument == summaries[j].Instrument {
+			return summaries[i].Variation < summaries[j].Variation
+		}
+		return summaries[i].Instrument < summaries[j].Instrument
+	})
+
+	return TasteProfileOutput{
+		ProfilePath:         path,
+		PreferencesRecorded: len(profile.Preferences),
+		Summaries:           summaries,
+		NextSuggestions:     nextTasteSuggestions(summaries),
+	}
+}
+
+func nextTasteSuggestions(summaries []TasteSummary) []string {
+	byInstrument := map[string]map[string]int{
+		"drum": {},
+		"bass": {},
+	}
+	for _, summary := range summaries {
+		if _, ok := byInstrument[summary.Instrument]; ok {
+			byInstrument[summary.Instrument][summary.Variation] = summary.Accepted + summary.Rejected
+		}
+	}
+
+	suggestions := make([]string, 0, 2)
+	for _, instrument := range []string{"drum", "bass"} {
+		counts := byInstrument[instrument]
+		if len(counts) == 0 {
+			continue
+		}
+		next := leastComparedVariation(instrument, counts)
+		suggestions = append(suggestions,
+			fmt.Sprintf("Try a %s %s variation next; it has been compared least often.", instrument, next),
+		)
+	}
+	return suggestions
+}
+
+func leastComparedVariation(instrument string, counts map[string]int) string {
+	var candidates []string
+	switch instrument {
+	case "drum":
+		candidates = []string{"density", "fill", "groove"}
+	case "bass":
+		candidates = []string{"groove", "octave_down", "octave_up", "staccato"}
+	}
+
+	next := candidates[0]
+	for _, candidate := range candidates[1:] {
+		if counts[candidate] < counts[next] {
+			next = candidate
+		}
+	}
+	return next
+}

--- a/internal/tools/ableton_taste_test.go
+++ b/internal/tools/ableton_taste_test.go
@@ -1,0 +1,87 @@
+package tools
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/taste"
+)
+
+func TestValidateTastePreference(t *testing.T) {
+	t.Parallel()
+
+	got, err := validateTastePreference(RecordVariationPreferenceInput{
+		Instrument: " DRUM ",
+		Variation:  "Groove",
+		Preferred:  "variation",
+		Note:       "More relaxed",
+	})
+	if err != nil {
+		t.Fatalf("validateTastePreference() error = %v", err)
+	}
+	if got.Instrument != "drum" || got.Variation != "groove" || got.Preferred != "variation" {
+		t.Errorf("preference = %#v", got)
+	}
+
+	_, err = validateTastePreference(RecordVariationPreferenceInput{
+		Instrument: "drum",
+		Variation:  "octave_up",
+		Preferred:  "variation",
+	})
+	if err == nil {
+		t.Fatal("expected invalid drum variation error")
+	}
+}
+
+func TestTasteProfileOutput(t *testing.T) {
+	t.Parallel()
+
+	profile := taste.Profile{
+		Version: 1,
+		Preferences: []taste.Preference{
+			{Instrument: "drum", Variation: "groove", Preferred: "variation"},
+			{Instrument: "drum", Variation: "groove", Preferred: "source"},
+			{Instrument: "bass", Variation: "octave_up", Preferred: "variation"},
+		},
+	}
+	got := tasteProfileOutput(profile, "/tmp/taste-profile.json")
+	if got.PreferencesRecorded != 3 {
+		t.Errorf("PreferencesRecorded = %d, want 3", got.PreferencesRecorded)
+	}
+	if len(got.Summaries) != 2 {
+		t.Fatalf("summaries = %#v, want 2", got.Summaries)
+	}
+	if got.Summaries[1].Instrument != "drum" || got.Summaries[1].Variation != "groove" || got.Summaries[1].Accepted != 1 || got.Summaries[1].Rejected != 1 {
+		t.Errorf("drum summary = %#v, want groove 1/1", got.Summaries[1])
+	}
+	joined := strings.Join(got.NextSuggestions, "\n")
+	if !strings.Contains(joined, "drum density") || !strings.Contains(joined, "bass groove") {
+		t.Errorf("NextSuggestions = %v", got.NextSuggestions)
+	}
+}
+
+func TestTasteStoreRoundTripForToolProfile(t *testing.T) {
+	t.Parallel()
+
+	store, err := taste.NewStore(filepath.Join(t.TempDir(), "profile.json"))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	preference, err := validateTastePreference(RecordVariationPreferenceInput{
+		Instrument: "bass",
+		Variation:  "staccato",
+		Preferred:  "variation",
+	})
+	if err != nil {
+		t.Fatalf("validateTastePreference() error = %v", err)
+	}
+	profile, err := store.Record(preference)
+	if err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+	got := tasteProfileOutput(profile, store.Path())
+	if got.ProfilePath != store.Path() || got.PreferencesRecorded != 1 {
+		t.Errorf("profile output = %#v", got)
+	}
+}

--- a/internal/tools/ableton_variations.go
+++ b/internal/tools/ableton_variations.go
@@ -77,7 +77,7 @@ func createDrumVariation(client variationClient, input CreateDrumVariationInput)
 	}
 
 	variation := strings.ToLower(strings.TrimSpace(input.Variation))
-	if variation != "groove" && variation != "density" && variation != "fill" {
+	if !isDrumVariation(variation) {
 		return CreateDrumVariationOutput{}, errors.New("variation must be groove, density, or fill")
 	}
 	opts, err := resolveVariationOptions(input)
@@ -181,6 +181,15 @@ func createDrumVariation(client variationClient, input CreateDrumVariationInput)
 		Seed:            opts.Seed,
 		Fired:           fired,
 	}, nil
+}
+
+func isDrumVariation(variation string) bool {
+	switch variation {
+	case "groove", "density", "fill":
+		return true
+	default:
+		return false
+	}
 }
 
 func resolveVariationOptions(input CreateDrumVariationInput) (variationOptions, error) {

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
 	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/config"
 	mcpinternal "github.com/nozomi-koborinai/ableton-osc-mcp/internal/mcp"
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/taste"
 	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/tools"
 )
 
@@ -40,6 +41,10 @@ func main() {
 	defer func() {
 		_ = ableton.Close()
 	}()
+	tasteStore, err := taste.NewStore(cfg.TasteProfilePath)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	toolList := []ai.Tool{
 		// Song / Transport
@@ -116,6 +121,10 @@ func main() {
 
 		// Recipes
 		tools.NewAbletonSetupDrumTrack(g, ableton),
+
+		// A/B comparison feedback
+		tools.NewAbletonRecordVariationPreference(g, tasteStore),
+		tools.NewAbletonGetTasteProfile(g, tasteStore),
 
 		// Raw OSC
 		tools.NewAbletonOscSend(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add local taste-profile storage for drum and bass A/B choices
- add `ableton_record_variation_preference` and `ableton_get_taste_profile`
- return accepted/rejected variation summaries and the least-compared next candidate
- store only selection metadata and optional notes, not audio or Ableton project data
- add `ABLETON_OSC_TASTE_PROFILE_PATH` to configure the local profile path
- check temporary-file cleanup errors to satisfy CI linting

## Testing
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- CI runs `golangci-lint` (not installed locally)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

