### PR TITLE
feat: match audio clips to project tempo with Warp

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Run drum / bass / scene A/B comparisons through one create→audition recipe, then save taste locally
 - Compare mix balance with snapshots you can restore
 - Humanize MIDI clips with microtiming, velocity variation, and swing
+- Match an audio clip to the project tempo with Warp (e.g. after loading a sample)
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots and send raw OSC for advanced control
@@ -261,6 +262,7 @@ Mix is intentionally outside `ableton_compare_ab_variation` because it uses snap
 | `ableton_create_clip` | Create a clip in a slot |
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
+| `ableton_match_clip_tempo` | Enable Warp on an audio clip so it follows the project tempo (`beats` or `complex`) |
 | `ableton_compare_ab_variation` | Preferred A/B entry: create one drum/bass/scene variation, audition A→B, return a preference prompt |
 | `ableton_create_drum_variation` | Create-only drum A/B variation (groove / density / fill); use when you do not want audition yet |
 | `ableton_create_bass_variation` | Create-only bass A/B variation (octave / staccato / groove) |
@@ -302,6 +304,7 @@ Once configured, you can ask your AI assistant:
 - "I prefer the variation; save that and suggest what to compare next"
 - "Create a mix B with the bass 0.05 lower, let me listen, then restore A"
 - "Humanize the drum clip with a bit of swing"
+- "Warp that audio sample to the project tempo"
 - "Autogain the drum and bass tracks while the beat is playing"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"

