### PR TITLE
feat: search and load local Splice samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - List devices on a track
 - Load Drum Racks / presets from Live's Browser (with the included AbletonOSC patch)
 - Browse Live Browser folders by path and load items onto tracks
+- Search the local synced Splice library and load samples onto audio tracks (Live 12.0.5+)
 - Set up a drum track with kit + clip + pattern in one recipe
 - Run drum / bass / scene A/B comparisons through one create→audition recipe, then save taste locally
 - Compare mix balance with snapshots you can restore
@@ -34,6 +35,7 @@ This repo ships a small Remote Script patch under [`remote-script/`](remote-scri
 - `/live/browser/load_at_path`
 - `/live/track/load/browser_item`
 - `/live/device/load/preset`
+- `/live/clip_slot/create_audio_clip` (local audio file → session slot; Live 12.0.5+)
 
 Install steps: see [remote-script/README.md](remote-script/README.md).
 After applying the patch, **restart Ableton Live** (a full restart is required the first time; `/live/api/reload` alone is not enough).
@@ -278,6 +280,9 @@ Mix is intentionally outside `ableton_compare_ab_variation` because it uses snap
 | `ableton_load_browser_item` | Load Drum Rack / instrument onto a track by name |
 | `ableton_load_browser_path` | Load Browser item onto a track by exact path (requires patch) |
 | `ableton_load_device_preset` | Hotswap a preset onto a device |
+| `ableton_get_splice_library` | Locate the local Splice content folder (synced downloads only) |
+| `ableton_search_splice_samples` | Search audio files under the local Splice library |
+| `ableton_load_splice_sample` | Load a local Splice audio file into an empty audio-track clip slot (Live 12.0.5+, patch) |
 | `ableton_get_track_meter` | Track output meter levels |
 | `ableton_autogain_tracks` | Iteratively adjust track volumes toward a target meter level |
 | `ableton_apply_mix_variation` | Mix A/B entry: apply small B volume changes and return the A snapshot |
@@ -303,6 +308,7 @@ Once configured, you can ask your AI assistant:
 - "Create a mix B with the bass 0.05 lower, let me listen, then restore A"
 - "Humanize the drum clip with a bit of swing"
 - "Autogain the drum and bass tracks while the beat is playing"
+- "Search my local Splice library for a punchy kick and load one onto an audio track"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"
 - "Add a kick drum pattern on beats 1, 2, 3, 4"
@@ -342,8 +348,20 @@ In most cases, the default settings work fine. Change these only if:
 | `ABLETON_OSC_CLIENT_PORT` | `11001` | Port for receiving replies |
 | `ABLETON_OSC_TIMEOUT_MS` | `500` | Query timeout in milliseconds |
 | `ABLETON_OSC_TASTE_PROFILE_PATH` | OS user config directory / `ableton-osc-mcp/taste-profile.json` | Local path for saved A/B preferences |
+| `ABLETON_OSC_SPLICE_PATH` | _(auto: `~/Splice` or `~/Documents/Splice`)_ | Local Splice content folder for sample search/load |
 
 </details>
+
+## Splice samples (local library)
+
+This does **not** call the Splice cloud API or download new sounds. It uses samples already synced by the Splice desktop app.
+
+1. Sync/download sounds in the Splice app
+2. Optional: set `ABLETON_OSC_SPLICE_PATH` if auto-detect misses your folder
+3. Re-copy `remote-script/abletonosc/browser.py` into AbletonOSC (adds `/live/clip_slot/create_audio_clip`) and restart Live
+4. Use `ableton_search_splice_samples` → `ableton_load_splice_sample` on an **audio** track empty slot
+
+Loading into a clip slot needs **Ableton Live 12.0.5+** (`ClipSlot.create_audio_clip`).
 
 ## Contributing
 

--- a/internal/abletonosc/convert.go
+++ b/internal/abletonosc/convert.go
@@ -54,3 +54,12 @@ func AsBool(v interface{}) (bool, error) {
 		return false, fmt.Errorf("cannot convert %T to bool", v)
 	}
 }
