### PR TITLE
feat: add create-then-audition A/B comparison recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Load Drum Racks / presets from Live's Browser (with the included AbletonOSC patch)
 - Browse Live Browser folders by path and load items onto tracks
 - Set up a drum track with kit + clip + pattern in one recipe
+- Compare a drum, bass, or scene A/B variation in one create→audition recipe
 - Humanize MIDI clips with microtiming, velocity variation, and swing
 - Create safe A/B drum variations that change only groove, density, or fills
 - Create safe A/B bass variations that change only octave, note length, or groove
@@ -251,6 +252,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_create_drum_variation` | Duplicate a drum clip into an empty slot and change groove, density, or fill for A/B comparison (rejects no-op changes) |
 | `ableton_create_bass_variation` | Duplicate a bass clip into an empty slot and change octave, note length, or groove for A/B comparison |
 | `ableton_audition_ab` | Alternate A/B clips or scenes for N bars, waiting on Live song time with 1-bar launch quantization |
+| `ableton_compare_ab_variation` | Create one drum/bass/scene variation, audition A→B, and return a preference prompt |
 | `ableton_record_variation_preference` | Save whether the source or variation matched your taste (drum, bass, scene, or mix) |
 | `ableton_get_taste_profile` | Summarize saved A/B choices and suggest the next comparison across all families |
 | `ableton_fire_clip_slot` / `ableton_stop_clip` | Fire/stop a clip |

--- a/internal/tools/ableton_compare_ab.go
+++ b/internal/tools/ableton_compare_ab.go
@@ -1,0 +1,225 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+type CompareABVariationInput struct {
+	Kind             string   `json:"kind" jsonschema:"description=What to compare: drum, bass, or scene"`
+	Variation        string   `json:"variation" jsonschema:"description=One-axis variation for the chosen kind"`
+	TrackIndex       *int     `json:"track_index,omitempty" jsonschema:"description=Required for drum/bass; omit for scene,minimum=0"`
+	SourceClipIndex  *int     `json:"source_clip_index,omitempty" jsonschema:"description=Required for drum/bass A clip,minimum=0"`
+	TargetClipIndex  *int     `json:"target_clip_index,omitempty" jsonschema:"description=Required for drum/bass empty B slot,minimum=0"`
+	SourceSceneIndex *int     `json:"source_scene_index,omitempty" jsonschema:"description=Required for scene A,minimum=0"`
+	TrackIndices     []int    `json:"track_indices,omitempty" jsonschema:"description=Required for scene: MIDI tracks to vary"`
+	Strength         *float64 `json:"strength,omitempty" jsonschema:"description=Drum/bass variation intensity 0-1,minimum=0,maximum=1"`
+	VelocityDelta    *int     `json:"velocity_delta,omitempty" jsonschema:"description=Scene velocity change (default 12),minimum=1,maximum=30"`
+	Seed             *int64   `json:"seed,omitempty" jsonschema:"description=Optional RNG seed for drum/bass groove or density"`
+	BarsPerVersion   *int     `json:"bars_per_version,omitempty" jsonschema:"description=Bars to hear each version (default 2),minimum=1,maximum=8"`
+	Cycles           *int     `json:"cycles,omitempty" jsonschema:"description=How many A→B cycles to play (default 1),minimum=1,maximum=4"`
+	StopAfter        bool     `json:"stop_after,omitempty" jsonschema:"description=Stop playback after the final B version"`
+}
+
+type CompareABVariationOutput struct {
+	Kind             string           `json:"kind"`
+	Variation        string           `json:"variation"`
+	TrackIndex       *int             `json:"track_index,omitempty"`
+	SourceIndex      int              `json:"source_index"`
+	VariationIndex   int              `json:"variation_index"`
+	NotesChanged     int              `json:"notes_changed,omitempty"`
+	NotesAdded       int              `json:"notes_added,omitempty"`
+	NotesSkipped     int              `json:"notes_skipped,omitempty"`
+	TracksChanged    []int            `json:"tracks_changed,omitempty"`
+	Seed             int64            `json:"seed,omitempty"`
+	Audition         AuditionABOutput `json:"audition"`
+	PreferencePrompt string           `json:"preference_prompt"`
+}
+
+type compareABClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+func NewAbletonCompareABVariation(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_compare_ab_variation",
+		"Ableton Live: create one drum/bass/scene A/B variation into an empty target, audition A then B, and return a preference prompt (does not record the choice)",
+		func(_ *ai.ToolContext, input CompareABVariationInput) (CompareABVariationOutput, error) {
+			return compareABVariation(client, input, time.Sleep)
+		},
+	)
+}
+
+func compareABVariation(client compareABClient, input CompareABVariationInput, sleep auditionSleeper) (CompareABVariationOutput, error) {
+	kind := strings.ToLower(strings.TrimSpace(input.Kind))
+	variation := strings.ToLower(strings.TrimSpace(input.Variation))
+	if variation == "" {
+		return CompareABVariationOutput{}, errors.New("variation is required")
+	}
+
+	var (
+		out           CompareABVariationOutput
+		auditionInput AuditionABInput
+		err           error
+	)
+	out.Kind = kind
+	out.Variation = variation
+
+	switch kind {
+	case "drum":
+		out, auditionInput, err = createDrumCompare(client, input, variation)
+	case "bass":
+		out, auditionInput, err = createBassCompare(client, input, variation)
+	case "scene":
+		out, auditionInput, err = createSceneCompare(client, input, variation)
+	default:
+		return CompareABVariationOutput{}, errors.New("kind must be drum, bass, or scene")
+	}
+	if err != nil {
+		return CompareABVariationOutput{}, err
+	}
+
+	auditionInput.BarsPerVersion = input.BarsPerVersion
+	auditionInput.Cycles = input.Cycles
+	auditionInput.StopAfter = input.StopAfter
+	auditionInput.Instrument = kind
+	auditionInput.Variation = variation
+
+	audition, err := auditionAB(client, auditionInput, sleep)
+	if err != nil {
+		return CompareABVariationOutput{}, fmt.Errorf("audition after %s variation: %w", kind, err)
+	}
+	out.Audition = audition
+	out.PreferencePrompt = audition.PreferencePrompt
+	return out, nil
+}
+
+func createDrumCompare(client compareABClient, input CompareABVariationInput, variation string) (CompareABVariationOutput, AuditionABInput, error) {
+	trackIndex, sourceClip, targetClip, err := requireClipCompareSlots(input)
+	if err != nil {
+		return CompareABVariationOutput{}, AuditionABInput{}, err
+	}
+	if input.SourceSceneIndex != nil || len(input.TrackIndices) > 0 || input.VelocityDelta != nil {
+		return CompareABVariationOutput{}, AuditionABInput{}, errors.New("scene fields must be omitted for drum comparisons")
+	}
+	created, err := createDrumVariation(client, CreateDrumVariationInput{
+		TrackIndex:      trackIndex,
+		SourceClipIndex: sourceClip,
+		TargetClipIndex: targetClip,
+		Variation:       variation,
+		Strength:        input.Strength,
+		Seed:            input.Seed,
+		Fire:            false,
+	})
+	if err != nil {
+		return CompareABVariationOutput{}, AuditionABInput{}, err
+	}
+	track := created.TrackIndex
+	return CompareABVariationOutput{
+			Kind:           "drum",
+			Variation:      created.Variation,
+			TrackIndex:     &track,
+			SourceIndex:    created.SourceClipIndex,
+			VariationIndex: created.TargetClipIndex,
+			NotesChanged:   created.NotesChanged,
+			NotesAdded:     created.NotesAdded,
+			Seed:           created.Seed,
+		}, AuditionABInput{
+			TargetType:     "clip",
+			TrackIndex:     &track,
+			SourceIndex:    created.SourceClipIndex,
+			VariationIndex: created.TargetClipIndex,
+		}, nil
+}
+
+func createBassCompare(client compareABClient, input CompareABVariationInput, variation string) (CompareABVariationOutput, AuditionABInput, error) {
+	trackIndex, sourceClip, targetClip, err := requireClipCompareSlots(input)
+	if err != nil {
+		return CompareABVariationOutput{}, AuditionABInput{}, err
+	}
+	if input.SourceSceneIndex != nil || len(input.TrackIndices) > 0 || input.VelocityDelta != nil {
+		return CompareABVariationOutput{}, AuditionABInput{}, errors.New("scene fields must be omitted for bass comparisons")
+	}
+	created, err := createBassVariation(client, CreateBassVariationInput{
+		TrackIndex:      trackIndex,
+		SourceClipIndex: sourceClip,
+		TargetClipIndex: targetClip,
+		Variation:       variation,
+		Strength:        input.Strength,
+		Seed:            input.Seed,
+		Fire:            false,
+	})
+	if err != nil {
+		return CompareABVariationOutput{}, AuditionABInput{}, err
+	}
+	track := created.TrackIndex
+	return CompareABVariationOutput{
+			Kind:           "bass",
+			Variation:      created.Variation,
+			TrackIndex:     &track,
+			SourceIndex:    created.SourceClipIndex,
+			VariationIndex: created.TargetClipIndex,
+			NotesChanged:   created.NotesChanged,
+			NotesSkipped:   created.NotesSkipped,
+			Seed:           created.Seed,
+		}, AuditionABInput{
+			TargetType:     "clip",
+			TrackIndex:     &track,
+			SourceIndex:    created.SourceClipIndex,
+			VariationIndex: created.TargetClipIndex,
+		}, nil
+}
+
+func createSceneCompare(client compareABClient, input CompareABVariationInput, variation string) (CompareABVariationOutput, AuditionABInput, error) {
+	if input.SourceSceneIndex == nil {
+		return CompareABVariationOutput{}, AuditionABInput{}, errors.New("source_scene_index is required for scene comparisons")
+	}
+	if input.TrackIndex != nil || input.SourceClipIndex != nil || input.TargetClipIndex != nil {
+		return CompareABVariationOutput{}, AuditionABInput{}, errors.New("clip fields must be omitted for scene comparisons")
+	}
+	if input.Strength != nil || input.Seed != nil {
+		return CompareABVariationOutput{}, AuditionABInput{}, errors.New("strength and seed must be omitted for scene comparisons")
+	}
+	created, err := createSceneEnergyVariation(client, CreateSceneEnergyVariationInput{
+		SourceSceneIndex: *input.SourceSceneIndex,
+		TrackIndices:     input.TrackIndices,
+		Variation:        variation,
+		VelocityDelta:    input.VelocityDelta,
+		Fire:             false,
+	})
+	if err != nil {
+		return CompareABVariationOutput{}, AuditionABInput{}, err
+	}
+	return CompareABVariationOutput{
+			Kind:           "scene",
+			Variation:      created.Variation,
+			SourceIndex:    created.SourceSceneIndex,
+			VariationIndex: created.TargetSceneIndex,
+			NotesChanged:   created.NotesChanged,
+			TracksChanged:  created.TracksChanged,
+		}, AuditionABInput{
+			TargetType:     "scene",
+			SourceIndex:    created.SourceSceneIndex,
+			VariationIndex: created.TargetSceneIndex,
+		}, nil
+}
+
+func requireClipCompareSlots(input CompareABVariationInput) (trackIndex, sourceClip, targetClip int, err error) {
+	if input.TrackIndex == nil {
+		return 0, 0, 0, errors.New("track_index is required for clip comparisons")
+	}
+	if input.SourceClipIndex == nil {
+		return 0, 0, 0, errors.New("source_clip_index is required for clip comparisons")
+	}
+	if input.TargetClipIndex == nil {
+		return 0, 0, 0, errors.New("target_clip_index is required for clip comparisons")
+	}
+	return *input.TrackIndex, *input.SourceClipIndex, *input.TargetClipIndex, nil
+}

--- a/internal/tools/ableton_compare_ab_test.go
+++ b/internal/tools/ableton_compare_ab_test.go
@@ -1,0 +1,177 @@
+package tools
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type compareABCall struct {
+	address string
+	args    []interface{}
+}
+
+type compareABStub struct {
+	hasClip      bool
+	notes        []interface{}
+	clipLength   float64
+	tempo        float64
+	signature    int
+	isPlaying    bool
+	quantization int
+	songTime     float64
+	calls        []compareABCall
+	sendErr      map[string]error
+}
+
+func (s *compareABStub) Query(address string, args ...interface{}) ([]interface{}, error) {
+	switch address {
+	case "/live/clip_slot/get/has_clip":
+		return []interface{}{int32(0), int32(1), s.hasClip}, nil
+	case "/live/clip/get/notes":
+		return s.notes, nil
+	case "/live/clip/get/length":
+		return []interface{}{int32(0), int32(0), float32(s.clipLength)}, nil
+	case "/live/song/get/tempo":
+		return []interface{}{float32(s.tempo)}, nil
+	case "/live/song/get/signature_numerator":
+		return []interface{}{int32(s.signature)}, nil
+	case "/live/song/get/is_playing":
+		if s.isPlaying {
+			return []interface{}{int32(1)}, nil
+		}
+		return []interface{}{int32(0)}, nil
+	case "/live/song/get/clip_trigger_quantization":
+		return []interface{}{int32(s.quantization)}, nil
+	case "/live/song/get/current_song_time":
+		return []interface{}{float32(s.songTime)}, nil
+	default:
+		return nil, errors.New("unexpected query: " + address)
+	}
+}
+
+func (s *compareABStub) Send(address string, args ...interface{}) error {
+	if err := s.sendErr[address]; err != nil {
+		return err
+	}
+	s.calls = append(s.calls, compareABCall{address: address, args: append([]interface{}{}, args...)})
+	if address == "/live/song/start_playing" {
+		s.isPlaying = true
+	}
+	if address == "/live/song/set/clip_trigger_quantization" && len(args) > 0 {
+		if q, ok := args[0].(int32); ok {
+			s.quantization = int(q)
+		}
+	}
+	return nil
+}
+
+func TestCompareABVariationDrum(t *testing.T) {
+	t.Parallel()
+
+	track := 0
+	source := 0
+	target := 1
+	bars := 1
+	strength := 1.0
+	seed := int64(1)
+	client := &compareABStub{
+		hasClip:    false,
+		notes:      []interface{}{int32(0), int32(0), int32(36), float32(0), float32(0.25), int32(100), false},
+		clipLength: 2,
+		tempo:      120,
+		signature:  4,
+		isPlaying:  true,
+		songTime:   0,
+	}
+
+	got, err := compareABVariation(client, CompareABVariationInput{
+		Kind:            "drum",
+		Variation:       "density",
+		TrackIndex:      &track,
+		SourceClipIndex: &source,
+		TargetClipIndex: &target,
+		Strength:        &strength,
+		Seed:            &seed,
+		BarsPerVersion:  &bars,
+	}, func(d time.Duration) {
+		client.songTime += d.Seconds() * client.tempo / 60
+	})
+	if err != nil {
+		t.Fatalf("compareABVariation() error = %v", err)
+	}
+	if got.Kind != "drum" || got.Variation != "density" || got.NotesAdded == 0 {
+		t.Errorf("result = %#v", got)
+	}
+	if got.SourceIndex != 0 || got.VariationIndex != 1 {
+		t.Errorf("indices = %#v", got)
+	}
+	if !strings.Contains(got.PreferencePrompt, "instrument=drum variation=density") {
+		t.Errorf("preference_prompt = %q", got.PreferencePrompt)
+	}
+	if !hasCompareSend(client.calls, "/live/clip_slot/duplicate_clip_to") {
+		t.Error("expected variation duplicate")
+	}
+	if countCompareSend(client.calls, "/live/clip_slot/fire") < 2 {
+		t.Error("expected audition to fire A and B")
+	}
+	// Create must not fire B before audition owns launching.
+	dupIdx := indexCompareSend(client.calls, "/live/clip_slot/duplicate_clip_to")
+	firstFire := indexCompareSend(client.calls, "/live/clip_slot/fire")
+	if dupIdx < 0 || firstFire < 0 || firstFire < dupIdx {
+		t.Errorf("fire should happen after create; dup=%d fire=%d", dupIdx, firstFire)
+	}
+}
+
+func TestCompareABVariationRejectsClipFieldsForScene(t *testing.T) {
+	t.Parallel()
+
+	track := 0
+	scene := 1
+	_, err := compareABVariation(&compareABStub{}, CompareABVariationInput{
+		Kind:             "scene",
+		Variation:        "lift",
+		TrackIndex:       &track,
+		SourceSceneIndex: &scene,
+		TrackIndices:     []int{0},
+	}, time.Sleep)
+	if err == nil {
+		t.Fatal("expected clip-field rejection for scene kind")
+	}
+}
+
+func TestCompareABVariationRequiresClipSlots(t *testing.T) {
+	t.Parallel()
+
+	_, err := compareABVariation(&compareABStub{}, CompareABVariationInput{
+		Kind:      "bass",
+		Variation: "octave_up",
+	}, time.Sleep)
+	if err == nil {
+		t.Fatal("expected missing clip slot error")
+	}
+}
+
+func hasCompareSend(calls []compareABCall, address string) bool {
+	return indexCompareSend(calls, address) >= 0
+}
+
+func indexCompareSend(calls []compareABCall, address string) int {
+	for i, call := range calls {
+		if call.address == address {
+			return i
+		}
+	}
+	return -1
+}
+
+func countCompareSend(calls []compareABCall, address string) int {
+	n := 0
+	for _, call := range calls {
+		if call.address == address {
+			n++
+		}
+	}
+	return n
+}

--- a/main.go
+++ b/main.go
@@ -126,6 +126,7 @@ func main() {
 
 		// Recipes
 		tools.NewAbletonSetupDrumTrack(g, ableton),
+		tools.NewAbletonCompareABVariation(g, ableton),
 
 		// A/B comparison feedback
 		tools.NewAbletonRecordVariationPreference(g, tasteStore),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `ableton_compare_ab_variation`, a thin recipe that wires the existing comparison loop:

1. Create one **drum / bass / scene** variation into an empty target (`fire=false`)
2. Audition A→B on Live song time
3. Return a concrete `preference_prompt` for `ableton_record_variation_preference`

It does **not** record taste preferences (that still needs a human choice) and does not cover mix snapshots.

## Why

Agents were chaining many low-level tools to run one fair comparison. This keeps the building blocks and offers one entry point for the common path.

## Test plan

- [x] `go test ./...`
- [ ] Drum density compare → B clip created, A then B fire, prompt names `instrument=drum variation=density`
- [ ] Scene fields rejected on drum/bass kinds; clip fields rejected on scene kind
- [ ] After listening, record with `ableton_record_variation_preference` using the returned prompt

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

