### PR TITLE
feat: add automated A/B audition tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Save A/B choices locally to build a taste profile and guide the next comparison
 - Compare small mix-balance hypotheses, then restore the original volume snapshot
 - Duplicate a scene and compare an energy lift or pullback on selected MIDI tracks
+- Audition A/B clips or scenes automatically in alternating bar-length sections
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots
@@ -249,6 +250,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
 | `ableton_create_drum_variation` | Duplicate a drum clip into an empty slot and change groove, density, or fill for A/B comparison |
 | `ableton_create_bass_variation` | Duplicate a bass clip into an empty slot and change octave, note length, or groove for A/B comparison |
+| `ableton_audition_ab` | Alternate A/B clips or scenes for a specified number of bars and cycles |
 | `ableton_record_variation_preference` | Save whether the source or variation matched your taste |
 | `ableton_get_taste_profile` | Summarize saved A/B choices and suggest the next comparison |
 | `ableton_fire_clip_slot` / `ableton_stop_clip` | Fire/stop a clip |
@@ -285,6 +287,7 @@ Once configured, you can ask your AI assistant:
 - "Create a groove variation of clip 0 in empty slot 1 so I can compare them"
 - "Create an octave-up variation of the bass clip in empty slot 1"
 - "I prefer the drum groove variation; save that choice and suggest what to compare next"
+- "Audition drum clips 0 and 1 on track 0 for two bars each, twice"
 - "Create a mix B version with the bass 0.05 lower; keep the returned snapshot so I can compare and restore A"
 - "Create an energy lift of scene 0 for the drum and bass MIDI tracks so I can compare the sections"
 - "Autogain the drum and bass tracks while the beat is playing"

