### PR TITLE
feat: add scene energy A/B variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Create safe A/B bass variations that change only octave, note length, or groove
 - Save A/B choices locally to build a taste profile and guide the next comparison
 - Compare small mix-balance hypotheses, then restore the original volume snapshot
+- Duplicate a scene and compare an energy lift or pullback on selected MIDI tracks
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots
@@ -254,6 +255,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_duplicate_clip_to` | Duplicate clip to another slot |
 | `ableton_set_clip_name` | Rename a clip |
 | `ableton_fire_scene` | Fire a scene |
+| `ableton_create_scene_energy_variation` | Duplicate a scene, then make a MIDI velocity lift or pullback for A/B comparison |
 | `ableton_get_device_parameters` / `ableton_set_device_parameter` | Device parameters |
 | `ableton_find_browser_item` | Search Live Browser (requires patch) |
 | `ableton_list_browser_folder` | List Browser roots or folder children (requires patch) |
@@ -284,6 +286,7 @@ Once configured, you can ask your AI assistant:
 - "Create an octave-up variation of the bass clip in empty slot 1"
 - "I prefer the drum groove variation; save that choice and suggest what to compare next"
 - "Create a mix B version with the bass 0.05 lower; keep the returned snapshot so I can compare and restore A"
+- "Create an energy lift of scene 0 for the drum and bass MIDI tracks so I can compare the sections"
 - "Autogain the drum and bass tracks while the beat is playing"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"

--- a/internal/tools/ableton_scene_variations.go
+++ b/internal/tools/ableton_scene_variations.go
@@ -1,0 +1,242 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const defaultSceneEnergyVelocityDelta = 12
+
+type CreateSceneEnergyVariationInput struct {
+	SourceSceneIndex int    `json:"source_scene_index" jsonschema:"minimum=0"`
+	TrackIndices     []int  `json:"track_indices" jsonschema:"description=MIDI tracks whose clips in the source scene will change, minItems=1"`
+	Variation        string `json:"variation" jsonschema:"description=One change only: lift or pullback"`
+	VelocityDelta    *int   `json:"velocity_delta,omitempty" jsonschema:"description=Velocity change in MIDI units (default 12),minimum=1,maximum=30"`
+	Fire             bool   `json:"fire,omitempty" jsonschema:"description=Fire the duplicated B scene after creating it"`
+}
+
+type CreateSceneEnergyVariationOutput struct {
+	SourceSceneIndex int    `json:"source_scene_index"`
+	TargetSceneIndex int    `json:"target_scene_index" jsonschema:"description=Duplicated B scene, inserted directly after the source scene"`
+	Variation        string `json:"variation"`
+	VelocityDelta    int    `json:"velocity_delta"`
+	TracksChanged    []int  `json:"tracks_changed"`
+	TracksSkipped    []int  `json:"tracks_skipped,omitempty"`
+	NotesChanged     int    `json:"notes_changed"`
+	Fired            bool   `json:"fired"`
+}
+
+type sceneVariationTrack struct {
+	Index int
+	Notes []MidiNote
+}
+
+func NewAbletonCreateSceneEnergyVariation(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_create_scene_energy_variation",
+		"Ableton Live: duplicate a scene and create an A/B energy lift or pullback by changing selected MIDI-track velocities",
+		func(_ *ai.ToolContext, input CreateSceneEnergyVariationInput) (CreateSceneEnergyVariationOutput, error) {
+			return createSceneEnergyVariation(client, input)
+		},
+	)
+}
+
+func createSceneEnergyVariation(client variationClient, input CreateSceneEnergyVariationInput) (CreateSceneEnergyVariationOutput, error) {
+	if input.SourceSceneIndex < 0 {
+		return CreateSceneEnergyVariationOutput{}, errors.New("source_scene_index must be >= 0")
+	}
+	variation := strings.ToLower(strings.TrimSpace(input.Variation))
+	if variation != "lift" && variation != "pullback" {
+		return CreateSceneEnergyVariationOutput{}, errors.New("variation must be lift or pullback")
+	}
+	velocityDelta := defaultSceneEnergyVelocityDelta
+	if input.VelocityDelta != nil {
+		velocityDelta = *input.VelocityDelta
+	}
+	if velocityDelta < 1 || velocityDelta > 30 {
+		return CreateSceneEnergyVariationOutput{}, errors.New("velocity_delta must be between 1 and 30")
+	}
+
+	numScenes, err := queryNumScenes(client)
+	if err != nil {
+		return CreateSceneEnergyVariationOutput{}, err
+	}
+	if input.SourceSceneIndex >= numScenes {
+		return CreateSceneEnergyVariationOutput{}, fmt.Errorf("source_scene_index %d is outside %d scenes", input.SourceSceneIndex, numScenes)
+	}
+	trackIndices, err := validateSceneVariationTracks(input.TrackIndices)
+	if err != nil {
+		return CreateSceneEnergyVariationOutput{}, err
+	}
+
+	sourceTracks := make([]sceneVariationTrack, 0, len(trackIndices))
+	skipped := make([]int, 0)
+	for _, trackIndex := range trackIndices {
+		hasClip, err := queryClipHasClip(client, trackIndex, input.SourceSceneIndex)
+		if err != nil {
+			return CreateSceneEnergyVariationOutput{}, fmt.Errorf("track %d source clip: %w", trackIndex, err)
+		}
+		if !hasClip {
+			skipped = append(skipped, trackIndex)
+			continue
+		}
+		res, err := client.Query("/live/clip/get/notes", int32(trackIndex), int32(input.SourceSceneIndex))
+		if err != nil {
+			return CreateSceneEnergyVariationOutput{}, fmt.Errorf("track %d must contain a MIDI clip: %w", trackIndex, err)
+		}
+		_, _, notes, err := parseClipNotesResponse(res)
+		if err != nil {
+			return CreateSceneEnergyVariationOutput{}, fmt.Errorf("track %d source notes: %w", trackIndex, err)
+		}
+		if len(notes) == 0 {
+			skipped = append(skipped, trackIndex)
+			continue
+		}
+		sourceTracks = append(sourceTracks, sceneVariationTrack{Index: trackIndex, Notes: notes})
+	}
+	if len(sourceTracks) == 0 {
+		return CreateSceneEnergyVariationOutput{}, errors.New("no selected tracks contain MIDI notes in the source scene")
+	}
+
+	delta := velocityDelta
+	if variation == "pullback" {
+		delta = -velocityDelta
+	}
+	changedNotes := 0
+	variedTracks := make([]sceneVariationTrack, 0, len(sourceTracks))
+	for _, track := range sourceTracks {
+		varied, changed := shiftNoteVelocities(track.Notes, delta)
+		if changed == 0 {
+			skipped = append(skipped, track.Index)
+			continue
+		}
+		variedTracks = append(variedTracks, sceneVariationTrack{Index: track.Index, Notes: varied})
+		changedNotes += changed
+	}
+	if len(variedTracks) == 0 {
+		return CreateSceneEnergyVariationOutput{}, errors.New("variation would not change any selected MIDI notes")
+	}
+
+	if err := client.Send("/live/song/duplicate_scene", int32(input.SourceSceneIndex)); err != nil {
+		return CreateSceneEnergyVariationOutput{}, fmt.Errorf("duplicate source scene: %w", err)
+	}
+	afterNumScenes, err := queryNumScenes(client)
+	if err != nil {
+		return CreateSceneEnergyVariationOutput{}, fmt.Errorf("verify duplicated scene: %w", err)
+	}
+	if afterNumScenes != numScenes+1 {
+		return CreateSceneEnergyVariationOutput{}, fmt.Errorf("scene count after duplicate = %d, want %d", afterNumScenes, numScenes+1)
+	}
+	targetSceneIndex := input.SourceSceneIndex + 1
+
+	for _, track := range variedTracks {
+		original := sourceNotesForTrack(sourceTracks, track.Index)
+		if err := replaceVariationNotes(client, track.Index, targetSceneIndex, original, track.Notes); err != nil {
+			return CreateSceneEnergyVariationOutput{}, discardSceneVariation(
+				client,
+				targetSceneIndex,
+				fmt.Errorf("track %d update failed: %w", track.Index, err),
+			)
+		}
+	}
+	if err := client.Send(
+		"/live/scene/set/name",
+		int32(targetSceneIndex),
+		"Variation: energy "+variation,
+	); err != nil {
+		return CreateSceneEnergyVariationOutput{}, discardSceneVariation(client, targetSceneIndex, fmt.Errorf("set name failed: %w", err))
+	}
+
+	fired := false
+	if input.Fire {
+		if err := client.Send("/live/scene/fire", int32(targetSceneIndex)); err != nil {
+			return CreateSceneEnergyVariationOutput{}, discardSceneVariation(client, targetSceneIndex, fmt.Errorf("fire target scene: %w", err))
+		}
+		fired = true
+	}
+
+	changedTracks := make([]int, 0, len(variedTracks))
+	for _, track := range variedTracks {
+		changedTracks = append(changedTracks, track.Index)
+	}
+	return CreateSceneEnergyVariationOutput{
+		SourceSceneIndex: input.SourceSceneIndex,
+		TargetSceneIndex: targetSceneIndex,
+		Variation:        variation,
+		VelocityDelta:    velocityDelta,
+		TracksChanged:    changedTracks,
+		TracksSkipped:    skipped,
+		NotesChanged:     changedNotes,
+		Fired:            fired,
+	}, nil
+}
+
+func discardSceneVariation(client variationClient, sceneIndex int, cause error) error {
+	if err := client.Send("/live/song/delete_scene", int32(sceneIndex)); err != nil {
+		return fmt.Errorf("scene variation failed: %w; cleanup of scene %d also failed: %v", cause, sceneIndex, err)
+	}
+	return fmt.Errorf("scene variation failed: %w; duplicated scene %d removed", cause, sceneIndex)
+}
+
+func queryNumScenes(client variationClient) (int, error) {
+	res, err := client.Query("/live/song/get/num_scenes")
+	if err != nil {
+		return 0, fmt.Errorf("get scene count: %w", err)
+	}
+	if err := ensureResponseLen(res, 1); err != nil {
+		return 0, fmt.Errorf("get scene count: %w", err)
+	}
+	return abletonosc.AsInt(res[0])
+}
+
+func validateSceneVariationTracks(trackIndices []int) ([]int, error) {
+	if len(trackIndices) == 0 {
+		return nil, errors.New("track_indices must not be empty")
+	}
+	seen := make(map[int]bool, len(trackIndices))
+	out := make([]int, 0, len(trackIndices))
+	for _, trackIndex := range trackIndices {
+		if trackIndex < 0 {
+			return nil, errors.New("track_indices must be >= 0")
+		}
+		if seen[trackIndex] {
+			return nil, fmt.Errorf("duplicate track_index: %d", trackIndex)
+		}
+		seen[trackIndex] = true
+		out = append(out, trackIndex)
+	}
+	return out, nil
+}
+
+func shiftNoteVelocities(notes []MidiNote, delta int) ([]MidiNote, int) {
+	out := copyMidiNotes(notes)
+	changed := 0
+	for i := range out {
+		velocity := out[i].Velocity + delta
+		if velocity < 1 {
+			velocity = 1
+		}
+		if velocity > 127 {
+			velocity = 127
+		}
+		if velocity != out[i].Velocity {
+			out[i].Velocity = velocity
+			changed++
+		}
+	}
+	return out, changed
+}
+
+func sourceNotesForTrack(tracks []sceneVariationTrack, trackIndex int) []MidiNote {
+	for _, track := range tracks {
+		if track.Index == trackIndex {
+			return track.Notes
+		}
+	}
+	return nil
+}

--- a/internal/tools/ableton_scene_variations_test.go
+++ b/internal/tools/ableton_scene_variations_test.go
@@ -1,0 +1,189 @@
+package tools
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type sceneVariationCall struct {
+	address string
+	args    []interface{}
+}
+
+type sceneVariationStub struct {
+	queries map[string][][]interface{}
+	queryAt map[string]int
+	calls   []sceneVariationCall
+	sendErr map[string]error
+}
+
+func (s *sceneVariationStub) Query(address string, args ...interface{}) ([]interface{}, error) {
+	s.calls = append(s.calls, sceneVariationCall{address: "Query:" + address, args: append([]interface{}{}, args...)})
+	sequence, ok := s.queries[address]
+	if !ok {
+		return nil, errors.New("unexpected query: " + address)
+	}
+	index := s.queryAt[address]
+	if index >= len(sequence) {
+		index = len(sequence) - 1
+	}
+	s.queryAt[address]++
+	return sequence[index], nil
+}
+
+func (s *sceneVariationStub) Send(address string, args ...interface{}) error {
+	s.calls = append(s.calls, sceneVariationCall{address: "Send:" + address, args: append([]interface{}{}, args...)})
+	return s.sendErr[address]
+}
+
+func TestShiftNoteVelocities(t *testing.T) {
+	t.Parallel()
+
+	notes := []MidiNote{
+		{Pitch: 36, StartTime: 0, Duration: 0.25, Velocity: 120},
+		{Pitch: 38, StartTime: 1, Duration: 0.25, Velocity: 5},
+	}
+	lifted, changed := shiftNoteVelocities(notes, 12)
+	if changed != 2 || lifted[0].Velocity != 127 || lifted[1].Velocity != 17 {
+		t.Errorf("lifted = %#v changed=%d", lifted, changed)
+	}
+	pulledBack, changed := shiftNoteVelocities(notes, -12)
+	if changed != 2 || pulledBack[0].Velocity != 108 || pulledBack[1].Velocity != 1 {
+		t.Errorf("pulledBack = %#v changed=%d", pulledBack, changed)
+	}
+	if notes[0].Velocity != 120 {
+		t.Error("source notes were mutated")
+	}
+}
+
+func TestCreateSceneEnergyVariation(t *testing.T) {
+	t.Parallel()
+
+	client := &sceneVariationStub{
+		queries: map[string][][]interface{}{
+			"/live/song/get/num_scenes": {
+				{int32(3)},
+				{int32(4)},
+			},
+			"/live/clip_slot/get/has_clip": {
+				{int32(0), int32(1), true},
+			},
+			"/live/clip/get/notes": {
+				{
+					int32(0), int32(1),
+					int32(36), float32(0), float32(0.25), int32(100), false,
+				},
+			},
+		},
+		queryAt: map[string]int{},
+	}
+
+	got, err := createSceneEnergyVariation(client, CreateSceneEnergyVariationInput{
+		SourceSceneIndex: 1,
+		TrackIndices:     []int{0},
+		Variation:        "lift",
+		Fire:             true,
+	})
+	if err != nil {
+		t.Fatalf("createSceneEnergyVariation() error = %v", err)
+	}
+	if got.TargetSceneIndex != 2 || got.NotesChanged != 1 || !got.Fired {
+		t.Errorf("result = %#v", got)
+	}
+	if !hasSceneVariationSend(client.calls, "/live/song/duplicate_scene") {
+		t.Error("expected scene duplication")
+	}
+	if !hasSceneVariationSend(client.calls, "/live/scene/set/name") {
+		t.Error("expected scene name")
+	}
+	if !hasSceneVariationSend(client.calls, "/live/scene/fire") {
+		t.Error("expected target scene fire")
+	}
+}
+
+func TestCreateSceneEnergyVariationSkipsEmptyTrack(t *testing.T) {
+	t.Parallel()
+
+	client := &sceneVariationStub{
+		queries: map[string][][]interface{}{
+			"/live/song/get/num_scenes": {
+				{int32(3)},
+			},
+			"/live/clip_slot/get/has_clip": {
+				{int32(0), int32(1), false},
+			},
+		},
+		queryAt: map[string]int{},
+	}
+	_, err := createSceneEnergyVariation(client, CreateSceneEnergyVariationInput{
+		SourceSceneIndex: 1,
+		TrackIndices:     []int{0},
+		Variation:        "lift",
+	})
+	if err == nil {
+		t.Fatal("createSceneEnergyVariation() error = nil, want no-MIDI error")
+	}
+	if hasSceneVariationSend(client.calls, "/live/song/duplicate_scene") {
+		t.Error("must not duplicate a scene when no MIDI notes can change")
+	}
+}
+
+func TestCreateSceneEnergyVariationRemovesDuplicateOnFailure(t *testing.T) {
+	t.Parallel()
+
+	client := &sceneVariationStub{
+		queries: map[string][][]interface{}{
+			"/live/song/get/num_scenes": {
+				{int32(2)},
+				{int32(3)},
+			},
+			"/live/clip_slot/get/has_clip": {
+				{int32(0), int32(0), true},
+			},
+			"/live/clip/get/notes": {
+				{
+					int32(0), int32(0),
+					int32(36), float32(0), float32(0.25), int32(100), false,
+				},
+			},
+		},
+		queryAt: map[string]int{},
+		sendErr: map[string]error{
+			"/live/scene/set/name": errors.New("set name failed"),
+		},
+	}
+	_, err := createSceneEnergyVariation(client, CreateSceneEnergyVariationInput{
+		SourceSceneIndex: 0,
+		TrackIndices:     []int{0},
+		Variation:        "lift",
+	})
+	if err == nil {
+		t.Fatal("createSceneEnergyVariation() error = nil, want error")
+	}
+	if !hasSceneVariationSend(client.calls, "/live/song/delete_scene") {
+		t.Error("expected duplicated scene cleanup")
+	}
+}
+
+func TestValidateSceneVariationTracks(t *testing.T) {
+	t.Parallel()
+
+	got, err := validateSceneVariationTracks([]int{2, 0})
+	if err != nil || !reflect.DeepEqual(got, []int{2, 0}) {
+		t.Errorf("validateSceneVariationTracks() = %v, %v", got, err)
+	}
+	_, err = validateSceneVariationTracks([]int{0, 0})
+	if err == nil {
+		t.Fatal("duplicate tracks should fail")
+	}
+}
+
+func hasSceneVariationSend(calls []sceneVariationCall, address string) bool {
+	for _, call := range calls {
+		if call.address == "Send:"+address {
+			return true
+		}
+	}
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func main() {
 
 		// Scenes
 		tools.NewAbletonFireScene(g, ableton),
+		tools.NewAbletonCreateSceneEnergyVariation(g, ableton),
 
 		// Devices / Browser
 		tools.NewAbletonGetDeviceParameters(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ableton_create_scene_energy_variation` for section-level A/B comparison
- duplicate a scene, then create one MIDI-velocity `lift` or `pullback` across selected tracks
- preserve the source scene, require selected source MIDI clips, and optionally fire the B scene
- remove the duplicated scene if an update fails after duplication
- document the new MCP tool

## Testing
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

