### PR TITLE
fix: keep scene variation when fire fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_duplicate_clip_to` | Duplicate clip to another slot |
 | `ableton_set_clip_name` | Rename a clip |
 | `ableton_fire_scene` | Fire a scene |
-| `ableton_create_scene_energy_variation` | Duplicate a scene, then make a MIDI velocity lift or pullback for A/B comparison |
+| `ableton_create_scene_energy_variation` | Duplicate a scene, then make a MIDI velocity lift or pullback for A/B comparison (keeps B if fire fails) |
 | `ableton_get_device_parameters` / `ableton_set_device_parameter` | Device parameters |
 | `ableton_find_browser_item` | Search Live Browser (requires patch) |
 | `ableton_list_browser_folder` | List Browser roots or folder children (requires patch) |

--- a/internal/tools/ableton_scene_variations.go
+++ b/internal/tools/ableton_scene_variations.go
@@ -156,7 +156,11 @@ func createSceneEnergyVariation(client variationClient, input CreateSceneEnergyV
 	fired := false
 	if input.Fire {
 		if err := client.Send("/live/scene/fire", int32(targetSceneIndex)); err != nil {
-			return CreateSceneEnergyVariationOutput{}, discardSceneVariation(client, targetSceneIndex, fmt.Errorf("fire target scene: %w", err))
+			// B is already a valid variation; keep it for A/B comparison even if launch fails.
+			return CreateSceneEnergyVariationOutput{}, fmt.Errorf(
+				"fire target scene %d failed: %w (variation scene kept for A/B comparison)",
+				targetSceneIndex, err,
+			)
 		}
 		fired = true
 	}

--- a/internal/tools/ableton_scene_variations_test.go
+++ b/internal/tools/ableton_scene_variations_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -163,6 +164,50 @@ func TestCreateSceneEnergyVariationRemovesDuplicateOnFailure(t *testing.T) {
 	}
 	if !hasSceneVariationSend(client.calls, "/live/song/delete_scene") {
 		t.Error("expected duplicated scene cleanup")
+	}
+}
+
+func TestCreateSceneEnergyVariationKeepsSceneWhenFireFails(t *testing.T) {
+	t.Parallel()
+
+	client := &sceneVariationStub{
+		queries: map[string][][]interface{}{
+			"/live/song/get/num_scenes": {
+				{int32(2)},
+				{int32(3)},
+			},
+			"/live/clip_slot/get/has_clip": {
+				{int32(0), int32(0), true},
+			},
+			"/live/clip/get/notes": {
+				{
+					int32(0), int32(0),
+					int32(36), float32(0), float32(0.25), int32(100), false,
+				},
+			},
+		},
+		queryAt: map[string]int{},
+		sendErr: map[string]error{
+			"/live/scene/fire": errors.New("fire failed"),
+		},
+	}
+	_, err := createSceneEnergyVariation(client, CreateSceneEnergyVariationInput{
+		SourceSceneIndex: 0,
+		TrackIndices:     []int{0},
+		Variation:        "lift",
+		Fire:             true,
+	})
+	if err == nil {
+		t.Fatal("createSceneEnergyVariation() error = nil, want fire error")
+	}
+	if !hasSceneVariationSend(client.calls, "/live/song/duplicate_scene") {
+		t.Error("expected scene duplication before fire")
+	}
+	if hasSceneVariationSend(client.calls, "/live/song/delete_scene") {
+		t.Error("fire failure must not delete a completed variation scene")
+	}
+	if !strings.Contains(err.Error(), "fire target scene 1 failed") || !strings.Contains(err.Error(), "variation scene kept") {
+		t.Errorf("error = %q", err)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After a scene energy variation is fully built (notes + name), a launch failure no longer deletes the B scene.

- Mid-edit failures still call `discardSceneVariation` / `delete_scene`
- Fire failure returns an error that notes the variation scene was kept
- Matches drum/bass behavior: create succeeds even if optional fire fails

## Why

Throwing away a valid B on an OSC fire glitch broke the A/B loop the tool exists to support.

## Test plan

- [x] `go test ./...`
- [ ] Create a scene lift with `fire=true` under a forced fire failure → B remains, error mentions scene kept
- [ ] Name/note update failure still removes the incomplete duplicate

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