--- a/internal/tools/ableton_audition.go
+++ b/internal/tools/ableton_audition.go
@@ -1,0 +1,183 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const (
+	defaultAuditionBarsPerVersion = 2
+	defaultAuditionCycles         = 1
+	defaultAuditionBeatsPerBar    = 4
+)
+
+type AuditionABInput struct {
+	TargetType     string `json:"target_type" jsonschema:"description=What to audition: clip or scene"`
+	TrackIndex     *int   `json:"track_index,omitempty" jsonschema:"description=Required for clip auditions; omit for scenes,minimum=0"`
+	SourceIndex    int    `json:"source_index" jsonschema:"description=A version: clip slot or scene index,minimum=0"`
+	VariationIndex int    `json:"variation_index" jsonschema:"description=B version: clip slot or scene index,minimum=0"`
+	BarsPerVersion *int   `json:"bars_per_version,omitempty" jsonschema:"description=Bars to hear each version (default 2),minimum=1,maximum=8"`
+	Cycles         *int   `json:"cycles,omitempty" jsonschema:"description=How many A→B cycles to play (default 1),minimum=1,maximum=4"`
+	BeatsPerBar    *int   `json:"beats_per_bar,omitempty" jsonschema:"description=Beats per bar for duration calculation (default 4),minimum=1,maximum=16"`
+	StartPlayback  bool   `json:"start_playback,omitempty" jsonschema:"description=Start Live playback before the audition"`
+	StopAfter      bool   `json:"stop_after,omitempty" jsonschema:"description=Stop playback after the final B version"`
+}
+
+type AuditionABOutput struct {
+	TargetType       string  `json:"target_type"`
+	TrackIndex       *int    `json:"track_index,omitempty"`
+	SourceIndex      int     `json:"source_index"`
+	VariationIndex   int     `json:"variation_index"`
+	BarsPerVersion   int     `json:"bars_per_version"`
+	Cycles           int     `json:"cycles"`
+	TempoBPM         float64 `json:"tempo_bpm"`
+	DurationSec      float64 `json:"duration_sec"`
+	FinalVersion     string  `json:"final_version"`
+	TimingNote       string  `json:"timing_note"`
+	PreferencePrompt string  `json:"preference_prompt"`
+}
+
+type auditionClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+type auditionSleeper func(time.Duration)
+
+func NewAbletonAuditionAB(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_audition_ab",
+		"Ableton Live: audition an A and B clip or scene in alternating bar-length sections, then prompt for a preference",
+		func(_ *ai.ToolContext, input AuditionABInput) (AuditionABOutput, error) {
+			return auditionAB(client, input, time.Sleep)
+		},
+	)
+}
+
+func auditionAB(client auditionClient, input AuditionABInput, sleep auditionSleeper) (AuditionABOutput, error) {
+	targetType, bars, cycles, beatsPerBar, err := validateAuditionInput(input)
+	if err != nil {
+		return AuditionABOutput{}, err
+	}
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+
+	tempoRes, err := client.Query("/live/song/get/tempo")
+	if err != nil {
+		return AuditionABOutput{}, fmt.Errorf("get tempo: %w", err)
+	}
+	if err := ensureResponseLen(tempoRes, 1); err != nil {
+		return AuditionABOutput{}, fmt.Errorf("get tempo: %w", err)
+	}
+	tempo, err := abletonosc.AsFloat64(tempoRes[0])
+	if err != nil || tempo <= 0 {
+		return AuditionABOutput{}, fmt.Errorf("unexpected tempo: %v", tempoRes)
+	}
+	wait := auditionWaitDuration(tempo, bars, beatsPerBar)
+
+	if input.StartPlayback {
+		if err := client.Send("/live/song/start_playing"); err != nil {
+			return AuditionABOutput{}, fmt.Errorf("start playback: %w", err)
+		}
+	}
+
+	for i := 0; i < cycles; i++ {
+		if err := fireAuditionTarget(client, targetType, input.TrackIndex, input.SourceIndex); err != nil {
+			return AuditionABOutput{}, fmt.Errorf("fire A (cycle %d): %w", i+1, err)
+		}
+		sleep(wait)
+		if err := fireAuditionTarget(client, targetType, input.TrackIndex, input.VariationIndex); err != nil {
+			return AuditionABOutput{}, fmt.Errorf("fire B (cycle %d): %w", i+1, err)
+		}
+		sleep(wait)
+	}
+	if input.StopAfter {
+		if err := client.Send("/live/song/stop_playing"); err != nil {
+			return AuditionABOutput{}, fmt.Errorf("stop playback: %w", err)
+		}
+	}
+
+	var trackIndex *int
+	if input.TrackIndex != nil {
+		index := *input.TrackIndex
+		trackIndex = &index
+	}
+	return AuditionABOutput{
+		TargetType:       targetType,
+		TrackIndex:       trackIndex,
+		SourceIndex:      input.SourceIndex,
+		VariationIndex:   input.VariationIndex,
+		BarsPerVersion:   bars,
+		Cycles:           cycles,
+		TempoBPM:         tempo,
+		DurationSec:      wait.Seconds() * float64(cycles*2),
+		FinalVersion:     "variation",
+		TimingNote:       "Uses Live's current global quantization; duration is a tempo-based estimate.",
+		PreferencePrompt: "Which was closer to your ideal: source or variation? Record the choice with ableton_record_variation_preference.",
+	}, nil
+}
+
+func validateAuditionInput(input AuditionABInput) (string, int, int, int, error) {
+	targetType := strings.ToLower(strings.TrimSpace(input.TargetType))
+	if targetType != "clip" && targetType != "scene" {
+		return "", 0, 0, 0, errors.New("target_type must be clip or scene")
+	}
+	if input.SourceIndex < 0 || input.VariationIndex < 0 {
+		return "", 0, 0, 0, errors.New("source_index and variation_index must be >= 0")
+	}
+	if input.SourceIndex == input.VariationIndex {
+		return "", 0, 0, 0, errors.New("source_index and variation_index must differ")
+	}
+	if targetType == "clip" {
+		if input.TrackIndex == nil {
+			return "", 0, 0, 0, errors.New("track_index is required for clip auditions")
+		}
+		if *input.TrackIndex < 0 {
+			return "", 0, 0, 0, errors.New("track_index must be >= 0")
+		}
+	} else if input.TrackIndex != nil {
+		return "", 0, 0, 0, errors.New("track_index must be omitted for scene auditions")
+	}
+
+	bars := defaultAuditionBarsPerVersion
+	if input.BarsPerVersion != nil {
+		bars = *input.BarsPerVersion
+	}
+	cycles := defaultAuditionCycles
+	if input.Cycles != nil {
+		cycles = *input.Cycles
+	}
+	beatsPerBar := defaultAuditionBeatsPerBar
+	if input.BeatsPerBar != nil {
+		beatsPerBar = *input.BeatsPerBar
+	}
+	if bars < 1 || bars > 8 {
+		return "", 0, 0, 0, errors.New("bars_per_version must be between 1 and 8")
+	}
+	if cycles < 1 || cycles > 4 {
+		return "", 0, 0, 0, errors.New("cycles must be between 1 and 4")
+	}
+	if beatsPerBar < 1 || beatsPerBar > 16 {
+		return "", 0, 0, 0, errors.New("beats_per_bar must be between 1 and 16")
+	}
+	return targetType, bars, cycles, beatsPerBar, nil
+}
+
+func fireAuditionTarget(client auditionClient, targetType string, trackIndex *int, index int) error {
+	if targetType == "scene" {
+		return client.Send("/live/scene/fire", int32(index))
+	}
+	return client.Send("/live/clip_slot/fire", int32(*trackIndex), int32(index))
+}
+
+func auditionWaitDuration(tempo float64, bars, beatsPerBar int) time.Duration {
+	seconds := float64(bars*beatsPerBar) * 60 / tempo
+	return time.Duration(seconds * float64(time.Second))
+}

