### PR TITLE
fix: align taste recording with audition prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Humanize MIDI clips with microtiming, velocity variation, and swing
 - Create safe A/B drum variations that change only groove, density, or fills
 - Create safe A/B bass variations that change only octave, note length, or groove
-- Save A/B choices locally to build a taste profile and guide the next comparison
+- Save A/B choices locally (drum, bass, scene, mix) to build a taste profile and guide the next comparison
 - Compare small mix-balance hypotheses, then restore the original volume snapshot
 - Duplicate a scene and compare an energy lift or pullback on selected MIDI tracks
 - Audition A/B clips or scenes automatically on Live song time (1-bar quantization)
@@ -251,8 +251,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_create_drum_variation` | Duplicate a drum clip into an empty slot and change groove, density, or fill for A/B comparison |
 | `ableton_create_bass_variation` | Duplicate a bass clip into an empty slot and change octave, note length, or groove for A/B comparison |
 | `ableton_audition_ab` | Alternate A/B clips or scenes for N bars, waiting on Live song time with 1-bar launch quantization |
-| `ableton_record_variation_preference` | Save whether the source or variation matched your taste |
-| `ableton_get_taste_profile` | Summarize saved A/B choices and suggest the next comparison |
+| `ableton_record_variation_preference` | Save whether the source or variation matched your taste (drum, bass, scene, or mix) |
+| `ableton_get_taste_profile` | Summarize saved A/B choices and suggest the next comparison across all families |
 | `ableton_fire_clip_slot` / `ableton_stop_clip` | Fire/stop a clip |
 | `ableton_duplicate_clip_to` | Duplicate clip to another slot |
 | `ableton_set_clip_name` | Rename a clip |

--- a/internal/tools/ableton_audition.go
+++ b/internal/tools/ableton_audition.go
@@ -30,6 +30,8 @@ type AuditionABInput struct {
 	BarsPerVersion *int   `json:"bars_per_version,omitempty" jsonschema:"description=Bars to hear each version (default 2),minimum=1,maximum=8"`
 	Cycles         *int   `json:"cycles,omitempty" jsonschema:"description=How many A→B cycles to play (default 1),minimum=1,maximum=4"`
 	BeatsPerBar    *int   `json:"beats_per_bar,omitempty" jsonschema:"description=Override beats per bar (default: Live signature numerator),minimum=1,maximum=16"`
+	Instrument     string `json:"instrument,omitempty" jsonschema:"description=Optional taste family for the preference prompt: drum or bass for clips; scene for scenes"`
+	Variation      string `json:"variation,omitempty" jsonschema:"description=Optional variation that was compared (e.g. groove, lift) for the preference prompt"`
 	StartPlayback  bool   `json:"start_playback,omitempty" jsonschema:"description=Start Live playback before the audition (also auto-starts when transport is stopped)"`
 	StopAfter      bool   `json:"stop_after,omitempty" jsonschema:"description=Stop playback after the final B version"`
 }
@@ -45,6 +47,8 @@ type AuditionABOutput struct {
 	TempoBPM         float64 `json:"tempo_bpm"`
 	DurationSec      float64 `json:"duration_sec"`
 	PlaybackStarted  bool    `json:"playback_started"`
+	Instrument       string  `json:"instrument,omitempty"`
+	Variation        string  `json:"variation,omitempty"`
 	FinalVersion     string  `json:"final_version"`
 	TimingNote       string  `json:"timing_note"`
 	PreferencePrompt string  `json:"preference_prompt"`
@@ -67,7 +71,7 @@ func NewAbletonAuditionAB(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 }
 
 func auditionAB(client auditionClient, input AuditionABInput, sleep auditionSleeper) (AuditionABOutput, error) {
-	targetType, bars, cycles, beatsPerBarOverride, err := validateAuditionInput(input)
+	targetType, bars, cycles, beatsPerBarOverride, instrument, variation, err := validateAuditionInput(input)
 	if err != nil {
 		return AuditionABOutput{}, err
 	}
@@ -148,9 +152,11 @@ func auditionAB(client auditionClient, input AuditionABInput, sleep auditionSlee
 		TempoBPM:         tempo,
 		DurationSec:      durationSec,
 		PlaybackStarted:  playbackStarted,
+		Instrument:       instrument,
+		Variation:        variation,
 		FinalVersion:     "variation",
 		TimingNote:       "Waits on Live song time with 1-bar clip trigger quantization (restored afterward). Switches land on the next bar boundary.",
-		PreferencePrompt: "Which was closer to your ideal: source or variation? Record the choice with ableton_record_variation_preference.",
+		PreferencePrompt: auditionPreferencePrompt(targetType, instrument, variation),
 	}, nil
 }
 
@@ -307,26 +313,26 @@ func ceilBarBeat(songTime float64, beatsPerBar int) float64 {
 	return barStart + bpb
 }
 
-func validateAuditionInput(input AuditionABInput) (string, int, int, int, error) {
+func validateAuditionInput(input AuditionABInput) (string, int, int, int, string, string, error) {
 	targetType := strings.ToLower(strings.TrimSpace(input.TargetType))
 	if targetType != "clip" && targetType != "scene" {
-		return "", 0, 0, 0, errors.New("target_type must be clip or scene")
+		return "", 0, 0, 0, "", "", errors.New("target_type must be clip or scene")
 	}
 	if input.SourceIndex < 0 || input.VariationIndex < 0 {
-		return "", 0, 0, 0, errors.New("source_index and variation_index must be >= 0")
+		return "", 0, 0, 0, "", "", errors.New("source_index and variation_index must be >= 0")
 	}
 	if input.SourceIndex == input.VariationIndex {
-		return "", 0, 0, 0, errors.New("source_index and variation_index must differ")
+		return "", 0, 0, 0, "", "", errors.New("source_index and variation_index must differ")
 	}
 	if targetType == "clip" {
 		if input.TrackIndex == nil {
-			return "", 0, 0, 0, errors.New("track_index is required for clip auditions")
+			return "", 0, 0, 0, "", "", errors.New("track_index is required for clip auditions")
 		}
 		if *input.TrackIndex < 0 {
-			return "", 0, 0, 0, errors.New("track_index must be >= 0")
+			return "", 0, 0, 0, "", "", errors.New("track_index must be >= 0")
 		}
 	} else if input.TrackIndex != nil {
-		return "", 0, 0, 0, errors.New("track_index must be omitted for scene auditions")
+		return "", 0, 0, 0, "", "", errors.New("track_index must be omitted for scene auditions")
 	}
 
 	bars := defaultAuditionBarsPerVersion
@@ -341,16 +347,72 @@ func validateAuditionInput(input AuditionABInput) (string, int, int, int, error)
 	if input.BeatsPerBar != nil {
 		beatsPerBar = *input.BeatsPerBar
 		if beatsPerBar < 1 || beatsPerBar > 16 {
-			return "", 0, 0, 0, errors.New("beats_per_bar must be between 1 and 16")
+			return "", 0, 0, 0, "", "", errors.New("beats_per_bar must be between 1 and 16")
 		}
 	}
 	if bars < 1 || bars > 8 {
-		return "", 0, 0, 0, errors.New("bars_per_version must be between 1 and 8")
+		return "", 0, 0, 0, "", "", errors.New("bars_per_version must be between 1 and 8")
 	}
 	if cycles < 1 || cycles > 4 {
-		return "", 0, 0, 0, errors.New("cycles must be between 1 and 4")
+		return "", 0, 0, 0, "", "", errors.New("cycles must be between 1 and 4")
 	}
-	return targetType, bars, cycles, beatsPerBar, nil
+
+	instrument, variation, err := validateAuditionTasteHint(targetType, input.Instrument, input.Variation)
+	if err != nil {
+		return "", 0, 0, 0, "", "", err
+	}
+	return targetType, bars, cycles, beatsPerBar, instrument, variation, nil
+}
+
+func validateAuditionTasteHint(targetType, instrument, variation string) (string, string, error) {
+	instrument = strings.ToLower(strings.TrimSpace(instrument))
+	variation = strings.ToLower(strings.TrimSpace(variation))
+	if instrument == "" && variation == "" {
+		return "", "", nil
+	}
+	if instrument == "" {
+		if targetType == "scene" {
+			instrument = "scene"
+		} else {
+			return "", "", errors.New("instrument is required when variation is set for clip auditions")
+		}
+	}
+	switch targetType {
+	case "clip":
+		if instrument != "drum" && instrument != "bass" {
+			return "", "", errors.New("clip audition instrument must be drum or bass")
+		}
+	case "scene":
+		if instrument != "scene" {
+			return "", "", errors.New("scene audition instrument must be scene")
+		}
+	}
+	if variation != "" {
+		if err := validateTasteInstrumentVariation(instrument, variation); err != nil {
+			return "", "", err
+		}
+	}
+	return instrument, variation, nil
+}
+
+func auditionPreferencePrompt(targetType, instrument, variation string) string {
+	if instrument != "" && variation != "" {
+		return fmt.Sprintf(
+			"Which was closer to your ideal: source or variation? Record with ableton_record_variation_preference using instrument=%s variation=%s.",
+			instrument, variation,
+		)
+	}
+	if instrument != "" {
+		candidates := strings.Join(tasteVariationsFor(instrument), ", ")
+		return fmt.Sprintf(
+			"Which was closer to your ideal: source or variation? Record with ableton_record_variation_preference using instrument=%s and the variation you compared (%s).",
+			instrument, candidates,
+		)
+	}
+	if targetType == "scene" {
+		return "Which was closer to your ideal: source or variation? Record with ableton_record_variation_preference using instrument=scene and variation=lift or pullback."
+	}
+	return "Which was closer to your ideal: source or variation? Record with ableton_record_variation_preference using instrument=drum or bass and the variation you compared (e.g. groove, density, octave_up)."
 }
 
 func fireAuditionTarget(client auditionClient, targetType string, trackIndex *int, index int) error {

--- a/internal/tools/ableton_audition_test.go
+++ b/internal/tools/ableton_audition_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -259,7 +260,7 @@ func TestCeilBarBeat(t *testing.T) {
 func TestValidateAuditionInput(t *testing.T) {
 	t.Parallel()
 
-	_, _, _, _, err := validateAuditionInput(AuditionABInput{
+	_, _, _, _, _, _, err := validateAuditionInput(AuditionABInput{
 		TargetType:     "clip",
 		SourceIndex:    0,
 		VariationIndex: 1,
@@ -269,7 +270,7 @@ func TestValidateAuditionInput(t *testing.T) {
 	}
 
 	trackIndex := 0
-	_, _, _, _, err = validateAuditionInput(AuditionABInput{
+	_, _, _, _, _, _, err = validateAuditionInput(AuditionABInput{
 		TargetType:     "scene",
 		TrackIndex:     &trackIndex,
 		SourceIndex:    0,
@@ -279,7 +280,7 @@ func TestValidateAuditionInput(t *testing.T) {
 		t.Fatal("scene audition with track index should fail")
 	}
 
-	_, _, _, beats, err := validateAuditionInput(AuditionABInput{
+	_, _, _, beats, _, _, err := validateAuditionInput(AuditionABInput{
 		TargetType:     "scene",
 		SourceIndex:    0,
 		VariationIndex: 1,
@@ -289,5 +290,64 @@ func TestValidateAuditionInput(t *testing.T) {
 	}
 	if beats != 0 {
 		t.Errorf("beats override = %d, want 0 (query Live)", beats)
+	}
+
+	_, _, _, _, _, _, err = validateAuditionInput(AuditionABInput{
+		TargetType:     "scene",
+		SourceIndex:    0,
+		VariationIndex: 1,
+		Instrument:     "drum",
+	})
+	if err == nil {
+		t.Fatal("scene audition with drum instrument should fail")
+	}
+}
+
+func TestAuditionPreferencePrompt(t *testing.T) {
+	t.Parallel()
+
+	specific := auditionPreferencePrompt("clip", "drum", "groove")
+	if !strings.Contains(specific, "instrument=drum variation=groove") {
+		t.Errorf("specific prompt = %q", specific)
+	}
+	scene := auditionPreferencePrompt("scene", "", "")
+	if !strings.Contains(scene, "instrument=scene") || !strings.Contains(scene, "lift or pullback") {
+		t.Errorf("scene prompt = %q", scene)
+	}
+	clip := auditionPreferencePrompt("clip", "", "")
+	if !strings.Contains(clip, "drum or bass") {
+		t.Errorf("clip prompt = %q", clip)
+	}
+}
+
+func TestAuditionABIncludesTasteHint(t *testing.T) {
+	t.Parallel()
+
+	client := &auditionStub{
+		tempo:        120,
+		songTime:     0,
+		signature:    4,
+		isPlaying:    true,
+		quantization: 4,
+	}
+	bars := 1
+	got, err := auditionAB(client, AuditionABInput{
+		TargetType:     "scene",
+		SourceIndex:    0,
+		VariationIndex: 1,
+		BarsPerVersion: &bars,
+		Instrument:     "scene",
+		Variation:      "lift",
+	}, func(d time.Duration) {
+		advanceAuditionStub(client, d)
+	})
+	if err != nil {
+		t.Fatalf("auditionAB() error = %v", err)
+	}
+	if got.Instrument != "scene" || got.Variation != "lift" {
+		t.Errorf("taste hint = %#v", got)
+	}
+	if !strings.Contains(got.PreferencePrompt, "instrument=scene variation=lift") {
+		t.Errorf("preference_prompt = %q", got.PreferencePrompt)
 	}
 }

--- a/internal/tools/ableton_mix_ab.go
+++ b/internal/tools/ableton_mix_ab.go
@@ -121,8 +121,8 @@ func applyMixVariation(client mixABClient, input ApplyMixVariationInput) (ApplyM
 		return ApplyMixVariationOutput{}, err
 	}
 	return ApplyMixVariationOutput{
-		Before: before,
-		After:  MixSnapshotOutput{Tracks: afterTracks},
+		Before:           before,
+		After:            MixSnapshotOutput{Tracks: afterTracks},
 		PreferencePrompt: "After comparing A/B, record with ableton_record_variation_preference using instrument=mix variation=volume, then restore A with ableton_restore_mix_snapshot.",
 	}, nil
 }

--- a/internal/tools/ableton_mix_ab.go
+++ b/internal/tools/ableton_mix_ab.go
@@ -36,8 +36,9 @@ type ApplyMixVariationInput struct {
 }
 
 type ApplyMixVariationOutput struct {
-	Before MixSnapshotOutput `json:"before" jsonschema:"description=Use this snapshot with ableton_restore_mix_snapshot to return to A"`
-	After  MixSnapshotOutput `json:"after"`
+	Before           MixSnapshotOutput `json:"before" jsonschema:"description=Use this snapshot with ableton_restore_mix_snapshot to return to A"`
+	After            MixSnapshotOutput `json:"after"`
+	PreferencePrompt string            `json:"preference_prompt"`
 }
 
 type RestoreMixSnapshotInput struct {
@@ -122,6 +123,7 @@ func applyMixVariation(client mixABClient, input ApplyMixVariationInput) (ApplyM
 	return ApplyMixVariationOutput{
 		Before: before,
 		After:  MixSnapshotOutput{Tracks: afterTracks},
+		PreferencePrompt: "After comparing A/B, record with ableton_record_variation_preference using instrument=mix variation=volume, then restore A with ableton_restore_mix_snapshot.",
 	}, nil
 }
 

--- a/internal/tools/ableton_mix_ab_test.go
+++ b/internal/tools/ableton_mix_ab_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"errors"
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -82,6 +83,9 @@ func TestApplyMixVariationAndRestore(t *testing.T) {
 	}
 	if math.Abs(client.volumes[1]-0.6) > 1e-6 {
 		t.Errorf("track 1 volume = %v, want 0.6", client.volumes[1])
+	}
+	if !strings.Contains(got.PreferencePrompt, "instrument=mix variation=volume") {
+		t.Errorf("preference_prompt = %q", got.PreferencePrompt)
 	}
 
 	restored, err := restoreMixSnapshot(client, got.Before.Tracks)

--- a/internal/tools/ableton_scene_variations.go
+++ b/internal/tools/ableton_scene_variations.go
@@ -30,6 +30,7 @@ type CreateSceneEnergyVariationOutput struct {
 	TracksSkipped    []int  `json:"tracks_skipped,omitempty"`
 	NotesChanged     int    `json:"notes_changed"`
 	Fired            bool   `json:"fired"`
+	PreferencePrompt string `json:"preference_prompt"`
 }
 
 type sceneVariationTrack struct {
@@ -173,6 +174,7 @@ func createSceneEnergyVariation(client variationClient, input CreateSceneEnergyV
 		TracksSkipped:    skipped,
 		NotesChanged:     changedNotes,
 		Fired:            fired,
+		PreferencePrompt: auditionPreferencePrompt("scene", "scene", variation),
 	}, nil
 }
 

--- a/internal/tools/ableton_taste.go
+++ b/internal/tools/ableton_taste.go
@@ -13,8 +13,8 @@ import (
 )
 
 type RecordVariationPreferenceInput struct {
-	Instrument string `json:"instrument" jsonschema:"description=Instrument family: drum or bass"`
-	Variation  string `json:"variation" jsonschema:"description=Variation that was compared (e.g. groove, density, octave_up)"`
+	Instrument string `json:"instrument" jsonschema:"description=Comparison family: drum, bass, scene, or mix"`
+	Variation  string `json:"variation" jsonschema:"description=Variation that was compared (e.g. groove, lift, volume)"`
 	Preferred  string `json:"preferred" jsonschema:"description=Which version you preferred: source or variation"`
 	Note       string `json:"note,omitempty" jsonschema:"description=Optional short reason for the choice (max 500 characters)"`
 }
@@ -47,9 +47,11 @@ type tasteStore interface {
 	Path() string
 }
 
+var tasteInstrumentOrder = []string{"bass", "drum", "mix", "scene"}
+
 func NewAbletonRecordVariationPreference(g *genkit.Genkit, store tasteStore) ai.Tool {
 	return genkit.DefineTool(g, "ableton_record_variation_preference",
-		"Ableton Live: record whether an A/B drum or bass variation matched your taste",
+		"Ableton Live: record whether an A/B drum, bass, scene, or mix variation matched your taste",
 		func(_ *ai.ToolContext, input RecordVariationPreferenceInput) (TasteProfileOutput, error) {
 			preference, err := validateTastePreference(input)
 			if err != nil {
@@ -90,17 +92,8 @@ func validateTastePreference(input RecordVariationPreferenceInput) (taste.Prefer
 	preferred := strings.ToLower(strings.TrimSpace(input.Preferred))
 	note := strings.TrimSpace(input.Note)
 
-	switch instrument {
-	case "drum":
-		if !isDrumVariation(variation) {
-			return taste.Preference{}, errors.New("drum variation must be groove, density, or fill")
-		}
-	case "bass":
-		if !isBassVariation(variation) {
-			return taste.Preference{}, errors.New("bass variation must be octave_up, octave_down, staccato, or groove")
-		}
-	default:
-		return taste.Preference{}, errors.New("instrument must be drum or bass")
+	if err := validateTasteInstrumentVariation(instrument, variation); err != nil {
+		return taste.Preference{}, err
 	}
 	if preferred != "source" && preferred != "variation" {
 		return taste.Preference{}, errors.New("preferred must be source or variation")
@@ -114,6 +107,38 @@ func validateTastePreference(input RecordVariationPreferenceInput) (taste.Prefer
 		Preferred:  preferred,
 		Note:       note,
 	}, nil
+}
+
+func validateTasteInstrumentVariation(instrument, variation string) error {
+	switch instrument {
+	case "drum":
+		if !isDrumVariation(variation) {
+			return errors.New("drum variation must be groove, density, or fill")
+		}
+	case "bass":
+		if !isBassVariation(variation) {
+			return errors.New("bass variation must be octave_up, octave_down, staccato, or groove")
+		}
+	case "scene":
+		if !isSceneVariation(variation) {
+			return errors.New("scene variation must be lift or pullback")
+		}
+	case "mix":
+		if !isMixVariation(variation) {
+			return errors.New("mix variation must be volume")
+		}
+	default:
+		return errors.New("instrument must be drum, bass, scene, or mix")
+	}
+	return nil
+}
+
+func isSceneVariation(variation string) bool {
+	return variation == "lift" || variation == "pullback"
+}
+
+func isMixVariation(variation string) bool {
+	return variation == "volume"
 }
 
 func tasteProfileOutput(profile taste.Profile, path string) TasteProfileOutput {
@@ -164,9 +189,9 @@ func tasteProfileOutput(profile taste.Profile, path string) TasteProfileOutput {
 }
 
 func nextTasteSuggestions(summaries []TasteSummary) []string {
-	byInstrument := map[string]map[string]int{
-		"drum": {},
-		"bass": {},
+	byInstrument := map[string]map[string]int{}
+	for _, instrument := range tasteInstrumentOrder {
+		byInstrument[instrument] = map[string]int{}
 	}
 	for _, summary := range summaries {
 		if _, ok := byInstrument[summary.Instrument]; ok {
@@ -174,13 +199,9 @@ func nextTasteSuggestions(summaries []TasteSummary) []string {
 		}
 	}
 
-	suggestions := make([]string, 0, 2)
-	for _, instrument := range []string{"drum", "bass"} {
-		counts := byInstrument[instrument]
-		if len(counts) == 0 {
-			continue
-		}
-		next := leastComparedVariation(instrument, counts)
+	suggestions := make([]string, 0, len(tasteInstrumentOrder))
+	for _, instrument := range tasteInstrumentOrder {
+		next := leastComparedVariation(instrument, byInstrument[instrument])
 		suggestions = append(suggestions,
 			fmt.Sprintf("Try a %s %s variation next; it has been compared least often.", instrument, next),
 		)
@@ -189,14 +210,7 @@ func nextTasteSuggestions(summaries []TasteSummary) []string {
 }
 
 func leastComparedVariation(instrument string, counts map[string]int) string {
-	var candidates []string
-	switch instrument {
-	case "drum":
-		candidates = []string{"density", "fill", "groove"}
-	case "bass":
-		candidates = []string{"groove", "octave_down", "octave_up", "staccato"}
-	}
-
+	candidates := tasteVariationsFor(instrument)
 	next := candidates[0]
 	for _, candidate := range candidates[1:] {
 		if counts[candidate] < counts[next] {
@@ -204,4 +218,19 @@ func leastComparedVariation(instrument string, counts map[string]int) string {
 		}
 	}
 	return next
+}
+
+func tasteVariationsFor(instrument string) []string {
+	switch instrument {
+	case "drum":
+		return []string{"density", "fill", "groove"}
+	case "bass":
+		return []string{"groove", "octave_down", "octave_up", "staccato"}
+	case "scene":
+		return []string{"lift", "pullback"}
+	case "mix":
+		return []string{"volume"}
+	default:
+		return nil
+	}
 }

--- a/internal/tools/ableton_taste_test.go
+++ b/internal/tools/ableton_taste_test.go
@@ -32,6 +32,30 @@ func TestValidateTastePreference(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid drum variation error")
 	}
+
+	got, err = validateTastePreference(RecordVariationPreferenceInput{
+		Instrument: "scene",
+		Variation:  "lift",
+		Preferred:  "source",
+	})
+	if err != nil {
+		t.Fatalf("scene preference error = %v", err)
+	}
+	if got.Instrument != "scene" || got.Variation != "lift" {
+		t.Errorf("scene preference = %#v", got)
+	}
+
+	got, err = validateTastePreference(RecordVariationPreferenceInput{
+		Instrument: "mix",
+		Variation:  "volume",
+		Preferred:  "variation",
+	})
+	if err != nil {
+		t.Fatalf("mix preference error = %v", err)
+	}
+	if got.Instrument != "mix" || got.Variation != "volume" {
+		t.Errorf("mix preference = %#v", got)
+	}
 }
 
 func TestTasteProfileOutput(t *testing.T) {
@@ -43,21 +67,43 @@ func TestTasteProfileOutput(t *testing.T) {
 			{Instrument: "drum", Variation: "groove", Preferred: "variation"},
 			{Instrument: "drum", Variation: "groove", Preferred: "source"},
 			{Instrument: "bass", Variation: "octave_up", Preferred: "variation"},
+			{Instrument: "scene", Variation: "lift", Preferred: "variation"},
 		},
 	}
 	got := tasteProfileOutput(profile, "/tmp/taste-profile.json")
-	if got.PreferencesRecorded != 3 {
-		t.Errorf("PreferencesRecorded = %d, want 3", got.PreferencesRecorded)
+	if got.PreferencesRecorded != 4 {
+		t.Errorf("PreferencesRecorded = %d, want 4", got.PreferencesRecorded)
 	}
-	if len(got.Summaries) != 2 {
-		t.Fatalf("summaries = %#v, want 2", got.Summaries)
-	}
-	if got.Summaries[1].Instrument != "drum" || got.Summaries[1].Variation != "groove" || got.Summaries[1].Accepted != 1 || got.Summaries[1].Rejected != 1 {
-		t.Errorf("drum summary = %#v, want groove 1/1", got.Summaries[1])
+	if len(got.Summaries) != 3 {
+		t.Fatalf("summaries = %#v, want 3", got.Summaries)
 	}
 	joined := strings.Join(got.NextSuggestions, "\n")
 	if !strings.Contains(joined, "drum density") || !strings.Contains(joined, "bass groove") {
 		t.Errorf("NextSuggestions = %v", got.NextSuggestions)
+	}
+	if !strings.Contains(joined, "scene pullback") || !strings.Contains(joined, "mix volume") {
+		t.Errorf("NextSuggestions missing scene/mix = %v", got.NextSuggestions)
+	}
+	if len(got.NextSuggestions) != 4 {
+		t.Errorf("want 4 family suggestions, got %v", got.NextSuggestions)
+	}
+}
+
+func TestTasteProfileColdStartSuggestions(t *testing.T) {
+	t.Parallel()
+
+	got := tasteProfileOutput(taste.Profile{Version: 1}, "/tmp/taste-profile.json")
+	if got.PreferencesRecorded != 0 {
+		t.Fatalf("PreferencesRecorded = %d", got.PreferencesRecorded)
+	}
+	if len(got.NextSuggestions) != 4 {
+		t.Fatalf("cold start suggestions = %v, want 4", got.NextSuggestions)
+	}
+	joined := strings.Join(got.NextSuggestions, "\n")
+	for _, want := range []string{"bass groove", "drum density", "mix volume", "scene lift"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("cold start missing %q in %v", want, got.NextSuggestions)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the gap between A/B audition / mix / scene flows and `ableton_record_variation_preference`.

- Accept taste families **`scene`** (`lift` / `pullback`) and **`mix`** (`volume`) in addition to drum / bass
- Cold-start profiles now always return next-comparison suggestions for all four families
- `ableton_audition_ab` accepts optional `instrument` / `variation` and emits a precise `preference_prompt`
- Scene create and mix apply outputs include matching preference prompts

## Why

Audition always told the agent to record a preference, but scene/mix choices were rejected and an empty profile suggested nothing next.

## Test plan

- [x] `go test ./...`
- [ ] Record a scene `lift` preference and confirm it appears in `ableton_get_taste_profile`
- [ ] Run a scene audition with `instrument=scene variation=lift` and check the prompt names those fields
- [ ] On a fresh profile path, confirm four next-suggestion lines (bass / drum / mix / scene)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