+
+func AsString(v interface{}) (string, error) {
+	switch t := v.(type) {
+	case string:
+		return t, nil
+	default:
+		return "", fmt.Errorf("cannot convert %T to string", v)
+	}
+}

--- a/internal/abletonosc/convert_test.go
+++ b/internal/abletonosc/convert_test.go
@@ -63,6 +63,16 @@ func TestAsInt(t *testing.T) {
 	}
 }
 
+func TestAsString(t *testing.T) {
+	got, err := AsString("hello")
+	if err != nil || got != "hello" {
+		t.Fatalf("AsString(string) = %q, %v", got, err)
+	}
+	if _, err := AsString(1); err == nil {
+		t.Fatal("AsString(int) should fail")
+	}
+}
+
 func TestAsBool(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	AbletonClientPort int
 	Timeout           time.Duration
 	TasteProfilePath  string
+	SplicePath        string // optional; empty means auto-detect common Splice folders
 }
 
 // Load reads configuration from environment variables with defaults.
@@ -36,6 +37,7 @@ func Load() Config {
 		AbletonClientPort: envInt("ABLETON_OSC_CLIENT_PORT", defaultAbletonClientPort),
 		Timeout:           envDurationMs("ABLETON_OSC_TIMEOUT_MS", defaultTimeoutMs),
 		TasteProfilePath:  envString("ABLETON_OSC_TASTE_PROFILE_PATH", defaultTasteProfilePath()),
+		SplicePath:        strings.TrimSpace(os.Getenv("ABLETON_OSC_SPLICE_PATH")),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestLoadDefaults(t *testing.T) {
 	// Clear any env vars that might be set.
-	for _, key := range []string{"ABLETON_OSC_HOST", "ABLETON_OSC_PORT", "ABLETON_OSC_CLIENT_PORT", "ABLETON_OSC_TIMEOUT_MS", "ABLETON_OSC_TASTE_PROFILE_PATH"} {
+	for _, key := range []string{"ABLETON_OSC_HOST", "ABLETON_OSC_PORT", "ABLETON_OSC_CLIENT_PORT", "ABLETON_OSC_TIMEOUT_MS", "ABLETON_OSC_TASTE_PROFILE_PATH", "ABLETON_OSC_SPLICE_PATH"} {
 		t.Setenv(key, "")
 	}
 
@@ -28,6 +28,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.TasteProfilePath == "" {
 		t.Error("TasteProfilePath is empty")
 	}
+	if cfg.SplicePath != "" {
+		t.Errorf("SplicePath = %q, want empty (auto-detect)", cfg.SplicePath)
+	}
 }
 
 func TestLoadFromEnv(t *testing.T) {
@@ -36,6 +39,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("ABLETON_OSC_CLIENT_PORT", "12001")
 	t.Setenv("ABLETON_OSC_TIMEOUT_MS", "1000")
 	t.Setenv("ABLETON_OSC_TASTE_PROFILE_PATH", "/tmp/taste-profile.json")
+	t.Setenv("ABLETON_OSC_SPLICE_PATH", "/tmp/Splice")
 
 	cfg := Load()
 
@@ -53,6 +57,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.TasteProfilePath != "/tmp/taste-profile.json" {
 		t.Errorf("TasteProfilePath = %q, want custom path", cfg.TasteProfilePath)
+	}
+	if cfg.SplicePath != "/tmp/Splice" {
+		t.Errorf("SplicePath = %q, want /tmp/Splice", cfg.SplicePath)
 	}
 }
 

--- a/internal/splice/library.go
+++ b/internal/splice/library.go
@@ -1,0 +1,166 @@
+package splice
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	defaultMaxResults = 20
+	maxMaxResults     = 50
+	maxWalkFiles      = 5000
+)
+
+var audioExtensions = map[string]bool{
+	".wav":  true,
+	".aif":  true,
+	".aiff": true,
+	".flac": true,
+	".mp3":  true,
+	".ogg":  true,
+}
+
+type Sample struct {
+	Name         string `json:"name"`
+	RelativePath string `json:"relative_path"`
+	AbsolutePath string `json:"absolute_path"`
+}
+
+type Library struct {
+	Path   string
+	Source string // env, auto, or missing
+}
+
+func Resolve(configured string) (Library, error) {
+	configured = strings.TrimSpace(configured)
+	if configured != "" {
+		abs, err := filepath.Abs(expandHome(configured))
+		if err != nil {
+			return Library{}, fmt.Errorf("resolve splice path: %w", err)
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			return Library{Path: abs, Source: "env"}, fmt.Errorf("splice path from ABLETON_OSC_SPLICE_PATH: %w", err)
+		}
+		if !info.IsDir() {
+			return Library{Path: abs, Source: "env"}, errors.New("ABLETON_OSC_SPLICE_PATH must be a directory")
+		}
+		return Library{Path: abs, Source: "env"}, nil
+	}
+
+	for _, candidate := range defaultCandidates() {
+		info, err := os.Stat(candidate)
+		if err == nil && info.IsDir() {
+			return Library{Path: candidate, Source: "auto"}, nil
+		}
+	}
+	return Library{Source: "missing"}, errors.New("splice library not found; set ABLETON_OSC_SPLICE_PATH or install/sync the Splice desktop app")
+}
+
+func Search(root, query string, maxResults int) ([]Sample, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, errors.New("splice library path is required")
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("splice library: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, errors.New("splice library path must be a directory")
+	}
+	if maxResults <= 0 {
+		maxResults = defaultMaxResults
+	}
+	if maxResults > maxMaxResults {
+		maxResults = maxMaxResults
+	}
+	query = strings.ToLower(strings.TrimSpace(query))
+
+	var (
+		matches []Sample
+		seen    int
+	)
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if strings.HasPrefix(name, ".") || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		seen++
+		if seen > maxWalkFiles {
+			return errors.New("splice library walk limit reached; narrow the query or set a deeper ABLETON_OSC_SPLICE_PATH")
+		}
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if !audioExtensions[ext] {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		base := d.Name()
+		if query != "" {
+			haystack := strings.ToLower(rel + " " + strings.TrimSuffix(base, ext))
+			if !strings.Contains(haystack, query) {
+				return nil
+			}
+		}
+		abs, absErr := filepath.Abs(path)
+		if absErr != nil {
+			abs = path
+		}
+		matches = append(matches, Sample{
+			Name:         base,
+			RelativePath: filepath.ToSlash(rel),
+			AbsolutePath: abs,
+		})
+		if len(matches) >= maxResults {
+			return errStopWalk
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errStopWalk) {
+		return nil, err
+	}
+	return matches, nil
+}
+
+var errStopWalk = errors.New("stop walk")
+
+func defaultCandidates() []string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return nil
+	}
+	return []string{
+		filepath.Join(home, "Splice"),
+		filepath.Join(home, "Documents", "Splice"),
+	}
+}
+
+func expandHome(path string) string {
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return home
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}