--- a/internal/tools/ableton_audition_test.go
+++ b/internal/tools/ableton_audition_test.go
@@ -1,0 +1,130 @@
+package tools
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type auditionCall struct {
+	address string
+	args    []interface{}
+}
+
+type auditionStub struct {
+	tempo []interface{}
+	calls []auditionCall
+}
+
+func (s *auditionStub) Query(address string, _ ...interface{}) ([]interface{}, error) {
+	if address != "/live/song/get/tempo" {
+		return nil, errors.New("unexpected query: " + address)
+	}
+	return s.tempo, nil
+}
+
+func (s *auditionStub) Send(address string, args ...interface{}) error {
+	s.calls = append(s.calls, auditionCall{address: address, args: append([]interface{}{}, args...)})
+	return nil
+}
+
+func TestAuditionABClip(t *testing.T) {
+	t.Parallel()
+
+	trackIndex := 2
+	bars := 1
+	cycles := 2
+	client := &auditionStub{tempo: []interface{}{float32(120)}}
+	var waits []time.Duration
+	got, err := auditionAB(client, AuditionABInput{
+		TargetType:     "clip",
+		TrackIndex:     &trackIndex,
+		SourceIndex:    0,
+		VariationIndex: 1,
+		BarsPerVersion: &bars,
+		Cycles:         &cycles,
+		StartPlayback:  true,
+		StopAfter:      true,
+	}, func(d time.Duration) {
+		waits = append(waits, d)
+	})
+	if err != nil {
+		t.Fatalf("auditionAB() error = %v", err)
+	}
+	if len(waits) != 4 {
+		t.Fatalf("waits = %v, want four waits", waits)
+	}
+	for _, wait := range waits {
+		if wait != 2*time.Second {
+			t.Errorf("wait = %v, want 2s", wait)
+		}
+	}
+	if got.DurationSec != 8 || got.FinalVersion != "variation" {
+		t.Errorf("output = %#v", got)
+	}
+	wantAddresses := []string{
+		"/live/song/start_playing",
+		"/live/clip_slot/fire",
+		"/live/clip_slot/fire",
+		"/live/clip_slot/fire",
+		"/live/clip_slot/fire",
+		"/live/song/stop_playing",
+	}
+	gotAddresses := make([]string, 0, len(client.calls))
+	for _, call := range client.calls {
+		gotAddresses = append(gotAddresses, call.address)
+	}
+	if !reflect.DeepEqual(gotAddresses, wantAddresses) {
+		t.Errorf("send calls = %v, want %v", gotAddresses, wantAddresses)
+	}
+}
+
+func TestAuditionABScene(t *testing.T) {
+	t.Parallel()
+
+	client := &auditionStub{tempo: []interface{}{float64(60)}}
+	var waits []time.Duration
+	got, err := auditionAB(client, AuditionABInput{
+		TargetType:     "scene",
+		SourceIndex:    3,
+		VariationIndex: 4,
+	}, func(d time.Duration) {
+		waits = append(waits, d)
+	})
+	if err != nil {
+		t.Fatalf("auditionAB() error = %v", err)
+	}
+	if got.TrackIndex != nil || len(waits) != 2 || waits[0] != 8*time.Second {
+		t.Errorf("output = %#v waits=%v", got, waits)
+	}
+	for _, call := range client.calls {
+		if call.address != "/live/scene/fire" {
+			t.Errorf("unexpected send: %#v", call)
+		}
+	}
+}
+
+func TestValidateAuditionInput(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := validateAuditionInput(AuditionABInput{
+		TargetType:     "clip",
+		SourceIndex:    0,
+		VariationIndex: 1,
+	})
+	if err == nil {
+		t.Fatal("clip audition without track index should fail")
+	}
+
+	trackIndex := 0
+	_, _, _, _, err = validateAuditionInput(AuditionABInput{
+		TargetType:     "scene",
+		TrackIndex:     &trackIndex,
+		SourceIndex:    0,
+		VariationIndex: 1,
+	})
+	if err == nil {
+		t.Fatal("scene audition with track index should fail")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func main() {
 		tools.NewAbletonSetClipName(g, ableton),
 		tools.NewAbletonCreateDrumVariation(g, ableton),
 		tools.NewAbletonCreateBassVariation(g, ableton),
+		tools.NewAbletonAuditionAB(g, ableton),
 
 		// Scenes
 		tools.NewAbletonFireScene(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `ableton_audition_ab` to alternate clip or scene A/B variants for bar-length sections
- support configurable bars, cycles, beats per bar, optional playback start, and optional stop after B
- return a prompt for recording the preferred version in the taste profile
- report that timing is an estimate governed by Live's current global quantization

## Testing
- `go test ./internal/tools/ -run Audition -count=1 -v`
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