--- a/internal/tools/ableton_match_tempo.go
+++ b/internal/tools/ableton_match_tempo.go
@@ -1,0 +1,185 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const (
+	warpModeBeats   = 0
+	warpModeComplex = 4
+)
+
+type MatchClipTempoInput struct {
+	TrackIndex int    `json:"track_index" jsonschema:"minimum=0"`
+	ClipIndex  int    `json:"clip_index" jsonschema:"minimum=0"`
+	WarpMode   string `json:"warp_mode,omitempty" jsonschema:"description=Warp algorithm: beats (default, good for drums/loops) or complex (longer tonal samples)"`
+	Fire       bool   `json:"fire,omitempty" jsonschema:"description=Fire the clip after enabling warp"`
+}
+
+type MatchClipTempoOutput struct {
+	TrackIndex        int     `json:"track_index"`
+	ClipIndex         int     `json:"clip_index"`
+	TempoBPM          float64 `json:"tempo_bpm"`
+	Warping           bool    `json:"warping"`
+	WarpMode          string  `json:"warp_mode"`
+	LengthBeats       float64 `json:"length_beats"`
+	LengthBeatsBefore float64 `json:"length_beats_before"`
+	Fired             bool    `json:"fired"`
+	Note              string  `json:"note"`
+}
+
+type matchTempoClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+func NewAbletonMatchClipTempo(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_match_clip_tempo",
+		"Ableton Live: enable Warp on an audio clip so it follows the project tempo (useful after loading a Splice sample)",
+		func(_ *ai.ToolContext, input MatchClipTempoInput) (MatchClipTempoOutput, error) {
+			return matchClipTempo(client, input)
+		},
+	)
+}
+
+func matchClipTempo(client matchTempoClient, input MatchClipTempoInput) (MatchClipTempoOutput, error) {
+	if err := validateTrackClipIndices(input.TrackIndex, input.ClipIndex); err != nil {
+		return MatchClipTempoOutput{}, err
+	}
+	warpModeName, warpModeValue, err := resolveWarpMode(input.WarpMode)
+	if err != nil {
+		return MatchClipTempoOutput{}, err
+	}
+
+	hasClip, err := queryMatchTempoHasClip(client, input.TrackIndex, input.ClipIndex)
+	if err != nil {
+		return MatchClipTempoOutput{}, fmt.Errorf("check clip slot: %w", err)
+	}
+	if !hasClip {
+		return MatchClipTempoOutput{}, errors.New("clip slot is empty")
+	}
+
+	isAudio, err := queryClipIsAudio(client, input.TrackIndex, input.ClipIndex)
+	if err != nil {
+		return MatchClipTempoOutput{}, err
+	}
+	if !isAudio {
+		return MatchClipTempoOutput{}, errors.New("match tempo only works on audio clips")
+	}
+
+	tempo, err := queryAuditionTempo(client)
+	if err != nil {
+		return MatchClipTempoOutput{}, err
+	}
+
+	lengthBefore := queryMatchTempoClipLength(client, input.TrackIndex, input.ClipIndex)
+
+	if err := client.Send("/live/clip/set/warping", int32(input.TrackIndex), int32(input.ClipIndex), int32(1)); err != nil {
+		return MatchClipTempoOutput{}, fmt.Errorf("enable warping: %w", err)
+	}
+	if err := client.Send("/live/clip/set/warp_mode", int32(input.TrackIndex), int32(input.ClipIndex), int32(warpModeValue)); err != nil {
+		return MatchClipTempoOutput{}, fmt.Errorf("set warp mode: %w", err)
+	}
+
+	warping, err := queryClipWarping(client, input.TrackIndex, input.ClipIndex)
+	if err != nil {
+		return MatchClipTempoOutput{}, err
+	}
+	lengthAfter := queryMatchTempoClipLength(client, input.TrackIndex, input.ClipIndex)
+
+	fired := false
+	if input.Fire {
+		if err := client.Send("/live/clip_slot/fire", int32(input.TrackIndex), int32(input.ClipIndex)); err != nil {
+			return MatchClipTempoOutput{}, fmt.Errorf("fire clip: %w", err)
+		}
+		fired = true
+	}
+
+	return MatchClipTempoOutput{
+		TrackIndex:        input.TrackIndex,
+		ClipIndex:         input.ClipIndex,
+		TempoBPM:          tempo,
+		Warping:           warping,
+		WarpMode:          warpModeName,
+		LengthBeats:       lengthAfter,
+		LengthBeatsBefore: lengthBefore,
+		Fired:             fired,
+		Note:              "Warp is on so the clip follows the project tempo. Adjust warp markers in Live if the transient alignment is off.",
+	}, nil
+}
+
+func resolveWarpMode(raw string) (string, int, error) {
+	mode := strings.ToLower(strings.TrimSpace(raw))
+	if mode == "" {
+		mode = "beats"
+	}
+	switch mode {
+	case "beats":
+		return "beats", warpModeBeats, nil
+	case "complex":
+		return "complex", warpModeComplex, nil
+	default:
+		return "", 0, errors.New("warp_mode must be beats or complex")
+	}
+}
+
+func queryMatchTempoHasClip(client matchTempoClient, trackIndex, clipIndex int) (bool, error) {
+	res, err := client.Query("/live/clip_slot/get/has_clip", int32(trackIndex), int32(clipIndex))
+	if err != nil {
+		return false, err
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return false, err
+	}
+	return abletonosc.AsBool(res[2])
+}
+
+func queryClipIsAudio(client matchTempoClient, trackIndex, clipIndex int) (bool, error) {
+	res, err := client.Query("/live/clip/get/is_audio_clip", int32(trackIndex), int32(clipIndex))
+	if err != nil {
+		return false, fmt.Errorf("get is_audio_clip: %w", err)
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return false, fmt.Errorf("get is_audio_clip: %w", err)
+	}
+	isAudio, err := abletonosc.AsBool(res[2])
+	if err != nil {
+		return false, fmt.Errorf("get is_audio_clip: %w", err)
+	}
+	return isAudio, nil
+}
+
+func queryClipWarping(client matchTempoClient, trackIndex, clipIndex int) (bool, error) {
+	res, err := client.Query("/live/clip/get/warping", int32(trackIndex), int32(clipIndex))
+	if err != nil {
+		return false, fmt.Errorf("get warping: %w", err)
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return false, fmt.Errorf("get warping: %w", err)
+	}
+	warping, err := abletonosc.AsBool(res[2])
+	if err != nil {
+		return false, fmt.Errorf("get warping: %w", err)
+	}
+	return warping, nil
+}
+
+func queryMatchTempoClipLength(client matchTempoClient, trackIndex, clipIndex int) float64 {
+	res, err := client.Query("/live/clip/get/length", int32(trackIndex), int32(clipIndex))
+	if err != nil || len(res) == 0 {
+		return 0
+	}
+	value := res[len(res)-1]
+	length, err := abletonosc.AsFloat64(value)
+	if err != nil || length < 0 {
+		return 0
+	}
+	return length
+}