--- a/internal/splice/library_test.go
+++ b/internal/splice/library_test.go
@@ -1,0 +1,74 @@
+package splice
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveConfiguredPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lib, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	want, _ := filepath.Abs(dir)
+	if lib.Source != "env" || lib.Path != want {
+		t.Errorf("library = %#v, want path %q", lib, want)
+	}
+}
+
+func TestResolveMissing(t *testing.T) {
+	t.Parallel()
+
+	_, err := Resolve(filepath.Join(t.TempDir(), "missing"))
+	if err == nil {
+		t.Fatal("expected missing path error")
+	}
+}
+
+func TestSearchSamples(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "sounds", "kick_punch.wav"), "x")
+	mustWrite(t, filepath.Join(root, "sounds", "snare.aiff"), "x")
+	mustWrite(t, filepath.Join(root, "readme.txt"), "nope")
+
+	got, err := Search(root, "kick", 10)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "kick_punch.wav" {
+		t.Fatalf("got = %#v", got)
+	}
+	if got[0].RelativePath != "sounds/kick_punch.wav" {
+		t.Errorf("relative_path = %q", got[0].RelativePath)
+	}
+}
+
+func TestSearchRequiresAudioExtension(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "kick.txt"), "x")
+	got, err := Search(root, "kick", 10)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got = %#v, want none", got)
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/tools/ableton_splice.go
+++ b/internal/tools/ableton_splice.go
@@ -1,0 +1,257 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/splice"
+)
+
+type SpliceLibrarySettings struct {
+	ConfiguredPath string
+}
+
+type GetSpliceLibraryOutput struct {
+	Path   string `json:"path,omitempty"`
+	Source string `json:"source"`
+	Exists bool   `json:"exists"`
+	Hint   string `json:"hint,omitempty"`
+	Note   string `json:"note"`
+}
+
+type SearchSpliceSamplesInput struct {
+	Query      string `json:"query,omitempty" jsonschema:"description=Substring match against sample name or relative path"`
+	MaxResults *int   `json:"max_results,omitempty" jsonschema:"description=Max matches to return (default 20, max 50),minimum=1,maximum=50"`
+}
+
+type SearchSpliceSamplesOutput struct {
+	LibraryPath string          `json:"library_path"`
+	Query       string          `json:"query,omitempty"`
+	Samples     []splice.Sample `json:"samples"`
+	Note        string          `json:"note"`
+}
+
+type LoadSpliceSampleInput struct {
+	AbsolutePath string `json:"absolute_path,omitempty" jsonschema:"description=Absolute path from ableton_search_splice_samples"`
+	RelativePath string `json:"relative_path,omitempty" jsonschema:"description=Path relative to the resolved Splice library root"`
+	TrackIndex   int    `json:"track_index" jsonschema:"description=Destination audio track index,minimum=0"`
+	ClipIndex    int    `json:"clip_index" jsonschema:"description=Session clip slot index,minimum=0"`
+	Fire         bool   `json:"fire,omitempty" jsonschema:"description=Fire the clip after loading"`
+}
+
+type LoadSpliceSampleOutput struct {
+	TrackIndex   int    `json:"track_index"`
+	ClipIndex    int    `json:"clip_index"`
+	AbsolutePath string `json:"absolute_path"`
+	Fired        bool   `json:"fired"`
+	Note         string `json:"note"`
+}
+
+type spliceLoadClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+func NewAbletonGetSpliceLibrary(g *genkit.Genkit, settings SpliceLibrarySettings) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_splice_library",
+		"Locate the local Splice content folder (synced downloads only; does not call the Splice cloud API)",
+		func(_ *ai.ToolContext, _ EmptyInput) (GetSpliceLibraryOutput, error) {
+			return getSpliceLibrary(settings.ConfiguredPath), nil
+		},
+	)
+}
+
+func NewAbletonSearchSpliceSamples(g *genkit.Genkit, settings SpliceLibrarySettings) ai.Tool {
+	return genkit.DefineTool(g, "ableton_search_splice_samples",
+		"Search audio files under the local Splice library folder (already downloaded/synced samples only)",
+		func(_ *ai.ToolContext, input SearchSpliceSamplesInput) (SearchSpliceSamplesOutput, error) {
+			return searchSpliceSamples(settings.ConfiguredPath, input)
+		},
+	)
+}
+
+func NewAbletonLoadSpliceSample(g *genkit.Genkit, client *abletonosc.Client, settings SpliceLibrarySettings) ai.Tool {
+	return genkit.DefineTool(g, "ableton_load_splice_sample",
+		"Load a local Splice audio file into an empty session clip slot on an audio track (requires Live 12.0.5+ and the AbletonOSC browser patch)",
+		func(_ *ai.ToolContext, input LoadSpliceSampleInput) (LoadSpliceSampleOutput, error) {
+			return loadSpliceSample(client, settings.ConfiguredPath, input)
+		},
+	)
+}
+
+func getSpliceLibrary(configured string) GetSpliceLibraryOutput {
+	lib, err := splice.Resolve(configured)
+	if err != nil {
+		return GetSpliceLibraryOutput{
+			Path:   lib.Path,
+			Source: lib.Source,
+			Exists: false,
+			Hint:   err.Error(),
+			Note:   "Cloud Splice search/download is not supported. Sync samples in the Splice desktop app, then point ABLETON_OSC_SPLICE_PATH at that folder if auto-detect fails.",
+		}
+	}
+	return GetSpliceLibraryOutput{
+		Path:   lib.Path,
+		Source: lib.Source,
+		Exists: true,
+		Note:   "Local synced Splice library only. Use ableton_search_splice_samples, then ableton_load_splice_sample on an audio track.",
+	}
+}
+
+func searchSpliceSamples(configured string, input SearchSpliceSamplesInput) (SearchSpliceSamplesOutput, error) {
+	lib, err := splice.Resolve(configured)
+	if err != nil {
+		return SearchSpliceSamplesOutput{}, err
+	}
+	maxResults := 0
+	if input.MaxResults != nil {
+		maxResults = *input.MaxResults
+	}
+	samples, err := splice.Search(lib.Path, input.Query, maxResults)
+	if err != nil {
+		return SearchSpliceSamplesOutput{}, err
+	}
+	return SearchSpliceSamplesOutput{
+		LibraryPath: lib.Path,
+		Query:       strings.TrimSpace(input.Query),
+		Samples:     samples,
+		Note:        "These files are already on disk. Load one with ableton_load_splice_sample (audio track, Live 12.0.5+).",
+	}, nil
+}
+
+func loadSpliceSample(client spliceLoadClient, configured string, input LoadSpliceSampleInput) (LoadSpliceSampleOutput, error) {
+	if input.TrackIndex < 0 {
+		return LoadSpliceSampleOutput{}, errors.New("track_index must be >= 0")
+	}
+	if input.ClipIndex < 0 {
+		return LoadSpliceSampleOutput{}, errors.New("clip_index must be >= 0")
+	}
+	abs, err := resolveSpliceSamplePath(configured, input.AbsolutePath, input.RelativePath)
+	if err != nil {
+		return LoadSpliceSampleOutput{}, err
+	}
+
+	hasClip, err := querySpliceSlotHasClip(client, input.TrackIndex, input.ClipIndex)
+	if err != nil {
+		return LoadSpliceSampleOutput{}, fmt.Errorf("check target slot: %w", err)
+	}
+	if hasClip {
+		return LoadSpliceSampleOutput{}, errors.New("clip_index must be an empty slot")
+	}
+
+	res, err := client.Query(
+		"/live/clip_slot/create_audio_clip",
+		int32(input.TrackIndex),
+		int32(input.ClipIndex),
+		abs,
+	)
+	if err != nil {
+		return LoadSpliceSampleOutput{}, fmt.Errorf("create audio clip failed (browser patch + Live 12.0.5+ required): %w", err)
+	}
+	if err := parseCreateAudioClipResponse(res, input.TrackIndex, input.ClipIndex); err != nil {
+		return LoadSpliceSampleOutput{}, err
+	}
+
+	fired := false
+	if input.Fire {
+		if err := client.Send("/live/clip_slot/fire", int32(input.TrackIndex), int32(input.ClipIndex)); err != nil {
+			return LoadSpliceSampleOutput{}, fmt.Errorf("fire clip: %w", err)
+		}
+		fired = true
+	}
+	return LoadSpliceSampleOutput{
+		TrackIndex:   input.TrackIndex,
+		ClipIndex:    input.ClipIndex,
+		AbsolutePath: abs,
+		Fired:        fired,
+		Note:         "Loaded from local disk into a session audio clip.",
+	}, nil
+}
+
+func querySpliceSlotHasClip(client spliceLoadClient, trackIndex, clipIndex int) (bool, error) {
+	res, err := client.Query("/live/clip_slot/get/has_clip", int32(trackIndex), int32(clipIndex))
+	if err != nil {
+		return false, err
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return false, err
+	}
+	return abletonosc.AsBool(res[2])
+}
+
+func resolveSpliceSamplePath(configured, absolutePath, relativePath string) (string, error) {
+	absolutePath = strings.TrimSpace(absolutePath)
+	relativePath = strings.TrimSpace(relativePath)
+	if absolutePath == "" && relativePath == "" {
+		return "", errors.New("absolute_path or relative_path is required")
+	}
+	if absolutePath != "" {
+		if !filepath.IsAbs(absolutePath) {
+			return "", errors.New("absolute_path must be absolute")
+		}
+		return filepath.Clean(absolutePath), nil
+	}
+	lib, err := splice.Resolve(configured)
+	if err != nil {
+		return "", err
+	}
+	if relativePath == "" || relativePath == "." {
+		return "", errors.New("relative_path is empty")
+	}
+	abs := filepath.Clean(filepath.Join(lib.Path, filepath.FromSlash(relativePath)))
+	rel, err := filepath.Rel(lib.Path, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("relative_path must stay inside the Splice library")
+	}
+	return abs, nil
+}
+
+func parseCreateAudioClipResponse(res []interface{}, trackIndex, clipIndex int) error {
+	if len(res) == 0 {
+		return errors.New("empty create_audio_clip reply")
+	}
+	if status, ok := res[0].(string); ok && status == "error" {
+		return fmt.Errorf("create_audio_clip failed: %v", res)
+	}
+	if len(res) < 3 {
+		return fmt.Errorf("unexpected create_audio_clip reply: %v", res)
+	}
+	status, err := abletonosc.AsString(res[2])
+	if err != nil {
+		return fmt.Errorf("unexpected create_audio_clip reply: %v", res)
+	}
+	switch status {
+	case "created":
+		return nil
+	case "unsupported":
+		detail := "create_audio_clip requires Ableton Live 12.0.5+"
+		if len(res) > 3 {
+			if msg, msgErr := abletonosc.AsString(res[3]); msgErr == nil && msg != "" {
+				detail = msg
+			}
+		}
+		return errors.New(detail)
+	case "not_audio_track":
+		return fmt.Errorf("track %d is not an audio track", trackIndex)
+	case "invalid_track_index":
+		return fmt.Errorf("invalid track_index %d", trackIndex)
+	case "invalid_clip_index":
+		return fmt.Errorf("invalid clip_index %d", clipIndex)
+	case "error":
+		detail := "create_audio_clip failed"
+		if len(res) > 3 {
+			if msg, msgErr := abletonosc.AsString(res[3]); msgErr == nil && msg != "" {
+				detail = msg
+			}
+		}
+		return errors.New(detail)
+	default:
+		return fmt.Errorf("create_audio_clip failed: status=%s reply=%v", status, res)
+	}
+}

