### PR TITLE
feat: add A/B mix snapshot tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Create safe A/B drum variations that change only groove, density, or fills
 - Create safe A/B bass variations that change only octave, note length, or groove
 - Save A/B choices locally to build a taste profile and guide the next comparison
+- Compare small mix-balance hypotheses, then restore the original volume snapshot
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots
@@ -261,6 +262,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_load_device_preset` | Hotswap a preset onto a device |
 | `ableton_get_track_meter` | Track output meter levels |
 | `ableton_autogain_tracks` | Iteratively adjust track volumes toward a target meter level |
+| `ableton_capture_mix_snapshot` / `ableton_restore_mix_snapshot` | Capture and restore track volumes for safe A/B mix comparison |
+| `ableton_apply_mix_variation` | Apply small B-version volume changes and return the A snapshot |
 | `ableton_get_master_meter` / `ableton_get_master_volume` / `ableton_set_master_volume` | Master meter/volume (requires master patch) |
 | `ableton_get_master_devices` / `ableton_get_master_device_parameters` / `ableton_set_master_device_parameter` | Master devices (requires master patch) |
 | `ableton_load_on_master` | Load Browser item onto master (requires browser+master patch) |
@@ -280,6 +283,7 @@ Once configured, you can ask your AI assistant:
 - "Create a groove variation of clip 0 in empty slot 1 so I can compare them"
 - "Create an octave-up variation of the bass clip in empty slot 1"
 - "I prefer the drum groove variation; save that choice and suggest what to compare next"
+- "Create a mix B version with the bass 0.05 lower; keep the returned snapshot so I can compare and restore A"
 - "Autogain the drum and bass tracks while the beat is playing"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"

--- a/internal/tools/ableton_mix_ab.go
+++ b/internal/tools/ableton_mix_ab.go
@@ -1,0 +1,255 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const maxMixVariationDelta = 0.2
+
+type MixSnapshotInput struct {
+	TrackIndices []int `json:"track_indices,omitempty" jsonschema:"description=Tracks to capture; omit to include all regular tracks"`
+}
+
+type MixTrackLevel struct {
+	TrackIndex int     `json:"track_index"`
+	Volume     float64 `json:"volume" jsonschema:"description=Track volume 0.0-1.0"`
+}
+
+type MixSnapshotOutput struct {
+	Tracks []MixTrackLevel `json:"tracks"`
+}
+
+type MixVolumeChange struct {
+	TrackIndex int     `json:"track_index" jsonschema:"minimum=0"`
+	Delta      float64 `json:"delta" jsonschema:"description=Relative volume change for the B version (-0.2 to 0.2),minimum=-0.2,maximum=0.2"`
+}
+
+type ApplyMixVariationInput struct {
+	Changes []MixVolumeChange `json:"changes" jsonschema:"description=One or more small volume changes for the B version"`
+}
+
+type ApplyMixVariationOutput struct {
+	Before MixSnapshotOutput `json:"before" jsonschema:"description=Use this snapshot with ableton_restore_mix_snapshot to return to A"`
+	After  MixSnapshotOutput `json:"after"`
+}
+
+type RestoreMixSnapshotInput struct {
+	Tracks []MixTrackLevel `json:"tracks" jsonschema:"description=Snapshot tracks returned by ableton_capture_mix_snapshot or ableton_apply_mix_variation"`
+}
+
+type mixABClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+func NewAbletonCaptureMixSnapshot(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_capture_mix_snapshot",
+		"Ableton Live: capture current track volumes as an A/B mix snapshot",
+		func(_ *ai.ToolContext, input MixSnapshotInput) (MixSnapshotOutput, error) {
+			return captureMixSnapshot(client, input.TrackIndices)
+		},
+	)
+}
+
+func NewAbletonApplyMixVariation(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_apply_mix_variation",
+		"Ableton Live: apply small track-volume changes for a B mix version and return the A snapshot for restoration",
+		func(_ *ai.ToolContext, input ApplyMixVariationInput) (ApplyMixVariationOutput, error) {
+			return applyMixVariation(client, input)
+		},
+	)
+}
+
+func NewAbletonRestoreMixSnapshot(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_restore_mix_snapshot",
+		"Ableton Live: restore track volumes from an A/B mix snapshot",
+		func(_ *ai.ToolContext, input RestoreMixSnapshotInput) (MixSnapshotOutput, error) {
+			return restoreMixSnapshot(client, input.Tracks)
+		},
+	)
+}
+
+func captureMixSnapshot(client mixABClient, requested []int) (MixSnapshotOutput, error) {
+	indices, err := resolveMixTracks(client, requested)
+	if err != nil {
+		return MixSnapshotOutput{}, err
+	}
+	return captureMixTracks(client, indices)
+}
+
+func applyMixVariation(client mixABClient, input ApplyMixVariationInput) (ApplyMixVariationOutput, error) {
+	if len(input.Changes) == 0 {
+		return ApplyMixVariationOutput{}, errors.New("changes must not be empty")
+	}
+
+	indices := make([]int, 0, len(input.Changes))
+	deltas := make(map[int]float64, len(input.Changes))
+	for _, change := range input.Changes {
+		if change.TrackIndex < 0 {
+			return ApplyMixVariationOutput{}, errors.New("changes track_index must be >= 0")
+		}
+		if math.Abs(change.Delta) > maxMixVariationDelta {
+			return ApplyMixVariationOutput{}, fmt.Errorf("changes delta must be between -%.1f and %.1f", maxMixVariationDelta, maxMixVariationDelta)
+		}
+		if _, exists := deltas[change.TrackIndex]; exists {
+			return ApplyMixVariationOutput{}, fmt.Errorf("duplicate track_index in changes: %d", change.TrackIndex)
+		}
+		indices = append(indices, change.TrackIndex)
+		deltas[change.TrackIndex] = change.Delta
+	}
+
+	before, err := captureMixTracks(client, indices)
+	if err != nil {
+		return ApplyMixVariationOutput{}, err
+	}
+	afterTracks := make([]MixTrackLevel, 0, len(before.Tracks))
+	for _, track := range before.Tracks {
+		afterTracks = append(afterTracks, MixTrackLevel{
+			TrackIndex: track.TrackIndex,
+			Volume:     clampMixVolume(track.Volume + deltas[track.TrackIndex]),
+		})
+	}
+	if err := setMixTracksTransactionally(client, before.Tracks, afterTracks); err != nil {
+		return ApplyMixVariationOutput{}, err
+	}
+	return ApplyMixVariationOutput{
+		Before: before,
+		After:  MixSnapshotOutput{Tracks: afterTracks},
+	}, nil
+}
+
+func restoreMixSnapshot(client mixABClient, tracks []MixTrackLevel) (MixSnapshotOutput, error) {
+	if err := validateMixTracks(tracks); err != nil {
+		return MixSnapshotOutput{}, err
+	}
+	indices := make([]int, 0, len(tracks))
+	for _, track := range tracks {
+		indices = append(indices, track.TrackIndex)
+	}
+	before, err := captureMixTracks(client, indices)
+	if err != nil {
+		return MixSnapshotOutput{}, err
+	}
+	if err := setMixTracksTransactionally(client, before.Tracks, tracks); err != nil {
+		return MixSnapshotOutput{}, err
+	}
+	return MixSnapshotOutput{Tracks: copyMixTracks(tracks)}, nil
+}
+
+func resolveMixTracks(client mixABClient, requested []int) ([]int, error) {
+	if len(requested) > 0 {
+		seen := make(map[int]bool, len(requested))
+		indices := make([]int, 0, len(requested))
+		for _, index := range requested {
+			if index < 0 {
+				return nil, errors.New("track_indices must be >= 0")
+			}
+			if seen[index] {
+				continue
+			}
+			seen[index] = true
+			indices = append(indices, index)
+		}
+		return indices, nil
+	}
+
+	namesRes, err := client.Query("/live/song/get/track_names")
+	if err != nil {
+		return nil, fmt.Errorf("list tracks: %w", err)
+	}
+	if len(namesRes) == 0 {
+		return nil, errors.New("no tracks available")
+	}
+	indices := make([]int, len(namesRes))
+	for i := range namesRes {
+		indices[i] = i
+	}
+	return indices, nil
+}
+
+func captureMixTracks(client mixABClient, indices []int) (MixSnapshotOutput, error) {
+	tracks := make([]MixTrackLevel, 0, len(indices))
+	for _, index := range indices {
+		volume, err := queryMixTrackVolume(client, index)
+		if err != nil {
+			return MixSnapshotOutput{}, fmt.Errorf("track %d: %w", index, err)
+		}
+		tracks = append(tracks, MixTrackLevel{TrackIndex: index, Volume: volume})
+	}
+	return MixSnapshotOutput{Tracks: tracks}, nil
+}
+
+func queryMixTrackVolume(client mixABClient, trackIndex int) (float64, error) {
+	res, err := client.Query("/live/track/get/volume", int32(trackIndex))
+	if err != nil {
+		return 0, fmt.Errorf("get volume: %w", err)
+	}
+	if err := ensureResponseLen(res, 2); err != nil {
+		return 0, fmt.Errorf("get volume: %w", err)
+	}
+	return abletonosc.AsFloat64(res[1])
+}
+
+func setMixTracksTransactionally(client mixABClient, before, target []MixTrackLevel) error {
+	if len(before) != len(target) {
+		return errors.New("mix snapshot lengths differ")
+	}
+	changed := make([]MixTrackLevel, 0, len(target))
+	for i, track := range target {
+		if before[i].TrackIndex != track.TrackIndex {
+			return errors.New("mix snapshot track indices differ")
+		}
+		if err := client.Send("/live/track/set/volume", int32(track.TrackIndex), float32(track.Volume)); err != nil {
+			for j := len(changed) - 1; j >= 0; j-- {
+				original := before[j]
+				_ = client.Send("/live/track/set/volume", int32(original.TrackIndex), float32(original.Volume))
+			}
+			return fmt.Errorf("set track %d volume: %w", track.TrackIndex, err)
+		}
+		changed = append(changed, track)
+	}
+	return nil
+}
+
+func validateMixTracks(tracks []MixTrackLevel) error {
+	if len(tracks) == 0 {
+		return errors.New("tracks must not be empty")
+	}
+	seen := make(map[int]bool, len(tracks))
+	for _, track := range tracks {
+		if track.TrackIndex < 0 {
+			return errors.New("tracks track_index must be >= 0")
+		}
+		if track.Volume < 0 || track.Volume > 1 {
+			return errors.New("tracks volume must be 0.0 to 1.0")
+		}
+		if seen[track.TrackIndex] {
+			return fmt.Errorf("duplicate track_index in tracks: %d", track.TrackIndex)
+		}
+		seen[track.TrackIndex] = true
+	}
+	return nil
+}
+
+func clampMixVolume(volume float64) float64 {
+	if volume < 0 {
+		return 0
+	}
+	if volume > 1 {
+		return 1
+	}
+	return volume
+}
+
+func copyMixTracks(tracks []MixTrackLevel) []MixTrackLevel {
+	out := make([]MixTrackLevel, len(tracks))
+	copy(out, tracks)
+	return out
+}

--- a/internal/tools/ableton_mix_ab_test.go
+++ b/internal/tools/ableton_mix_ab_test.go
@@ -1,0 +1,132 @@
+package tools
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+type mixABCall struct {
+	address string
+	index   int
+	volume  float64
+}
+
+type mixABStub struct {
+	volumes   map[int]float64
+	failTrack *int
+	calls     []mixABCall
+}
+
+func (s *mixABStub) Query(address string, args ...interface{}) ([]interface{}, error) {
+	switch address {
+	case "/live/song/get/track_names":
+		return []interface{}{"Drums", "Bass"}, nil
+	case "/live/track/get/volume":
+		index := int(args[0].(int32))
+		volume, ok := s.volumes[index]
+		if !ok {
+			return nil, errors.New("missing track volume")
+		}
+		return []interface{}{int32(index), float32(volume)}, nil
+	default:
+		return nil, errors.New("unexpected query: " + address)
+	}
+}
+
+func (s *mixABStub) Send(address string, args ...interface{}) error {
+	if address != "/live/track/set/volume" {
+		return errors.New("unexpected send: " + address)
+	}
+	index := int(args[0].(int32))
+	volume := float64(args[1].(float32))
+	s.calls = append(s.calls, mixABCall{address: address, index: index, volume: volume})
+	if s.failTrack != nil && index == *s.failTrack {
+		return errors.New("set volume failed")
+	}
+	s.volumes[index] = volume
+	return nil
+}
+
+func TestCaptureMixSnapshot(t *testing.T) {
+	t.Parallel()
+
+	client := &mixABStub{volumes: map[int]float64{0: 0.5, 1: 0.7}}
+	got, err := captureMixSnapshot(client, nil)
+	if err != nil {
+		t.Fatalf("captureMixSnapshot() error = %v", err)
+	}
+	if len(got.Tracks) != 2 {
+		t.Fatalf("tracks = %#v, want two", got.Tracks)
+	}
+	if got.Tracks[0] != (MixTrackLevel{TrackIndex: 0, Volume: 0.5}) {
+		t.Errorf("track 0 = %#v", got.Tracks[0])
+	}
+}
+
+func TestApplyMixVariationAndRestore(t *testing.T) {
+	t.Parallel()
+
+	client := &mixABStub{volumes: map[int]float64{0: 0.5, 1: 0.7}}
+	got, err := applyMixVariation(client, ApplyMixVariationInput{
+		Changes: []MixVolumeChange{
+			{TrackIndex: 0, Delta: 0.1},
+			{TrackIndex: 1, Delta: -0.1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("applyMixVariation() error = %v", err)
+	}
+	if math.Abs(got.Before.Tracks[0].Volume-0.5) > 1e-6 || math.Abs(got.After.Tracks[0].Volume-0.6) > 1e-6 {
+		t.Errorf("track 0 snapshots = %#v", got)
+	}
+	if math.Abs(client.volumes[1]-0.6) > 1e-6 {
+		t.Errorf("track 1 volume = %v, want 0.6", client.volumes[1])
+	}
+
+	restored, err := restoreMixSnapshot(client, got.Before.Tracks)
+	if err != nil {
+		t.Fatalf("restoreMixSnapshot() error = %v", err)
+	}
+	if len(restored.Tracks) != 2 || math.Abs(client.volumes[0]-0.5) > 1e-6 || math.Abs(client.volumes[1]-0.7) > 1e-6 {
+		t.Errorf("restored = %#v volumes=%v", restored, client.volumes)
+	}
+}
+
+func TestApplyMixVariationRollsBackOnSetFailure(t *testing.T) {
+	t.Parallel()
+
+	failing := 1
+	client := &mixABStub{
+		volumes:   map[int]float64{0: 0.5, 1: 0.7},
+		failTrack: &failing,
+	}
+	_, err := applyMixVariation(client, ApplyMixVariationInput{
+		Changes: []MixVolumeChange{
+			{TrackIndex: 0, Delta: 0.1},
+			{TrackIndex: 1, Delta: -0.1},
+		},
+	})
+	if err == nil {
+		t.Fatal("applyMixVariation() error = nil, want error")
+	}
+	if math.Abs(client.volumes[0]-0.5) > 1e-6 {
+		t.Errorf("track 0 volume = %v, want rollback to 0.5", client.volumes[0])
+	}
+}
+
+func TestApplyMixVariationValidation(t *testing.T) {
+	t.Parallel()
+
+	client := &mixABStub{volumes: map[int]float64{0: 0.5}}
+	_, err := applyMixVariation(client, ApplyMixVariationInput{})
+	if err == nil {
+		t.Fatal("empty changes should fail")
+	}
+	_, err = applyMixVariation(client, ApplyMixVariationInput{
+		Changes: []MixVolumeChange{{TrackIndex: 0, Delta: 0.3}},
+	})
+	if err == nil {
+		t.Fatal("oversized delta should fail")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -113,6 +113,9 @@ func main() {
 		tools.NewAbletonSetMasterDeviceParameter(g, ableton),
 		tools.NewAbletonLoadOnMaster(g, ableton),
 		tools.NewAbletonAutogainTracks(g, ableton),
+		tools.NewAbletonCaptureMixSnapshot(g, ableton),
+		tools.NewAbletonApplyMixVariation(g, ableton),
+		tools.NewAbletonRestoreMixSnapshot(g, ableton),
 
 		// Bounce / Session Record
 		tools.NewAbletonGetSessionRecord(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ableton_capture_mix_snapshot` and `ableton_restore_mix_snapshot` for reversible track-volume A/B comparisons
- add `ableton_apply_mix_variation` for small B-version volume deltas, returning the A snapshot
- roll back earlier volume changes if applying a multi-track B version fails partway through
- document the new MCP tools

## Testing
- `go test ./internal/tools/ -run 'Mix|mix' -count=1 -v`
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

