### PR TITLE
feat: audio analysis for sampling (local file + URL reference)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Compare mix balance with snapshots you can restore
 - Humanize MIDI clips with microtiming, velocity variation, and swing
 - Match an audio clip to the project tempo with Warp (e.g. after loading a sample)
+- Analyze a local `.wav` for duration, levels, and estimated BPM (no URL downloads)
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots and send raw OSC for advanced control
@@ -238,6 +239,18 @@ Keep the lower-level tools for special cases:
 
 Mix is intentionally outside `ableton_compare_ab_variation` because it uses snapshots, not clip/scene slots.
 
+## Local audio analysis
+
+`ableton_analyze_local_audio` inspects a **local `.wav` path you already have**.
+
+It estimates duration, peak/RMS level, onset density, and BPM for placement/warping decisions. It intentionally does **not**:
+
+- accept `http(s)` / YouTube links
+- download remote audio
+- transcribe lyrics or extract note-for-note MIDI of a performance
+
+Use it with files you have rights to use, then load into Live and call `ableton_match_clip_tempo` if needed.
+
 ## Available Tools
 
 | Tool | Description |
@@ -263,6 +276,7 @@ Mix is intentionally outside `ableton_compare_ab_variation` because it uses snap
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
 | `ableton_match_clip_tempo` | Enable Warp on an audio clip so it follows the project tempo (`beats` or `complex`) |
+| `ableton_analyze_local_audio` | Analyze a local `.wav` (duration, levels, estimated BPM). Rejects URLs; no melody/note extraction |
 | `ableton_compare_ab_variation` | Preferred A/B entry: create one drum/bass/scene variation, audition A→B, return a preference prompt |
 | `ableton_create_drum_variation` | Create-only drum A/B variation (groove / density / fill); use when you do not want audition yet |
 | `ableton_create_bass_variation` | Create-only bass A/B variation (octave / staccato / groove) |
@@ -305,6 +319,7 @@ Once configured, you can ask your AI assistant:
 - "Create a mix B with the bass 0.05 lower, let me listen, then restore A"
 - "Humanize the drum clip with a bit of swing"
 - "Warp that audio sample to the project tempo"
+- "Analyze this local wav and tell me its BPM and how many bars it is at 128"
 - "Autogain the drum and bass tracks while the beat is playing"
 - "Find drum kits named Street in the browser"
 - "List the Drums browser folder, then load Street Kit onto track 0"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Compare mix balance with snapshots you can restore
 - Humanize MIDI clips with microtiming, velocity variation, and swing
 - Match an audio clip to the project tempo with Warp (e.g. after loading a sample)
-- Analyze a local `.wav` for duration, levels, and estimated BPM (no URL downloads)
+- Analyze a local `.wav`, or reference-analyze an `http(s)`/YouTube URL, for duration, levels, and estimated BPM (URL streams in memory and is never saved)
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots and send raw OSC for advanced control
@@ -239,17 +239,22 @@ Keep the lower-level tools for special cases:
 
 Mix is intentionally outside `ableton_compare_ab_variation` because it uses snapshots, not clip/scene slots.
 
-## Local audio analysis
+## Audio analysis
 
-`ableton_analyze_local_audio` inspects a **local `.wav` path you already have**.
+Two entry points estimate duration, peak/RMS level, onset density, and BPM to
+help you place or warp a sample. Both are **reference analysis only**: they
+extract factual metadata and never transcribe lyrics or extract note-for-note
+MIDI of a performance.
 
-It estimates duration, peak/RMS level, onset density, and BPM for placement/warping decisions. It intentionally does **not**:
+- `ableton_analyze_local_audio` — inspects a **local `.wav` path you already have**. No network access.
+- `ableton_analyze_audio_url` — reference-analyzes an `http(s)` URL (e.g. YouTube). It streams at most 60s through `yt-dlp` + `ffmpeg` **in memory, analyzes it, and discards it** — nothing is written to disk.
 
-- accept `http(s)` / YouTube links
-- download remote audio
-- transcribe lyrics or extract note-for-note MIDI of a performance
+`ableton_analyze_audio_url` requires `yt-dlp` and `ffmpeg` on `PATH`; this server
+never downloads on its own. Accessing some sites may violate their terms of
+service, and you are responsible for your right to use any source you analyze.
 
-Use it with files you have rights to use, then load into Live and call `ableton_match_clip_tempo` if needed.
+Use results with files you have rights to use, then load into Live and call
+`ableton_match_clip_tempo` if needed.
 
 ## Available Tools
 