--- a/internal/tools/ableton_splice_test.go
+++ b/internal/tools/ableton_splice_test.go
@@ -1,0 +1,146 @@
+package tools
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type spliceStub struct {
+	hasClip  bool
+	calls    []string
+	reply    []interface{}
+	queryErr error
+}
+
+func (s *spliceStub) Query(address string, args ...interface{}) ([]interface{}, error) {
+	s.calls = append(s.calls, "Query:"+address)
+	if s.queryErr != nil {
+		return nil, s.queryErr
+	}
+	if address == "/live/clip_slot/get/has_clip" {
+		return []interface{}{int32(0), int32(0), s.hasClip}, nil
+	}
+	if address == "/live/clip_slot/create_audio_clip" {
+		if s.reply != nil {
+			return s.reply, nil
+		}
+		return []interface{}{int32(0), int32(0), "created", args[2]}, nil
+	}
+	return nil, errors.New("unexpected query: " + address)
+}
+
+func (s *spliceStub) Send(address string, _ ...interface{}) error {
+	s.calls = append(s.calls, "Send:"+address)
+	return nil
+}
+
+func TestGetSpliceLibraryMissing(t *testing.T) {
+	t.Parallel()
+
+	got := getSpliceLibrary(filepath.Join(t.TempDir(), "nope"))
+	if got.Exists || got.Source != "env" {
+		t.Errorf("got = %#v", got)
+	}
+}
+
+func TestSearchSpliceSamples(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "kick.wav")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	max := 5
+	got, err := searchSpliceSamples(root, SearchSpliceSamplesInput{Query: "kick", MaxResults: &max})
+	if err != nil {
+		t.Fatalf("searchSpliceSamples() error = %v", err)
+	}
+	if len(got.Samples) != 1 || got.Samples[0].Name != "kick.wav" {
+		t.Errorf("got = %#v", got)
+	}
+}
+
+func TestLoadSpliceSample(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	abs := filepath.Join(root, "snare.wav")
+	if err := os.WriteFile(abs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	client := &spliceStub{}
+	got, err := loadSpliceSample(client, root, LoadSpliceSampleInput{
+		AbsolutePath: abs,
+		TrackIndex:   0,
+		ClipIndex:    0,
+		Fire:         true,
+	})
+	if err != nil {
+		t.Fatalf("loadSpliceSample() error = %v", err)
+	}
+	if !got.Fired || got.AbsolutePath != abs {
+		t.Errorf("got = %#v", got)
+	}
+}
+
+func TestLoadSpliceSampleRejectsOccupiedSlot(t *testing.T) {
+	t.Parallel()
+
+	client := &spliceStub{hasClip: true}
+	_, err := loadSpliceSample(client, t.TempDir(), LoadSpliceSampleInput{
+		AbsolutePath: "/tmp/x.wav",
+		TrackIndex:   0,
+		ClipIndex:    1,
+	})
+	if err == nil {
+		t.Fatal("expected occupied slot error")
+	}
+}
+
+func TestLoadSpliceSampleUnsupportedLive(t *testing.T) {
+	t.Parallel()
+
+	client := &spliceStub{
+		reply: []interface{}{int32(0), int32(0), "unsupported", "create_audio_clip requires Ableton Live 12.0.5+"},
+	}
+	_, err := loadSpliceSample(client, t.TempDir(), LoadSpliceSampleInput{
+		AbsolutePath: "/tmp/x.wav",
+		TrackIndex:   0,
+		ClipIndex:    0,
+	})
+	if err == nil || err.Error() == "" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestResolveSpliceSampleRelativePath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	got, err := resolveSpliceSamplePath(root, "", "sounds/kick.wav")
+	if err != nil {
+		t.Fatalf("resolveSpliceSamplePath() error = %v", err)
+	}
+	want := filepath.Join(root, "sounds", "kick.wav")
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+	_, err = resolveSpliceSamplePath(root, "", "../escape.wav")
+	if err == nil {
+		t.Fatal("expected path escape error")
+	}
+}
+
+func TestParseCreateAudioClipResponse(t *testing.T) {
+	t.Parallel()
+
+	if err := parseCreateAudioClipResponse([]interface{}{int32(1), int32(2), "created", "/tmp/a.wav"}, 1, 2); err != nil {
+		t.Fatalf("created reply error = %v", err)
+	}
+	if err := parseCreateAudioClipResponse([]interface{}{int32(1), int32(2), "not_audio_track"}, 1, 2); err == nil {
+		t.Fatal("expected not_audio_track error")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -104,6 +104,9 @@ func main() {
 		tools.NewAbletonLoadBrowserItem(g, ableton),
 		tools.NewAbletonLoadBrowserPath(g, ableton),
 		tools.NewAbletonLoadDevicePreset(g, ableton),
+		tools.NewAbletonGetSpliceLibrary(g, tools.SpliceLibrarySettings{ConfiguredPath: cfg.SplicePath}),
+		tools.NewAbletonSearchSpliceSamples(g, tools.SpliceLibrarySettings{ConfiguredPath: cfg.SplicePath}),
+		tools.NewAbletonLoadSpliceSample(g, ableton, tools.SpliceLibrarySettings{ConfiguredPath: cfg.SplicePath}),
 
 		// Mix bus / Master
 		tools.NewAbletonGetTrackMeter(g, ableton),

--- a/remote-script/README.md
+++ b/remote-script/README.md
@@ -12,6 +12,7 @@ Adds Live Browser `load_item()` support and master-track mix helpers so MCP tool
 | `/live/browser/list_folder` | _(none)_ or `root_name`, `*path_parts` | List roots, or children under a folder |
 | `/live/browser/load_at_path` | `track_index` (`-1`=master), `device_index`, `root_name`, `*path_parts`, `item_name` | Load by exact path |
 | `/live/browser/debug` | _(none)_ | Dump browser roots (debug) |
+| `/live/clip_slot/create_audio_clip` | `track_index`, `clip_index`, `absolute_path` | Create a session audio clip from a local file (Live 12.0.5+) |
 | `/live/master/get/volume` | — | Master volume |
 | `/live/master/set/volume` | `volume` | Set master volume |
 | `/live/master/get/output_meter_level` / `left` / `right` | — | Master meters |

--- a/remote-script/abletonosc/browser.py
+++ b/remote-script/abletonosc/browser.py
@@ -233,12 +233,47 @@ class BrowserHandler(AbletonOSCHandler):
             )
             return (track_index, device_index, "loaded", item.name)
 
+        def clip_slot_create_audio_clip_handler(params: Tuple[Any]):
+            """Params: track_index, clip_index, absolute_audio_path.
+
+            Requires Live 12.0.5+ (ClipSlot.create_audio_clip). Used to drop
+            local samples (e.g. synced Splice downloads) into session slots.
+            """
+            if len(params) < 3:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            clip_index = int(params[1])
+            path = str(params[2])
+            if track_index < 0 or track_index >= len(self.song.tracks):
+                return (track_index, clip_index, "invalid_track_index")
+            track = self.song.tracks[track_index]
+            if track.has_midi_input:
+                return (track_index, clip_index, "not_audio_track")
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                return (track_index, clip_index, "invalid_clip_index")
+            slot = track.clip_slots[clip_index]
+            if not hasattr(slot, "create_audio_clip"):
+                return (
+                    track_index,
+                    clip_index,
+                    "unsupported",
+                    "create_audio_clip requires Ableton Live 12.0.5+",
+                )
+            try:
+                slot.create_audio_clip(path)
+            except Exception as exc:
+                return (track_index, clip_index, "error", str(exc))
+            return (track_index, clip_index, "created", path)
+
         self.osc_server.add_handler("/live/browser/find", browser_find_handler)
         self.osc_server.add_handler("/live/browser/debug", browser_debug_handler)
         self.osc_server.add_handler("/live/browser/list_folder", browser_list_folder_handler)
         self.osc_server.add_handler("/live/browser/load_at_path", browser_load_at_path_handler)
         self.osc_server.add_handler("/live/track/load/browser_item", track_load_browser_item_handler)
         self.osc_server.add_handler("/live/device/load/preset", device_load_preset_handler)
+        self.osc_server.add_handler(
+            "/live/clip_slot/create_audio_clip", clip_slot_create_audio_clip_handler
+        )
 
         # Master-track helpers (also registered by MasterHandler; kept here so hot-reload
         # of browser.py always restores them even if master.py fails to import).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a thin **local Splice library** path — not the Splice cloud API.

- `ableton_get_splice_library` — resolve `ABLETON_OSC_SPLICE_PATH` or auto-detect `~/Splice` / `~/Documents/Splice`
- `ableton_search_splice_samples` — search already-downloaded audio files on disk
- `ableton_load_splice_sample` — load into an empty session slot on an **audio** track
- Remote Script: `/live/clip_slot/create_audio_clip` (needs **Live 12.0.5+** and an updated `browser.py` copy)

## Why

Cloud download/auth is a separate product. The useful first step is “find synced samples and drop them into Live.”

## Limits (intentional)

- Does not search or download from Splice online
- Load requires Live 12.0.5+ (`ClipSlot.create_audio_clip`)
- Destination must be an audio track empty clip slot

## Test plan

- [x] `go test ./...`
- [ ] Copy updated `remote-script/abletonosc/browser.py` into AbletonOSC and restart Live
- [ ] `ableton_get_splice_library` finds the synced folder (or set `ABLETON_OSC_SPLICE_PATH`)
- [ ] Search for a kick → load onto an audio track empty slot
- [ ] On Live 11 / missing API: load returns a clear unsupported error

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

