### PR TITLE
docs: point A/B workflows at compare_ab_variation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,12 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Load Drum Racks / presets from Live's Browser (with the included AbletonOSC patch)
 - Browse Live Browser folders by path and load items onto tracks
 - Set up a drum track with kit + clip + pattern in one recipe
-- Compare a drum, bass, or scene A/B variation in one create→audition recipe
+- Run drum / bass / scene A/B comparisons through one create→audition recipe, then save taste locally
+- Compare mix balance with snapshots you can restore
 - Humanize MIDI clips with microtiming, velocity variation, and swing
-- Create safe A/B drum variations that change only groove, density, or fills
-- Create safe A/B bass variations that change only octave, note length, or groove
-- Save A/B choices locally (drum, bass, scene, mix) to build a taste profile and guide the next comparison
-- Compare small mix-balance hypotheses, then restore the original volume snapshot
-- Duplicate a scene and compare an energy lift or pullback on selected MIDI tracks
-- Audition A/B clips or scenes automatically on Live song time (1-bar quantization)
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
-- Fire clip slots
-- Send raw OSC messages for advanced control
+- Fire clip slots and send raw OSC for advanced control
 
 ## Browser loading (AbletonOSC patch)
 
@@ -225,6 +219,24 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 > **Note**: Replace `/opt/homebrew/bin/ableton-osc-mcp` with your actual binary path if different.
 
+## A/B comparison workflow
+
+For the usual drum, bass, or scene listen-and-choose loop, start here:
+
+1. Optional: `ableton_get_taste_profile` — see what to try next
+2. `ableton_compare_ab_variation` — create one-axis B, audition A→B, get a preference prompt
+3. Ask the listener which they prefer, then `ableton_record_variation_preference`
+
+Keep the lower-level tools for special cases:
+
+| When you need… | Use |
+|---|---|
+| Create B without auditioning yet | `ableton_create_drum_variation` / `ableton_create_bass_variation` / `ableton_create_scene_energy_variation` |
+| Audition clips/scenes that already exist | `ableton_audition_ab` |
+| Mix balance A/B (volume deltas + restore) | `ableton_apply_mix_variation` → listen → record preference → `ableton_restore_mix_snapshot` |
+
+Mix is intentionally outside `ableton_compare_ab_variation` because it uses snapshots, not clip/scene slots.
+
 ## Available Tools
 
 | Tool | Description |