@@ -277,6 +282,7 @@ Use it with files you have rights to use, then load into Live and call `ableton_
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
 | `ableton_match_clip_tempo` | Enable Warp on an audio clip so it follows the project tempo (`beats` or `complex`) |
 | `ableton_analyze_local_audio` | Analyze a local `.wav` (duration, levels, estimated BPM). Rejects URLs; no melody/note extraction |
+| `ableton_analyze_audio_url` | Reference-analyze an `http(s)`/YouTube URL (tempo/length/levels). Streams via yt-dlp+ffmpeg in memory, saves nothing; requires yt-dlp+ffmpeg |
 | `ableton_compare_ab_variation` | Preferred A/B entry: create one drum/bass/scene variation, audition A→B, return a preference prompt |
 | `ableton_create_drum_variation` | Create-only drum A/B variation (groove / density / fill); use when you do not want audition yet |
 | `ableton_create_bass_variation` | Create-only bass A/B variation (octave / staccato / groove) |

--- a/internal/audioanalyze/analyze.go
+++ b/internal/audioanalyze/analyze.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	maxFileBytes      = 80 << 20 // 80 MiB
+	maxChunkBytes     = 1 << 20  // cap non-data chunk allocation (guards bogus sizes)
 	minBPM            = 70.0
 	maxBPM            = 180.0
 	envelopeHop       = 512
@@ -35,6 +36,8 @@ type Result struct {
 	Note              string  `json:"note"`
 }
 
+// AnalyzeFile analyzes a local WAV file already present on disk. It never
+// downloads or writes audio; callers must supply audio they have rights to use.
 func AnalyzeFile(path string, projectTempo float64) (Result, error) {
 	abs, err := validateLocalAudioPath(path)
 	if err != nil {
@@ -55,7 +58,25 @@ func AnalyzeFile(path string, projectTempo float64) (Result, error) {
 		return Result{}, fmt.Errorf("audio file too large (%d bytes); max is %d", info.Size(), maxFileBytes)
 	}
 
-	mono, sampleRate, channels, err := loadMonoWAV(abs)
+	f, err := os.Open(abs)
+	if err != nil {
+		return Result{}, fmt.Errorf("open audio file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	out, err := analyzeWAVStream(f, projectTempo)
+	if err != nil {
+		return Result{}, err
+	}
+	out.Path = abs
+	out.Note = "Local-file analysis only. No download, transcription, or note extraction. Use results to place/warp a sample you already have rights to use."
+	return out, nil
+}
+
+// analyzeWAVStream decodes WAV audio from r and computes sampling-oriented
+// metadata. Path and Note are left for the caller to fill in per source.
+func analyzeWAVStream(r io.Reader, projectTempo float64) (Result, error) {
+	mono, sampleRate, channels, err := loadMonoWAV(io.LimitReader(r, maxFileBytes+1))
 	if err != nil {
 		return Result{}, err
 	}
@@ -77,7 +98,6 @@ func AnalyzeFile(path string, projectTempo float64) (Result, error) {
 	}
 
 	out := Result{
-		Path:              abs,
 		Format:            "wav",
 		DurationSec:       duration,
 		SampleRate:        sampleRate,
@@ -88,7 +108,6 @@ func AnalyzeFile(path string, projectTempo float64) (Result, error) {
 		BPMConfidence:     confidence,
 		OnsetCount:        onsets,
 		SuggestedWarpMode: warpMode,
-		Note:              "Local-file analysis only. No download, transcription, or note extraction. Use results to place/warp a sample you already have rights to use.",
 	}
 	if projectTempo > 0 && duration > 0 {
 		beats := duration * (projectTempo / 60)
@@ -116,13 +135,7 @@ func validateLocalAudioPath(path string) (string, error) {
 	return filepath.Clean(path), nil
 }
 
-func loadMonoWAV(path string) ([]float64, int, int, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-	defer func() { _ = f.Close() }()
-
+func loadMonoWAV(f io.Reader) ([]float64, int, int, error) {
 	var header [12]byte
 	if _, err := io.ReadFull(f, header[:]); err != nil {
 		return nil, 0, 0, fmt.Errorf("read wav header: %w", err)
@@ -149,6 +162,22 @@ func loadMonoWAV(path string) ([]float64, int, int, error) {
 		}
 		chunkID := string(chunkHeader[0:4])
 		chunkSize := binary.LittleEndian.Uint32(chunkHeader[4:8])
+
+		// Streaming encoders (e.g. ffmpeg writing to a pipe) cannot seek back to
+		// patch the data chunk size, so it holds a placeholder. Read the data
+		// chunk to EOF instead of trusting the declared size.
+		if chunkID == "data" {
+			payload, err := io.ReadAll(f)
+			if err != nil {
+				return nil, 0, 0, fmt.Errorf("read data chunk: %w", err)
+			}
+			data = payload
+			break
+		}
+
+		if chunkSize > maxChunkBytes {
+			return nil, 0, 0, fmt.Errorf("%s chunk too large (%d bytes)", chunkID, chunkSize)
+		}
 		payload := make([]byte, chunkSize)
 		if _, err := io.ReadFull(f, payload); err != nil {
 			return nil, 0, 0, fmt.Errorf("read %s chunk: %w", chunkID, err)
@@ -158,8 +187,7 @@ func loadMonoWAV(path string) ([]float64, int, int, error) {
 			var pad [1]byte
 			_, _ = f.Read(pad[:])
 		}
-		switch chunkID {
-		case "fmt ":
+		if chunkID == "fmt " {
 			if len(payload) < 16 {
 				return nil, 0, 0, errors.New("invalid fmt chunk")
 			}
@@ -167,8 +195,6 @@ func loadMonoWAV(path string) ([]float64, int, int, error) {
 			channels = binary.LittleEndian.Uint16(payload[2:4])
 			sampleRate = binary.LittleEndian.Uint32(payload[4:8])
 			bitsPerSample = binary.LittleEndian.Uint16(payload[14:16])
-		case "data":
-			data = payload
 		}
 	}
 	if len(data) == 0 || channels == 0 || sampleRate == 0 {

--- a/internal/audioanalyze/analyze.go
+++ b/internal/audioanalyze/analyze.go
@@ -1,0 +1,397 @@
+package audioanalyze
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	maxFileBytes      = 80 << 20 // 80 MiB
+	minBPM            = 70.0
+	maxBPM            = 180.0
+	envelopeHop       = 512
+	maxAnalyzeSamples = 44100 * 60 // analyze at most 60s of audio
+)
+
+type Result struct {
+	Path              string  `json:"path"`
+	Format            string  `json:"format"`
+	DurationSec       float64 `json:"duration_sec"`
+	SampleRate        int     `json:"sample_rate"`
+	Channels          int     `json:"channels"`
+	PeakLevel         float64 `json:"peak_level"`
+	RMSLevel          float64 `json:"rms_level"`
+	EstimatedBPM      float64 `json:"estimated_bpm"`
+	BPMConfidence     float64 `json:"bpm_confidence"`
+	OnsetCount        int     `json:"onset_count"`
+	SuggestedWarpMode string  `json:"suggested_warp_mode"`
+	LengthBarsAtBPM   float64 `json:"length_bars_at_project_tempo,omitempty"`
+	Note              string  `json:"note"`
+}
+
+func AnalyzeFile(path string, projectTempo float64) (Result, error) {
+	abs, err := validateLocalAudioPath(path)
+	if err != nil {
+		return Result{}, err
+	}
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		return Result{}, fmt.Errorf("stat audio file: %w", err)
+	}
+	if info.IsDir() {
+		return Result{}, errors.New("path must be a file")
+	}
+	if info.Size() <= 0 {
+		return Result{}, errors.New("audio file is empty")
+	}
+	if info.Size() > maxFileBytes {
+		return Result{}, fmt.Errorf("audio file too large (%d bytes); max is %d", info.Size(), maxFileBytes)
+	}
+
+	mono, sampleRate, channels, err := loadMonoWAV(abs)
+	if err != nil {
+		return Result{}, err
+	}
+	if len(mono) == 0 || sampleRate <= 0 {
+		return Result{}, errors.New("no audio samples decoded")
+	}
+
+	duration := float64(len(mono)) / float64(sampleRate)
+	peak, rms := levels(mono)
+	analyze := mono
+	if len(analyze) > maxAnalyzeSamples {
+		analyze = analyze[:maxAnalyzeSamples]
+	}
+	bpm, confidence := estimateBPM(analyze, sampleRate)
+	onsets := countOnsets(analyze, sampleRate)
+	warpMode := "beats"
+	if duration >= 8 || onsets < 8 {
+		warpMode = "complex"
+	}
+
+	out := Result{
+		Path:              abs,
+		Format:            "wav",
+		DurationSec:       duration,
+		SampleRate:        sampleRate,
+		Channels:          channels,
+		PeakLevel:         peak,
+		RMSLevel:          rms,
+		EstimatedBPM:      bpm,
+		BPMConfidence:     confidence,
+		OnsetCount:        onsets,
+		SuggestedWarpMode: warpMode,
+		Note:              "Local-file analysis only. No download, transcription, or note extraction. Use results to place/warp a sample you already have rights to use.",
+	}
+	if projectTempo > 0 && duration > 0 {
+		beats := duration * (projectTempo / 60)
+		out.LengthBarsAtBPM = beats / 4
+	}
+	return out, nil
+}
+
+func validateLocalAudioPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("path is required")
+	}
+	lower := strings.ToLower(path)
+	if strings.Contains(lower, "://") || strings.HasPrefix(lower, "//") {
+		return "", errors.New("remote URLs are not supported; provide a local file path to audio you already have")
+	}
+	if !filepath.IsAbs(path) {
+		return "", errors.New("path must be absolute")
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != ".wav" {
+		return "", errors.New("only local .wav files are supported in this version")
+	}
+	return filepath.Clean(path), nil
+}
+
+func loadMonoWAV(path string) ([]float64, int, int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var header [12]byte
+	if _, err := io.ReadFull(f, header[:]); err != nil {
+		return nil, 0, 0, fmt.Errorf("read wav header: %w", err)
+	}
+	if string(header[0:4]) != "RIFF" || string(header[8:12]) != "WAVE" {
+		return nil, 0, 0, errors.New("not a RIFF/WAVE file")
+	}
+
+	var (
+		audioFormat   uint16
+		channels      uint16
+		sampleRate    uint32
+		bitsPerSample uint16
+		data          []byte
+	)
+
+	for {
+		var chunkHeader [8]byte
+		if _, err := io.ReadFull(f, chunkHeader[:]); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				break
+			}
+			return nil, 0, 0, err
+		}
+		chunkID := string(chunkHeader[0:4])
+		chunkSize := binary.LittleEndian.Uint32(chunkHeader[4:8])
+		payload := make([]byte, chunkSize)
+		if _, err := io.ReadFull(f, payload); err != nil {
+			return nil, 0, 0, fmt.Errorf("read %s chunk: %w", chunkID, err)
+		}
+		// Chunks are word-aligned.
+		if chunkSize%2 == 1 {
+			var pad [1]byte
+			_, _ = f.Read(pad[:])
+		}
+		switch chunkID {
+		case "fmt ":
+			if len(payload) < 16 {
+				return nil, 0, 0, errors.New("invalid fmt chunk")
+			}
+			audioFormat = binary.LittleEndian.Uint16(payload[0:2])
+			channels = binary.LittleEndian.Uint16(payload[2:4])
+			sampleRate = binary.LittleEndian.Uint32(payload[4:8])
+			bitsPerSample = binary.LittleEndian.Uint16(payload[14:16])
+		case "data":
+			data = payload
+		}
+	}
+	if len(data) == 0 || channels == 0 || sampleRate == 0 {
+		return nil, 0, 0, errors.New("wav missing fmt/data")
+	}
+	if audioFormat != 1 && audioFormat != 3 {
+		return nil, 0, 0, fmt.Errorf("unsupported wav format code %d (need PCM or IEEE float)", audioFormat)
+	}
+
+	mono, err := decodeMono(data, int(channels), int(bitsPerSample), audioFormat)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	return mono, int(sampleRate), int(channels), nil
+}
+
+func decodeMono(data []byte, channels, bitsPerSample int, audioFormat uint16) ([]float64, error) {
+	if channels < 1 {
+		return nil, errors.New("invalid channel count")
+	}
+	switch {
+	case audioFormat == 1 && bitsPerSample == 16:
+		frame := 2 * channels
+		if len(data) < frame {
+			return nil, errors.New("wav data too short")
+		}
+		n := len(data) / frame
+		out := make([]float64, n)
+		for i := 0; i < n; i++ {
+			var sum float64
+			for ch := 0; ch < channels; ch++ {
+				off := i*frame + ch*2
+				sample := int16(binary.LittleEndian.Uint16(data[off : off+2]))
+				sum += float64(sample) / 32768.0
+			}
+			out[i] = sum / float64(channels)
+		}
+		return out, nil
+	case audioFormat == 1 && bitsPerSample == 24:
+		frame := 3 * channels
+		if len(data) < frame {
+			return nil, errors.New("wav data too short")
+		}
+		n := len(data) / frame
+		out := make([]float64, n)
+		for i := 0; i < n; i++ {
+			var sum float64
+			for ch := 0; ch < channels; ch++ {
+				off := i*frame + ch*3
+				v := int32(data[off]) | int32(data[off+1])<<8 | int32(data[off+2])<<16
+				if v&0x800000 != 0 {
+					v |= ^0xFFFFFF
+				}
+				sum += float64(v) / 8388608.0
+			}
+			out[i] = sum / float64(channels)
+		}
+		return out, nil
+	case audioFormat == 3 && bitsPerSample == 32:
+		frame := 4 * channels
+		if len(data) < frame {
+			return nil, errors.New("wav data too short")
+		}
+		n := len(data) / frame
+		out := make([]float64, n)
+		for i := 0; i < n; i++ {
+			var sum float64
+			for ch := 0; ch < channels; ch++ {
+				off := i*frame + ch*4
+				bits := binary.LittleEndian.Uint32(data[off : off+4])
+				sum += float64(math.Float32frombits(bits))
+			}
+			out[i] = sum / float64(channels)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported wav encoding: format=%d bits=%d", audioFormat, bitsPerSample)
+	}
+}
+
+func levels(samples []float64) (peak, rms float64) {
+	if len(samples) == 0 {
+		return 0, 0
+	}
+	var sumSq float64
+	for _, s := range samples {
+		a := math.Abs(s)
+		if a > peak {
+			peak = a
+		}
+		sumSq += s * s
+	}
+	rms = math.Sqrt(sumSq / float64(len(samples)))
+	return peak, rms
+}
+
+func estimateBPM(samples []float64, sampleRate int) (float64, float64) {
+	if len(samples) < sampleRate || sampleRate <= 0 {
+		return 0, 0
+	}
+	env := energyEnvelope(samples, envelopeHop)
+	if len(env) < 8 {
+		return 0, 0
+	}
+	// First-order difference emphasizes onsets.
+	diff := make([]float64, len(env))
+	for i := 1; i < len(env); i++ {
+		d := env[i] - env[i-1]
+		if d > 0 {
+			diff[i] = d
+		}
+	}
+
+	hopSec := float64(envelopeHop) / float64(sampleRate)
+	minLag := int(math.Floor((60.0 / maxBPM) / hopSec))
+	maxLag := int(math.Ceil((60.0 / minBPM) / hopSec))
+	if minLag < 1 {
+		minLag = 1
+	}
+	if maxLag >= len(diff) {
+		maxLag = len(diff) - 1
+	}
+	if minLag >= maxLag {
+		return 0, 0
+	}
+
+	bestLag := minLag
+	bestCorr := -1.0
+	secondCorr := -1.0
+	for lag := minLag; lag <= maxLag; lag++ {
+		var corr, energy float64
+		n := len(diff) - lag
+		for i := 0; i < n; i++ {
+			corr += diff[i] * diff[i+lag]
+			energy += diff[i] * diff[i]
+		}
+		if energy <= 1e-12 {
+			continue
+		}
+		corr /= energy
+		if corr > bestCorr {
+			secondCorr = bestCorr
+			bestCorr = corr
+			bestLag = lag
+		} else if corr > secondCorr {
+			secondCorr = corr
+		}
+	}
+	if bestCorr <= 0 {
+		return 0, 0
+	}
+	bpm := 60.0 / (float64(bestLag) * hopSec)
+	// Prefer common dance tempos when a double/half is equally plausible.
+	bpm = normalizeBPM(bpm)
+	confidence := bestCorr
+	if secondCorr > 0 {
+		confidence = math.Max(0, math.Min(1, (bestCorr-secondCorr)/math.Max(bestCorr, 1e-9)))
+		confidence = math.Max(confidence, math.Min(1, bestCorr))
+	}
+	return round1(bpm), round2(confidence)
+}
+
+func normalizeBPM(bpm float64) float64 {
+	for bpm < minBPM && bpm*2 <= maxBPM {
+		bpm *= 2
+	}
+	for bpm > maxBPM && bpm/2 >= minBPM {
+		bpm /= 2
+	}
+	return bpm
+}
+
+func energyEnvelope(samples []float64, hop int) []float64 {
+	if hop < 1 {
+		hop = 512
+	}
+	n := len(samples) / hop
+	out := make([]float64, 0, n)
+	for i := 0; i+hop <= len(samples); i += hop {
+		var sum float64
+		for _, s := range samples[i : i+hop] {
+			sum += s * s
+		}
+		out = append(out, math.Sqrt(sum/float64(hop)))
+	}
+	return out
+}
+
+func countOnsets(samples []float64, sampleRate int) int {
+	env := energyEnvelope(samples, envelopeHop)
+	if len(env) < 3 {
+		return 0
+	}
+	var mean float64
+	for _, v := range env {
+		mean += v
+	}
+	mean /= float64(len(env))
+	threshold := mean * 1.5
+	count := 0
+	armed := true
+	minGap := int(math.Round(0.08 / (float64(envelopeHop) / float64(sampleRate)))) // ~80ms
+	if minGap < 1 {
+		minGap = 1
+	}
+	last := -minGap
+	for i := 1; i < len(env)-1; i++ {
+		if armed && env[i] > threshold && env[i] >= env[i-1] && env[i] >= env[i+1] && i-last >= minGap {
+			count++
+			last = i
+			armed = false
+		}
+		if env[i] < threshold*0.8 {
+			armed = true
+		}
+	}
+	return count
+}
+
+func round1(v float64) float64 {
+	return math.Round(v*10) / 10
+}
+
+func round2(v float64) float64 {
+	return math.Round(v*100) / 100
+}

--- a/internal/audioanalyze/analyze_test.go
+++ b/internal/audioanalyze/analyze_test.go
@@ -1,0 +1,91 @@
+package audioanalyze
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateRejectsURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := AnalyzeFile("https://example.com/a.wav", 0)
+	if err == nil {
+		t.Fatal("expected URL rejection")
+	}
+	_, err = AnalyzeFile("relative/a.wav", 0)
+	if err == nil {
+		t.Fatal("expected relative path rejection")
+	}
+}
+
+func TestAnalyzeClickTrackBPM(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "clicks_120.wav")
+	writeClickWAV(t, path, 44100, 120, 4)
+	got, err := AnalyzeFile(path, 120)
+	if err != nil {
+		t.Fatalf("AnalyzeFile() error = %v", err)
+	}
+	if got.SampleRate != 44100 || got.Channels != 1 {
+		t.Errorf("format = %#v", got)
+	}
+	if math.Abs(got.EstimatedBPM-120) > 3 {
+		t.Errorf("estimated_bpm = %v, want ~120", got.EstimatedBPM)
+	}
+	if got.DurationSec < 3.5 || got.OnsetCount < 4 {
+		t.Errorf("duration/onsets = %#v", got)
+	}
+	if got.LengthBarsAtBPM <= 0 {
+		t.Errorf("length_bars_at_project_tempo = %v", got.LengthBarsAtBPM)
+	}
+}
+
+func writeClickWAV(t *testing.T, path string, sampleRate, bpm, seconds int) {
+	t.Helper()
+	samples := sampleRate * seconds
+	pcm := make([]int16, samples)
+	interval := int(float64(sampleRate) * 60 / float64(bpm))
+	for i := 0; i < samples; i += interval {
+		end := i + sampleRate/200 // 5ms click
+		if end > samples {
+			end = samples
+		}
+		for j := i; j < end; j++ {
+			pcm[j] = 20000
+		}
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	dataBytes := len(pcm) * 2
+	write := func(v interface{}) {
+		t.Helper()
+		if err := binary.Write(f, binary.LittleEndian, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, _ = f.Write([]byte("RIFF"))
+	write(uint32(36 + dataBytes))
+	_, _ = f.Write([]byte("WAVE"))
+	_, _ = f.Write([]byte("fmt "))
+	write(uint32(16))
+	write(uint16(1))
+	write(uint16(1))
+	write(uint32(sampleRate))
+	write(uint32(sampleRate * 2))
+	write(uint16(2))
+	write(uint16(16))
+	_, _ = f.Write([]byte("data"))
+	write(uint32(dataBytes))
+	for _, s := range pcm {
+		write(s)
+	}
+}

--- a/internal/audioanalyze/url.go
+++ b/internal/audioanalyze/url.go
@@ -1,0 +1,153 @@
+package audioanalyze
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// urlAnalyzeSeconds bounds how much audio is streamed and decoded. We only
+	// need a short window to estimate tempo/levels, and keeping it short
+	// reinforces that this is reference analysis, not a copy of the work.
+	urlAnalyzeSeconds = 60
+	urlAnalyzeTimeout = 90 * time.Second
+)
+
+// AnalyzeURL streams a short window of audio referenced by a URL through
+// yt-dlp and ffmpeg, analyzes it in memory, and discards it. No audio is ever
+// written to disk. It extracts only factual metadata (tempo, length, levels)
+// and never transcribes melodies or notes.
+//
+// The user is responsible for the legality of accessing the URL: yt-dlp
+// touches the source site directly and some sites' terms prohibit this.
+func AnalyzeURL(ctx context.Context, rawURL string, projectTempo float64) (Result, error) {
+	clean, err := validateAudioURL(rawURL)
+	if err != nil {
+		return Result{}, err
+	}
+	ytdlp, err := exec.LookPath("yt-dlp")
+	if err != nil {
+		return Result{}, errors.New("yt-dlp not found on PATH; install yt-dlp to analyze URLs (this server never downloads on its own)")
+	}
+	ffmpeg, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		return Result{}, errors.New("ffmpeg not found on PATH; install ffmpeg to analyze URLs")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, urlAnalyzeTimeout)
+	defer cancel()
+
+	dl := exec.CommandContext(ctx, ytdlp, ytDlpArgs(clean)...)
+	ff := exec.CommandContext(ctx, ffmpeg, ffmpegArgs(urlAnalyzeSeconds)...)
+
+	dlOut, err := dl.StdoutPipe()
+	if err != nil {
+		return Result{}, fmt.Errorf("pipe yt-dlp output: %w", err)
+	}
+	ff.Stdin = dlOut
+	ffOut, err := ff.StdoutPipe()
+	if err != nil {
+		return Result{}, fmt.Errorf("pipe ffmpeg output: %w", err)
+	}
+
+	var dlErr, ffErr bytes.Buffer
+	dl.Stderr = &dlErr
+	ff.Stderr = &ffErr
+
+	if err := ff.Start(); err != nil {
+		return Result{}, fmt.Errorf("start ffmpeg: %w", err)
+	}
+	if err := dl.Start(); err != nil {
+		return Result{}, fmt.Errorf("start yt-dlp: %w", err)
+	}
+
+	wav, readErr := io.ReadAll(io.LimitReader(ffOut, maxFileBytes+1))
+
+	// yt-dlp finishing first (or failing) closes the pipe so ffmpeg exits.
+	dlWaitErr := dl.Wait()
+	ffWaitErr := ff.Wait()
+
+	if len(wav) == 0 {
+		if ctx.Err() == context.DeadlineExceeded {
+			return Result{}, errors.New("timed out fetching audio from URL")
+		}
+		return Result{}, fmt.Errorf("no audio decoded from URL: %s", firstNonEmpty(strings.TrimSpace(dlErr.String()), strings.TrimSpace(ffErr.String()), "yt-dlp/ffmpeg produced no output"))
+	}
+	if readErr != nil {
+		return Result{}, fmt.Errorf("read decoded audio: %w", readErr)
+	}
+	_ = dlWaitErr
+	_ = ffWaitErr
+
+	out, err := analyzeWAVStream(bytes.NewReader(wav), projectTempo)
+	if err != nil {
+		return Result{}, err
+	}
+	out.Path = clean
+	out.Note = fmt.Sprintf("URL reference analysis: streamed at most %ds, analyzed in memory, and discarded. Nothing was saved and no melody/notes were extracted. You are responsible for your right to use the source.", urlAnalyzeSeconds)
+	return out, nil
+}
+
+// ytDlpArgs streams best available audio to stdout without touching disk.
+func ytDlpArgs(u string) []string {
+	return []string{
+		"-q",
+		"--no-playlist",
+		"--no-part",
+		"-f", "bestaudio/best",
+		"-o", "-",
+		u,
+	}
+}
+
+// ffmpegArgs decodes stdin to a mono 44.1kHz WAV stream, capped to seconds.
+func ffmpegArgs(seconds int) []string {
+	return []string{
+		"-hide_banner",
+		"-loglevel", "error",
+		"-i", "pipe:0",
+		"-vn",
+		"-ac", "1",
+		"-ar", "44100",
+		"-t", strconv.Itoa(seconds),
+		"-f", "wav",
+		"pipe:1",
+	}
+}
+
+func validateAudioURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("url is required")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid url: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return "", errors.New("url must start with http:// or https://")
+	}
+	if u.Host == "" {
+		return "", errors.New("url has no host")
+	}
+	return u.String(), nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/audioanalyze/url_test.go
+++ b/internal/audioanalyze/url_test.go
@@ -1,0 +1,138 @@
+package audioanalyze
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestValidateAudioURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"https", "https://youtu.be/abc123", false},
+		{"http", "http://example.com/track.mp3", false},
+		{"empty", "   ", true},
+		{"scheme", "ftp://example.com/a.wav", true},
+		{"relative", "example.com/a.wav", true},
+		{"nohost", "https://", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := validateAudioURL(tc.in)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateAudioURL(%q) expected error", tc.in)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateAudioURL(%q) unexpected error: %v", tc.in, err)
+			}
+		})
+	}
+}
+
+func TestAnalyzeURLRejectsBadURL(t *testing.T) {
+	t.Parallel()
+
+	if _, err := AnalyzeURL(context.Background(), "not-a-url", 0); err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestFfmpegArgsBounded(t *testing.T) {
+	t.Parallel()
+
+	args := ffmpegArgs(60)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "-t 60") {
+		t.Errorf("ffmpeg args missing duration cap: %v", args)
+	}
+	if !strings.Contains(joined, "-ac 1") || !strings.Contains(joined, "-ar 44100") {
+		t.Errorf("ffmpeg args missing mono/44.1k downmix: %v", args)
+	}
+	if !strings.Contains(joined, "pipe:1") {
+		t.Errorf("ffmpeg args must stream to stdout, not a file: %v", args)
+	}
+}
+
+func TestYtDlpArgsStreamToStdout(t *testing.T) {
+	t.Parallel()
+
+	args := ytDlpArgs("https://example.com/a")
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "-o -") {
+		t.Errorf("yt-dlp must write to stdout (-o -), not disk: %v", args)
+	}
+	if args[len(args)-1] != "https://example.com/a" {
+		t.Errorf("url must be the final arg: %v", args)
+	}
+}
+
+func TestAnalyzeWAVStreamReader(t *testing.T) {
+	t.Parallel()
+
+	buf := clickWAVBytes(t, 44100, 120, 4)
+	got, err := analyzeWAVStream(bytes.NewReader(buf), 120)
+	if err != nil {
+		t.Fatalf("analyzeWAVStream() error = %v", err)
+	}
+	if got.SampleRate != 44100 || got.Channels != 1 {
+		t.Errorf("format = %#v", got)
+	}
+	if math.Abs(got.EstimatedBPM-120) > 3 {
+		t.Errorf("estimated_bpm = %v, want ~120", got.EstimatedBPM)
+	}
+	if got.Path != "" || got.Note != "" {
+		t.Errorf("core analysis should not set Path/Note: %#v", got)
+	}
+}
+
+// clickWAVBytes builds an in-memory mono 16-bit click track for reader tests.
+func clickWAVBytes(t *testing.T, sampleRate, bpm, seconds int) []byte {
+	t.Helper()
+	samples := sampleRate * seconds
+	pcm := make([]int16, samples)
+	interval := int(float64(sampleRate) * 60 / float64(bpm))
+	for i := 0; i < samples; i += interval {
+		end := i + sampleRate/200
+		if end > samples {
+			end = samples
+		}
+		for j := i; j < end; j++ {
+			pcm[j] = 20000
+		}
+	}
+
+	var b bytes.Buffer
+	dataBytes := len(pcm) * 2
+	write := func(v interface{}) {
+		if err := binary.Write(&b, binary.LittleEndian, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	b.WriteString("RIFF")
+	write(uint32(36 + dataBytes))
+	b.WriteString("WAVE")
+	b.WriteString("fmt ")
+	write(uint32(16))
+	write(uint16(1))
+	write(uint16(1))
+	write(uint32(sampleRate))
+	write(uint32(sampleRate * 2))
+	write(uint16(2))
+	write(uint16(16))
+	b.WriteString("data")
+	write(uint32(dataBytes))
+	for _, s := range pcm {
+		write(s)
+	}
+	return b.Bytes()
+}

--- a/internal/tools/ableton_analyze_audio.go
+++ b/internal/tools/ableton_analyze_audio.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/audioanalyze"
+)
+
+type AnalyzeLocalAudioInput struct {
+	Path         string   `json:"path" jsonschema:"description=Absolute local path to a .wav file you already have (no URLs)"`
+	ProjectTempo *float64 `json:"project_tempo,omitempty" jsonschema:"description=Optional project BPM to estimate length in bars,minimum=20,maximum=400"`
+}
+
+type AnalyzeLocalAudioOutput struct {
+	Path              string  `json:"path"`
+	Format            string  `json:"format"`
+	DurationSec       float64 `json:"duration_sec"`
+	SampleRate        int     `json:"sample_rate"`
+	Channels          int     `json:"channels"`
+	PeakLevel         float64 `json:"peak_level"`
+	RMSLevel          float64 `json:"rms_level"`
+	EstimatedBPM      float64 `json:"estimated_bpm"`
+	BPMConfidence     float64 `json:"bpm_confidence"`
+	OnsetCount        int     `json:"onset_count"`
+	SuggestedWarpMode string  `json:"suggested_warp_mode"`
+	LengthBarsAtBPM   float64 `json:"length_bars_at_project_tempo,omitempty"`
+	Note              string  `json:"note"`
+	NextStep          string  `json:"next_step"`
+}
+
+func NewAbletonAnalyzeLocalAudio(g *genkit.Genkit) ai.Tool {
+	return genkit.DefineTool(g, "ableton_analyze_local_audio",
+		"Analyze a local .wav file for sampling placement (duration, levels, estimated BPM). Does not download URLs or extract melodies/notes.",
+		func(_ *ai.ToolContext, input AnalyzeLocalAudioInput) (AnalyzeLocalAudioOutput, error) {
+			return analyzeLocalAudio(input)
+		},
+	)
+}
+
+func analyzeLocalAudio(input AnalyzeLocalAudioInput) (AnalyzeLocalAudioOutput, error) {
+	projectTempo := 0.0
+	if input.ProjectTempo != nil {
+		projectTempo = *input.ProjectTempo
+	}
+	got, err := audioanalyze.AnalyzeFile(input.Path, projectTempo)
+	if err != nil {
+		return AnalyzeLocalAudioOutput{}, err
+	}
+	return AnalyzeLocalAudioOutput{
+		Path:              got.Path,
+		Format:            got.Format,
+		DurationSec:       got.DurationSec,
+		SampleRate:        got.SampleRate,
+		Channels:          got.Channels,
+		PeakLevel:         got.PeakLevel,
+		RMSLevel:          got.RMSLevel,
+		EstimatedBPM:      got.EstimatedBPM,
+		BPMConfidence:     got.BPMConfidence,
+		OnsetCount:        got.OnsetCount,
+		SuggestedWarpMode: got.SuggestedWarpMode,
+		LengthBarsAtBPM:   got.LengthBarsAtBPM,
+		Note:              got.Note,
+		NextStep:          "If you load this sample into Live, use ableton_match_clip_tempo with the suggested_warp_mode so it follows the project tempo.",
+	}, nil
+}

--- a/internal/tools/ableton_analyze_audio_test.go
+++ b/internal/tools/ableton_analyze_audio_test.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAnalyzeLocalAudioRejectsURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := analyzeLocalAudio(AnalyzeLocalAudioInput{Path: "https://youtube.com/watch?v=abc"})
+	if err == nil {
+		t.Fatal("expected URL rejection")
+	}
+}
+
+func TestAnalyzeLocalAudioWAV(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tone.wav")
+	writeSilentWAV(t, path, 44100, 1)
+	tempo := 128.0
+	got, err := analyzeLocalAudio(AnalyzeLocalAudioInput{Path: path, ProjectTempo: &tempo})
+	if err != nil {
+		t.Fatalf("analyzeLocalAudio() error = %v", err)
+	}
+	if got.SampleRate != 44100 || got.NextStep == "" {
+		t.Errorf("got = %#v", got)
+	}
+}
+
+func writeSilentWAV(t *testing.T, path string, sampleRate, seconds int) {
+	t.Helper()
+	samples := sampleRate * seconds
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	dataBytes := samples * 2
+	write := func(v interface{}) {
+		if err := binary.Write(f, binary.LittleEndian, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, _ = f.Write([]byte("RIFF"))
+	write(uint32(36 + dataBytes))
+	_, _ = f.Write([]byte("WAVE"))
+	_, _ = f.Write([]byte("fmt "))
+	write(uint32(16))
+	write(uint16(1))
+	write(uint16(1))
+	write(uint32(sampleRate))
+	write(uint32(sampleRate * 2))
+	write(uint16(2))
+	write(uint16(16))
+	_, _ = f.Write([]byte("data"))
+	write(uint32(dataBytes))
+	zeros := make([]byte, dataBytes)
+	if _, err := f.Write(zeros); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/tools/ableton_analyze_url.go
+++ b/internal/tools/ableton_analyze_url.go
@@ -1,0 +1,62 @@
+package tools
+
+import (
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/audioanalyze"
+)
+
+type AnalyzeAudioURLInput struct {
+	URL          string   `json:"url" jsonschema:"description=http(s) URL to reference (e.g. YouTube). Streamed briefly for analysis and never saved."`
+	ProjectTempo *float64 `json:"project_tempo,omitempty" jsonschema:"description=Optional project BPM to estimate length in bars,minimum=20,maximum=400"`
+}
+
+type AnalyzeAudioURLOutput struct {
+	Source            string  `json:"source"`
+	Format            string  `json:"format"`
+	DurationSec       float64 `json:"duration_sec"`
+	SampleRate        int     `json:"sample_rate"`
+	Channels          int     `json:"channels"`
+	PeakLevel         float64 `json:"peak_level"`
+	RMSLevel          float64 `json:"rms_level"`
+	EstimatedBPM      float64 `json:"estimated_bpm"`
+	BPMConfidence     float64 `json:"bpm_confidence"`
+	OnsetCount        int     `json:"onset_count"`
+	SuggestedWarpMode string  `json:"suggested_warp_mode"`
+	LengthBarsAtBPM   float64 `json:"length_bars_at_project_tempo,omitempty"`
+	Note              string  `json:"note"`
+	NextStep          string  `json:"next_step"`
+}
+
+func NewAbletonAnalyzeAudioURL(g *genkit.Genkit) ai.Tool {
+	return genkit.DefineTool(g, "ableton_analyze_audio_url",
+		"Reference-analyze audio at an http(s) URL (e.g. YouTube) for tempo/length/levels. Streams a short window through yt-dlp+ffmpeg in memory, saves nothing, and never extracts melodies or notes. Requires yt-dlp and ffmpeg on PATH; you are responsible for your right to access the URL.",
+		func(tc *ai.ToolContext, input AnalyzeAudioURLInput) (AnalyzeAudioURLOutput, error) {
+			projectTempo := 0.0
+			if input.ProjectTempo != nil {
+				projectTempo = *input.ProjectTempo
+			}
+			got, err := audioanalyze.AnalyzeURL(tc, input.URL, projectTempo)
+			if err != nil {
+				return AnalyzeAudioURLOutput{}, err
+			}
+			return AnalyzeAudioURLOutput{
+				Source:            got.Path,
+				Format:            got.Format,
+				DurationSec:       got.DurationSec,
+				SampleRate:        got.SampleRate,
+				Channels:          got.Channels,
+				PeakLevel:         got.PeakLevel,
+				RMSLevel:          got.RMSLevel,
+				EstimatedBPM:      got.EstimatedBPM,
+				BPMConfidence:     got.BPMConfidence,
+				OnsetCount:        got.OnsetCount,
+				SuggestedWarpMode: got.SuggestedWarpMode,
+				LengthBarsAtBPM:   got.LengthBarsAtBPM,
+				Note:              got.Note,
+				NextStep:          "Use the tempo/length as a reference to build your own part. This tool does not import the audio; place only samples you have the right to use.",
+			}, nil
+		},
+	)
+}

--- a/internal/tools/ableton_analyze_url_test.go
+++ b/internal/tools/ableton_analyze_url_test.go
@@ -1,0 +1,21 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/audioanalyze"
+)
+
+func TestAnalyzeAudioURLRejectsNonURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := audioanalyze.AnalyzeURL(context.Background(), "/local/file.wav", 0)
+	if err == nil {
+		t.Fatal("expected rejection for non-http input")
+	}
+	if !strings.Contains(err.Error(), "http") {
+		t.Errorf("error should mention http scheme requirement: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func main() {
 		tools.NewAbletonDuplicateClipTo(g, ableton),
 		tools.NewAbletonSetClipName(g, ableton),
 		tools.NewAbletonMatchClipTempo(g, ableton),
+		tools.NewAbletonAnalyzeLocalAudio(g),
 		tools.NewAbletonCreateDrumVariation(g, ableton),
 		tools.NewAbletonCreateBassVariation(g, ableton),
 		tools.NewAbletonAuditionAB(g, ableton),

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func main() {
 		tools.NewAbletonSetClipName(g, ableton),
 		tools.NewAbletonMatchClipTempo(g, ableton),
 		tools.NewAbletonAnalyzeLocalAudio(g),
+		tools.NewAbletonAnalyzeAudioURL(g),
 		tools.NewAbletonCreateDrumVariation(g, ableton),
 		tools.NewAbletonCreateBassVariation(g, ableton),
 		tools.NewAbletonAuditionAB(g, ableton),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add sampling-oriented audio analysis with two entry points:

- `ableton_analyze_local_audio` — analyze a local `.wav` you already have.
- `ableton_analyze_audio_url` — reference-analyze an `http(s)`/YouTube URL.

Both estimate duration, peak/RMS level, onset density, and BPM (with a
confidence), and suggest a warp mode so you can place/warp a sample and follow
the project tempo via `ableton_match_clip_tempo`.

## URL analysis is reference-only, never a copy

`ableton_analyze_audio_url` streams **at most 60s** of the source through
`yt-dlp` and `ffmpeg`, analyzes it **in memory, and discards it**. Nothing is
written to disk, and no melody or note-for-note MIDI is extracted — only
factual metadata (tempo/length/levels).

- Requires `yt-dlp` and `ffmpeg` on `PATH`; the server never downloads on its own.
- Accessing some sites may violate their terms of service; the user is
  responsible for their right to use any source they analyze.

## Implementation notes

- Analysis core now works on an `io.Reader` (`analyzeWAVStream`), so the same
  BPM/level/onset logic serves both file and streamed input.
- WAV parsing reads the `data` chunk to EOF, so streaming encoders (ffmpeg over
  a pipe) that cannot patch the chunk size are handled; non-data chunk
  allocation is capped to guard against bogus sizes.

## Testing

- `go test ./...` (unit tests: URL validation, argument bounding, reader-based
  analysis, local WAV analysis).
- Manual end-to-end smoke: served a local file over HTTP and ran the real
  `yt-dlp | ffmpeg` pipeline — audio was fetched, decoded to WAV in memory, and
  analyzed (duration/levels/BPM) with nothing written to disk.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

