### PR TITLE
fix: reject no-op drum A/B variations before duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_create_clip` | Create a clip in a slot |
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
-| `ableton_create_drum_variation` | Duplicate a drum clip into an empty slot and change groove, density, or fill for A/B comparison |
+| `ableton_create_drum_variation` | Duplicate a drum clip into an empty slot and change groove, density, or fill for A/B comparison (rejects no-op changes) |
 | `ableton_create_bass_variation` | Duplicate a bass clip into an empty slot and change octave, note length, or groove for A/B comparison |
 | `ableton_audition_ab` | Alternate A/B clips or scenes for N bars, waiting on Live song time with 1-bar launch quantization |
 | `ableton_record_variation_preference` | Save whether the source or variation matched your taste (drum, bass, scene, or mix) |

--- a/internal/tools/ableton_bass_variations.go
+++ b/internal/tools/ableton_bass_variations.go
@@ -104,7 +104,7 @@ func createBassVariation(client variationClient, input CreateBassVariationInput)
 		rand.New(rand.NewSource(opts.Seed)),
 	)
 	if changed == 0 {
-		return CreateBassVariationOutput{}, errors.New("variation would not change any source notes")
+		return CreateBassVariationOutput{}, errors.New("variation would not change the source clip")
 	}
 
 	if err := client.Send(

--- a/internal/tools/ableton_variations.go
+++ b/internal/tools/ableton_variations.go
@@ -110,15 +110,6 @@ func createDrumVariation(client variationClient, input CreateDrumVariationInput)
 		clipLength = inferredClipLength(sourceNotes)
 	}
 
-	if err := client.Send(
-		"/live/clip_slot/duplicate_clip_to",
-		int32(input.TrackIndex),
-		int32(input.SourceClipIndex),
-		int32(input.TargetClipIndex),
-	); err != nil {
-		return CreateDrumVariationOutput{}, fmt.Errorf("duplicate source clip: %w", err)
-	}
-
 	rng := rand.New(rand.NewSource(opts.Seed))
 	var notes []MidiNote
 	var notesChanged, notesAdded int
@@ -132,7 +123,7 @@ func createDrumVariation(client variationClient, input CreateDrumVariationInput)
 			Seed:           opts.Seed,
 		}
 		notes = humanizeNotes(sourceNotes, humanize, rng, clipLength)
-		notesChanged = len(notes)
+		notesChanged = countChangedMidiNotes(sourceNotes, notes)
 	case "density":
 		additions := densityNotes(sourceNotes, clipLength, opts.HatPitch, opts.Strength, rng)
 		notes = append(copyMidiNotes(sourceNotes), additions...)
@@ -142,12 +133,24 @@ func createDrumVariation(client variationClient, input CreateDrumVariationInput)
 		notes = append(copyMidiNotes(sourceNotes), additions...)
 		notesAdded = len(additions)
 	}
+	if notesChanged == 0 && notesAdded == 0 {
+		return CreateDrumVariationOutput{}, errors.New("variation would not change the source clip")
+	}
+
+	if err := client.Send(
+		"/live/clip_slot/duplicate_clip_to",
+		int32(input.TrackIndex),
+		int32(input.SourceClipIndex),
+		int32(input.TargetClipIndex),
+	); err != nil {
+		return CreateDrumVariationOutput{}, fmt.Errorf("duplicate source clip: %w", err)
+	}
 
 	if variation == "groove" {
 		if err := replaceVariationNotes(client, input.TrackIndex, input.TargetClipIndex, sourceNotes, notes); err != nil {
 			return CreateDrumVariationOutput{}, err
 		}
-	} else if notesAdded > 0 {
+	} else {
 		if err := client.Send("/live/clip/add/notes", addNotesArgs(input.TrackIndex, input.TargetClipIndex, notes[len(sourceNotes):])...); err != nil {
 			return CreateDrumVariationOutput{}, fmt.Errorf("add variation notes: %w", err)
 		}
@@ -315,4 +318,38 @@ func copyMidiNotes(notes []MidiNote) []MidiNote {
 		out = append(out, copied)
 	}
 	return out
+}
+
+func countChangedMidiNotes(original, varied []MidiNote) int {
+	if len(original) != len(varied) {
+		n := len(varied)
+		if len(original) > n {
+			n = len(original)
+		}
+		return n
+	}
+	changed := 0
+	for i := range original {
+		if !midiNotesEqual(original[i], varied[i]) {
+			changed++
+		}
+	}
+	return changed
+}
+
+func midiNotesEqual(a, b MidiNote) bool {
+	if a.Pitch != b.Pitch || a.Velocity != b.Velocity {
+		return false
+	}
+	if math.Abs(a.StartTime-b.StartTime) > 1e-6 || math.Abs(a.Duration-b.Duration) > 1e-6 {
+		return false
+	}
+	return midiMuteValue(a.Mute) == midiMuteValue(b.Mute)
+}
+
+func midiMuteValue(mute *bool) bool {
+	if mute == nil {
+		return false
+	}
+	return *mute
 }

--- a/internal/tools/ableton_variations_test.go
+++ b/internal/tools/ableton_variations_test.go
@@ -186,6 +186,97 @@ func TestCreateDrumVariationRejectsSameSlot(t *testing.T) {
 	}
 }
 
+func TestCreateDrumVariationRejectsNoopDensity(t *testing.T) {
+	t.Parallel()
+
+	strength := 0.0
+	client := &variationStub{
+		queries: map[string][]interface{}{
+			"/live/clip_slot/get/has_clip": {int32(0), int32(1), false},
+			"/live/clip/get/notes": {
+				int32(0), int32(0),
+				int32(36), float32(0), float32(0.25), int32(100), false,
+			},
+			"/live/clip/get/length": {int32(0), int32(0), float32(2)},
+		},
+		sendErr: map[string]error{},
+	}
+	_, err := createDrumVariation(client, CreateDrumVariationInput{
+		TrackIndex:      0,
+		SourceClipIndex: 0,
+		TargetClipIndex: 1,
+		Variation:       "density",
+		Strength:        &strength,
+	})
+	if err == nil {
+		t.Fatal("createDrumVariation() error = nil, want no-op density error")
+	}
+	if hasVariationSend(client.calls, "/live/clip_slot/duplicate_clip_to") {
+		t.Error("no-op density must not duplicate a B clip")
+	}
+}
+
+func TestCreateDrumVariationRejectsNoopFill(t *testing.T) {
+	t.Parallel()
+
+	// Clip shorter than 1 beat: fillNotes returns nothing.
+	client := &variationStub{
+		queries: map[string][]interface{}{
+			"/live/clip_slot/get/has_clip": {int32(0), int32(1), false},
+			"/live/clip/get/notes": {
+				int32(0), int32(0),
+				int32(36), float32(0), float32(0.25), int32(100), false,
+			},
+			"/live/clip/get/length": {int32(0), int32(0), float32(0.5)},
+		},
+		sendErr: map[string]error{},
+	}
+	_, err := createDrumVariation(client, CreateDrumVariationInput{
+		TrackIndex:      0,
+		SourceClipIndex: 0,
+		TargetClipIndex: 1,
+		Variation:       "fill",
+	})
+	if err == nil {
+		t.Fatal("createDrumVariation() error = nil, want no-op fill error")
+	}
+	if hasVariationSend(client.calls, "/live/clip_slot/duplicate_clip_to") {
+		t.Error("no-op fill must not duplicate a B clip")
+	}
+}
+
+func TestCreateDrumVariationRejectsNoopGroove(t *testing.T) {
+	t.Parallel()
+
+	strength := 0.0
+	seed := int64(7)
+	client := &variationStub{
+		queries: map[string][]interface{}{
+			"/live/clip_slot/get/has_clip": {int32(0), int32(1), false},
+			"/live/clip/get/notes": {
+				int32(0), int32(0),
+				int32(36), float32(0), float32(0.25), int32(100), false,
+			},
+			"/live/clip/get/length": {int32(0), int32(0), float32(4)},
+		},
+		sendErr: map[string]error{},
+	}
+	_, err := createDrumVariation(client, CreateDrumVariationInput{
+		TrackIndex:      0,
+		SourceClipIndex: 0,
+		TargetClipIndex: 1,
+		Variation:       "groove",
+		Strength:        &strength,
+		Seed:            &seed,
+	})
+	if err == nil {
+		t.Fatal("createDrumVariation() error = nil, want no-op groove error")
+	}
+	if hasVariationSend(client.calls, "/live/clip_slot/duplicate_clip_to") {
+		t.Error("no-op groove must not duplicate a B clip")
+	}
+}
+
 func newVariationRNG(seed int64) *rand.Rand {
 	return rand.New(rand.NewSource(seed))
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ableton_create_drum_variation` no longer creates an identical B clip when density/fill/groove would change nothing.

- Compute the variation **before** duplicating the source slot
- Reject with `variation would not change the source clip` when there are no note changes/additions
- Align the bass no-op error message to the same wording

## Why

Density/fill previously duplicated and renamed a B clip even when `notesAdded == 0`, so A/B audition compared two identical clips.

## Test plan

- [x] `go test ./...`
- [ ] Density with `strength=0` → error, no new clip
- [ ] Fill on a sub-1-beat clip → error, no new clip
- [ ] Groove with `strength=0` → error, no new clip
- [ ] Normal density/fill/groove still create a distinct B clip

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