@@ -249,17 +261,17 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_create_clip` | Create a clip in a slot |
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
-| `ableton_create_drum_variation` | Duplicate a drum clip into an empty slot and change groove, density, or fill for A/B comparison (rejects no-op changes) |
-| `ableton_create_bass_variation` | Duplicate a bass clip into an empty slot and change octave, note length, or groove for A/B comparison |
-| `ableton_audition_ab` | Alternate A/B clips or scenes for N bars, waiting on Live song time with 1-bar launch quantization |
-| `ableton_compare_ab_variation` | Create one drum/bass/scene variation, audition A→B, and return a preference prompt |
+| `ableton_compare_ab_variation` | Preferred A/B entry: create one drum/bass/scene variation, audition A→B, return a preference prompt |
+| `ableton_create_drum_variation` | Create-only drum A/B variation (groove / density / fill); use when you do not want audition yet |
+| `ableton_create_bass_variation` | Create-only bass A/B variation (octave / staccato / groove) |
+| `ableton_create_scene_energy_variation` | Create-only scene energy variation (lift / pullback); keeps B if fire fails |
+| `ableton_audition_ab` | Audition existing A/B clips or scenes on Live song time |
 | `ableton_record_variation_preference` | Save whether the source or variation matched your taste (drum, bass, scene, or mix) |
-| `ableton_get_taste_profile` | Summarize saved A/B choices and suggest the next comparison across all families |
+| `ableton_get_taste_profile` | Summarize saved A/B choices and suggest the next comparison |
 | `ableton_fire_clip_slot` / `ableton_stop_clip` | Fire/stop a clip |
 | `ableton_duplicate_clip_to` | Duplicate clip to another slot |
 | `ableton_set_clip_name` | Rename a clip |
 | `ableton_fire_scene` | Fire a scene |
-| `ableton_create_scene_energy_variation` | Duplicate a scene, then make a MIDI velocity lift or pullback for A/B comparison (keeps B if fire fails) |
 | `ableton_get_device_parameters` / `ableton_set_device_parameter` | Device parameters |
 | `ableton_find_browser_item` | Search Live Browser (requires patch) |
 | `ableton_list_browser_folder` | List Browser roots or folder children (requires patch) |
@@ -268,8 +280,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `ableton_load_device_preset` | Hotswap a preset onto a device |
 | `ableton_get_track_meter` | Track output meter levels |
 | `ableton_autogain_tracks` | Iteratively adjust track volumes toward a target meter level |
-| `ableton_capture_mix_snapshot` / `ableton_restore_mix_snapshot` | Capture and restore track volumes for safe A/B mix comparison |
-| `ableton_apply_mix_variation` | Apply small B-version volume changes and return the A snapshot |
+| `ableton_apply_mix_variation` | Mix A/B entry: apply small B volume changes and return the A snapshot |
+| `ableton_capture_mix_snapshot` / `ableton_restore_mix_snapshot` | Capture or restore track volumes for mix A/B |
 | `ableton_get_master_meter` / `ableton_get_master_volume` / `ableton_set_master_volume` | Master meter/volume (requires master patch) |
 | `ableton_get_master_devices` / `ableton_get_master_device_parameters` / `ableton_set_master_device_parameter` | Master devices (requires master patch) |
 | `ableton_load_on_master` | Load Browser item onto master (requires browser+master patch) |
@@ -285,13 +297,11 @@ Once configured, you can ask your AI assistant:
 - "Set the tempo to 140 BPM"
 - "Create a MIDI track, load Street Kit, and add a 4-bar clip"
 - "Set up a Street Kit drum track with a four-on-floor pattern"
+- "Compare a drum groove variation of clip 0 into empty slot 1, then ask which I prefer"
+- "Check my taste profile and run the least-tried bass comparison next"
+- "I prefer the variation; save that and suggest what to compare next"
+- "Create a mix B with the bass 0.05 lower, let me listen, then restore A"
 - "Humanize the drum clip with a bit of swing"
-- "Create a groove variation of clip 0 in empty slot 1 so I can compare them"
-- "Create an octave-up variation of the bass clip in empty slot 1"
-- "I prefer the drum groove variation; save that choice and suggest what to compare next"
-- "Audition drum clips 0 and 1 on track 0 for two bars each, twice"
-- "Create a mix B version with the bass 0.05 lower; keep the returned snapshot so I can compare and restore A"
-- "Create an energy lift of scene 0 for the drum and bass MIDI tracks so I can compare the sections"
 - "Autogain the drum and bass tracks while the beat is playing"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"

--- a/internal/tools/ableton_audition.go
+++ b/internal/tools/ableton_audition.go
@@ -63,7 +63,7 @@ type auditionSleeper func(time.Duration)
 
 func NewAbletonAuditionAB(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	return genkit.DefineTool(g, "ableton_audition_ab",
-		"Ableton Live: audition an A and B clip or scene in alternating bar-length sections synced to song time, then prompt for a preference",
+		"Ableton Live: audition existing A/B clips or scenes on song time and prompt for a preference — prefer ableton_compare_ab_variation when the B variation still needs to be created",
 		func(_ *ai.ToolContext, input AuditionABInput) (AuditionABOutput, error) {
 			return auditionAB(client, input, time.Sleep)
 		},

--- a/internal/tools/ableton_bass_variations.go
+++ b/internal/tools/ableton_bass_variations.go
@@ -45,7 +45,7 @@ type bassVariationOptions struct {
 
 func NewAbletonCreateBassVariation(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	return genkit.DefineTool(g, "ableton_create_bass_variation",
-		"Ableton Live: duplicate a bass MIDI clip into an empty slot and make one A/B variation: octave, staccato, or groove",
+		"Ableton Live: create only a bass A/B variation (octave, staccato, or groove) in an empty slot — prefer ableton_compare_ab_variation when you also want to audition",
 		func(_ *ai.ToolContext, input CreateBassVariationInput) (CreateBassVariationOutput, error) {
 			return createBassVariation(client, input)
 		},

--- a/internal/tools/ableton_compare_ab.go
+++ b/internal/tools/ableton_compare_ab.go
@@ -50,7 +50,7 @@ type compareABClient interface {
 
 func NewAbletonCompareABVariation(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	return genkit.DefineTool(g, "ableton_compare_ab_variation",
-		"Ableton Live: create one drum/bass/scene A/B variation into an empty target, audition A then B, and return a preference prompt (does not record the choice)",
+		"Ableton Live: preferred entry for drum/bass/scene A/B — create one variation into an empty target, audition A then B, and return a preference prompt (does not record the choice; use ableton_record_variation_preference after the listener chooses)",
 		func(_ *ai.ToolContext, input CompareABVariationInput) (CompareABVariationOutput, error) {
 			return compareABVariation(client, input, time.Sleep)
 		},

--- a/internal/tools/ableton_mix_ab.go
+++ b/internal/tools/ableton_mix_ab.go
@@ -61,7 +61,7 @@ func NewAbletonCaptureMixSnapshot(g *genkit.Genkit, client *abletonosc.Client) a
 
 func NewAbletonApplyMixVariation(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	return genkit.DefineTool(g, "ableton_apply_mix_variation",
-		"Ableton Live: apply small track-volume changes for a B mix version and return the A snapshot for restoration",
+		"Ableton Live: mix A/B entry — apply small track-volume changes for B and return the A snapshot (not covered by ableton_compare_ab_variation; restore with ableton_restore_mix_snapshot)",
 		func(_ *ai.ToolContext, input ApplyMixVariationInput) (ApplyMixVariationOutput, error) {
 			return applyMixVariation(client, input)
 		},

--- a/internal/tools/ableton_scene_variations.go
+++ b/internal/tools/ableton_scene_variations.go
@@ -40,7 +40,7 @@ type sceneVariationTrack struct {
 
 func NewAbletonCreateSceneEnergyVariation(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	return genkit.DefineTool(g, "ableton_create_scene_energy_variation",
-		"Ableton Live: duplicate a scene and create an A/B energy lift or pullback by changing selected MIDI-track velocities",
+		"Ableton Live: create only a scene energy A/B variation (lift or pullback) — prefer ableton_compare_ab_variation when you also want to audition",
 		func(_ *ai.ToolContext, input CreateSceneEnergyVariationInput) (CreateSceneEnergyVariationOutput, error) {
 			return createSceneEnergyVariation(client, input)
 		},

--- a/internal/tools/ableton_taste.go
+++ b/internal/tools/ableton_taste.go
@@ -51,7 +51,7 @@ var tasteInstrumentOrder = []string{"bass", "drum", "mix", "scene"}
 
 func NewAbletonRecordVariationPreference(g *genkit.Genkit, store tasteStore) ai.Tool {
 	return genkit.DefineTool(g, "ableton_record_variation_preference",
-		"Ableton Live: record whether an A/B drum, bass, scene, or mix variation matched your taste",
+		"Ableton Live: after an A/B listen, record whether source or variation matched your taste (drum, bass, scene, or mix) — usually follows ableton_compare_ab_variation or a mix compare",
 		func(_ *ai.ToolContext, input RecordVariationPreferenceInput) (TasteProfileOutput, error) {
 			preference, err := validateTastePreference(input)
 			if err != nil {
@@ -75,7 +75,7 @@ func NewAbletonRecordVariationPreference(g *genkit.Genkit, store tasteStore) ai.
 
 func NewAbletonGetTasteProfile(g *genkit.Genkit, store tasteStore) ai.Tool {
 	return genkit.DefineTool(g, "ableton_get_taste_profile",
-		"Ableton Live: summarize saved A/B variation preferences and suggest the next comparison",
+		"Ableton Live: summarize saved A/B preferences and suggest the next comparison — use before choosing what to run with ableton_compare_ab_variation",
 		func(_ *ai.ToolContext, _ EmptyInput) (TasteProfileOutput, error) {
 			profile, err := store.Load()
 			if err != nil {

--- a/internal/tools/ableton_variations.go
+++ b/internal/tools/ableton_variations.go
@@ -58,7 +58,7 @@ type variationClient interface {
 
 func NewAbletonCreateDrumVariation(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 	return genkit.DefineTool(g, "ableton_create_drum_variation",
-		"Ableton Live: duplicate a drum clip into an empty slot and make one A/B variation: groove, density, or fill",
+		"Ableton Live: create only a drum A/B variation (groove, density, or fill) in an empty slot — prefer ableton_compare_ab_variation when you also want to audition",
 		func(_ *ai.ToolContext, input CreateDrumVariationInput) (CreateDrumVariationOutput, error) {
 			return createDrumVariation(client, input)
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Light entry-point cleanup — no tools removed.

- README: add an **A/B comparison workflow** section that starts at `ableton_compare_ab_variation`
- README: tighten Features / Examples / tool table around that path; keep create-only and audition as special cases
- Tool descriptions: nudge create / audition / taste / mix toward the preferred entry without deleting building blocks

## Why

After shipping the compare recipe, agents still see many peer A/B tools. Guidance first is cheaper and safer than deleting APIs.

## Test plan

- [x] `go test ./...`
- [ ] Skim README “A/B comparison workflow” — path is clear for drum/bass/scene vs mix
- [ ] Confirm create/audition tool descriptions mention when to prefer `ableton_compare_ab_variation`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