--- a/internal/tools/ableton_match_tempo_test.go
+++ b/internal/tools/ableton_match_tempo_test.go
@@ -1,0 +1,127 @@
+package tools
+
+import (
+	"errors"
+	"testing"
+)
+
+type matchTempoStub struct {
+	hasClip  bool
+	isAudio  bool
+	warping  bool
+	tempo    float64
+	length   float64
+	calls    []string
+	sendErr  map[string]error
+	queryErr map[string]error
+}
+
+func (s *matchTempoStub) Query(address string, _ ...interface{}) ([]interface{}, error) {
+	if err := s.queryErr[address]; err != nil {
+		return nil, err
+	}
+	switch address {
+	case "/live/clip_slot/get/has_clip":
+		return []interface{}{int32(0), int32(0), s.hasClip}, nil
+	case "/live/clip/get/is_audio_clip":
+		return []interface{}{int32(0), int32(0), s.isAudio}, nil
+	case "/live/song/get/tempo":
+		return []interface{}{float32(s.tempo)}, nil
+	case "/live/clip/get/length":
+		return []interface{}{int32(0), int32(0), float32(s.length)}, nil
+	case "/live/clip/get/warping":
+		return []interface{}{int32(0), int32(0), s.warping}, nil
+	default:
+		return nil, errors.New("unexpected query: " + address)
+	}
+}
+
+func (s *matchTempoStub) Send(address string, args ...interface{}) error {
+	s.calls = append(s.calls, address)
+	if err := s.sendErr[address]; err != nil {
+		return err
+	}
+	if address == "/live/clip/set/warping" {
+		s.warping = true
+		// Live often reports a different beat length once warp is enabled.
+		if s.length > 0 {
+			s.length = s.length * 1.25
+		}
+	}
+	return nil
+}
+
+func TestMatchClipTempo(t *testing.T) {
+	t.Parallel()
+
+	client := &matchTempoStub{
+		hasClip: true,
+		isAudio: true,
+		tempo:   128,
+		length:  4,
+	}
+	got, err := matchClipTempo(client, MatchClipTempoInput{
+		TrackIndex: 0,
+		ClipIndex:  1,
+		WarpMode:   "complex",
+		Fire:       true,
+	})
+	if err != nil {
+		t.Fatalf("matchClipTempo() error = %v", err)
+	}
+	if !got.Warping || got.WarpMode != "complex" || got.TempoBPM != 128 || !got.Fired {
+		t.Errorf("got = %#v", got)
+	}
+	if got.LengthBeatsBefore != 4 || got.LengthBeats <= 4 {
+		t.Errorf("lengths before/after = %v / %v", got.LengthBeatsBefore, got.LengthBeats)
+	}
+	if !containsCall(client.calls, "/live/clip/set/warping") || !containsCall(client.calls, "/live/clip/set/warp_mode") {
+		t.Errorf("calls = %v", client.calls)
+	}
+}
+
+func TestMatchClipTempoRejectsMIDI(t *testing.T) {
+	t.Parallel()
+
+	_, err := matchClipTempo(&matchTempoStub{hasClip: true, isAudio: false, tempo: 120, length: 4}, MatchClipTempoInput{
+		TrackIndex: 0,
+		ClipIndex:  0,
+	})
+	if err == nil {
+		t.Fatal("expected MIDI rejection")
+	}
+}
+
+func TestMatchClipTempoRejectsEmptySlot(t *testing.T) {
+	t.Parallel()
+
+	_, err := matchClipTempo(&matchTempoStub{hasClip: false}, MatchClipTempoInput{
+		TrackIndex: 0,
+		ClipIndex:  0,
+	})
+	if err == nil {
+		t.Fatal("expected empty slot error")
+	}
+}
+
+func TestResolveWarpMode(t *testing.T) {
+	t.Parallel()
+
+	name, value, err := resolveWarpMode("")
+	if err != nil || name != "beats" || value != 0 {
+		t.Fatalf("default = %s %d %v", name, value, err)
+	}
+	_, _, err = resolveWarpMode("texture")
+	if err == nil {
+		t.Fatal("expected invalid warp mode error")
+	}
+}
+
+func containsCall(calls []string, want string) bool {
+	for _, call := range calls {
+		if call == want {
+			return true
+		}
+	}
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -88,6 +88,7 @@ func main() {
 		tools.NewAbletonHumanizeClip(g, ableton),
 		tools.NewAbletonDuplicateClipTo(g, ableton),
 		tools.NewAbletonSetClipName(g, ableton),
+		tools.NewAbletonMatchClipTempo(g, ableton),
 		tools.NewAbletonCreateDrumVariation(g, ableton),
 		tools.NewAbletonCreateBassVariation(g, ableton),
 		tools.NewAbletonAuditionAB(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `ableton_match_clip_tempo` for fitting an audio clip (e.g. a loaded Splice sample) to the project tempo.

- Requires an existing **audio** clip
- Enables Warp and sets mode to `beats` (default) or `complex`
- Returns project BPM and clip length before/after
- Optional `fire` after enabling Warp

## Why

Loading a sample alone leaves it unwarped; producers still have to click Warp manually. This is the smallest “make it fit the track” step.

## Out of scope

- Pitch/key matching
- YouTube download or cloud audio fetch (copyright / ToS; local-file analysis can be a later discussion)

## Test plan

- [x] `go test ./...`
- [ ] Load an audio sample, run match with `warp_mode=beats`, confirm Warp is on and playback follows song tempo
- [ ] MIDI clip → clear error
- [ ] Empty slot → clear error

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

