### PR TITLE
feat: estimate approximate key/scale in audio analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Compare mix balance with snapshots you can restore
 - Humanize MIDI clips with microtiming, velocity variation, and swing
 - Match an audio clip to the project tempo with Warp (e.g. after loading a sample)
-- Analyze a local `.wav`, or reference-analyze an `http(s)`/YouTube URL, for duration, levels, and estimated BPM (URL streams in memory and is never saved)
+- Analyze a local `.wav`, or reference-analyze an `http(s)`/YouTube URL, for duration, levels, estimated BPM, and approximate key/scale (URL streams in memory and is never saved)
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots and send raw OSC for advanced control
@@ -241,10 +241,14 @@ Mix is intentionally outside `ableton_compare_ab_variation` because it uses snap
 
 ## Audio analysis
 
-Two entry points estimate duration, peak/RMS level, onset density, and BPM to
-help you place or warp a sample. Both are **reference analysis only**: they
-extract factual metadata and never transcribe lyrics or extract note-for-note
-MIDI of a performance.
+Two entry points estimate duration, peak/RMS level, onset density, BPM, and an
+approximate musical key/scale to help you place or warp a sample and build a
+part in a matching key. Both are **reference analysis only**: they extract
+factual metadata and never transcribe lyrics or extract note-for-note MIDI of a
+performance.
+
+Key/scale is a chroma-based estimate (Krumhansl profiles) reported with a
+confidence; treat it as a starting hint, since dense mixes can fool it.
 
 - `ableton_analyze_local_audio` — inspects a **local `.wav` path you already have**. No network access.
 - `ableton_analyze_audio_url` — reference-analyzes an `http(s)` URL (e.g. YouTube). It streams at most 60s through `yt-dlp` + `ffmpeg` **in memory, analyzes it, and discards it** — nothing is written to disk.
@@ -281,8 +285,8 @@ Use results with files you have rights to use, then load into Live and call
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
 | `ableton_match_clip_tempo` | Enable Warp on an audio clip so it follows the project tempo (`beats` or `complex`) |
-| `ableton_analyze_local_audio` | Analyze a local `.wav` (duration, levels, estimated BPM). Rejects URLs; no melody/note extraction |
-| `ableton_analyze_audio_url` | Reference-analyze an `http(s)`/YouTube URL (tempo/length/levels). Streams via yt-dlp+ffmpeg in memory, saves nothing; requires yt-dlp+ffmpeg |
+| `ableton_analyze_local_audio` | Analyze a local `.wav` (duration, levels, estimated BPM, approx. key/scale). Rejects URLs; no melody/note extraction |
+| `ableton_analyze_audio_url` | Reference-analyze an `http(s)`/YouTube URL (tempo/length/levels, approx. key/scale). Streams via yt-dlp+ffmpeg in memory, saves nothing; requires yt-dlp+ffmpeg |
 | `ableton_compare_ab_variation` | Preferred A/B entry: create one drum/bass/scene variation, audition A→B, return a preference prompt |
 | `ableton_create_drum_variation` | Create-only drum A/B variation (groove / density / fill); use when you do not want audition yet |
 | `ableton_create_bass_variation` | Create-only bass A/B variation (octave / staccato / groove) |

--- a/internal/audioanalyze/analyze.go
+++ b/internal/audioanalyze/analyze.go
@@ -32,6 +32,9 @@ type Result struct {
 	BPMConfidence     float64 `json:"bpm_confidence"`
 	OnsetCount        int     `json:"onset_count"`
 	SuggestedWarpMode string  `json:"suggested_warp_mode"`
+	Key               string  `json:"key,omitempty"`
+	Scale             string  `json:"scale,omitempty"`
+	KeyConfidence     float64 `json:"key_confidence,omitempty"`
 	LengthBarsAtBPM   float64 `json:"length_bars_at_project_tempo,omitempty"`
 	Note              string  `json:"note"`
 }
@@ -108,6 +111,11 @@ func analyzeWAVStream(r io.Reader, projectTempo float64) (Result, error) {
 		BPMConfidence:     confidence,
 		OnsetCount:        onsets,
 		SuggestedWarpMode: warpMode,
+	}
+	if key, ok := estimateKey(analyze, sampleRate); ok {
+		out.Key = key.Tonic
+		out.Scale = key.Scale
+		out.KeyConfidence = key.Confidence
 	}
 	if projectTempo > 0 && duration > 0 {
 		beats := duration * (projectTempo / 60)

--- a/internal/audioanalyze/key.go
+++ b/internal/audioanalyze/key.go
@@ -1,0 +1,211 @@
+package audioanalyze
+
+import "math"
+
+// Key detection uses a chromagram (12 pitch-class energies) matched against the
+// Krumhansl-Kessler key profiles. It reports an approximate global key/scale
+// for reference only; dense, produced mixes can fool it, so callers should
+// treat it as a hint rather than ground truth.
+
+const (
+	keyFrameSize = 4096
+	keyHopSize   = 2048
+	// Restrict binning to a musical fundamental range to reduce noise/harmonics.
+	keyMinFreq = 55.0   // ~A1
+	keyMaxFreq = 2000.0 // ~B6
+)
+
+var pitchClassNames = [12]string{"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"}
+
+// Krumhansl-Kessler tonal hierarchy profiles (C-rooted).
+var (
+	majorProfile = [12]float64{6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88}
+	minorProfile = [12]float64{6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17}
+)
+
+// KeyResult holds an approximate key estimate.
+type KeyResult struct {
+	Tonic      string  // e.g. "C", "F#"
+	Scale      string  // "major" or "minor"
+	Confidence float64 // 0..1 margin between the best and next-best fit
+}
+
+// estimateKey computes a chromagram and matches it to major/minor key profiles.
+func estimateKey(samples []float64, sampleRate int) (KeyResult, bool) {
+	if sampleRate <= 0 || len(samples) < keyFrameSize {
+		return KeyResult{}, false
+	}
+	chroma := chromagram(samples, sampleRate)
+	var total float64
+	for _, v := range chroma {
+		total += v
+	}
+	if total <= 0 {
+		return KeyResult{}, false
+	}
+
+	bestCorr := math.Inf(-1)
+	secondCorr := math.Inf(-1)
+	var bestTonic int
+	var bestScale string
+	consider := func(tonic int, scale string, corr float64) {
+		if corr > bestCorr {
+			secondCorr = bestCorr
+			bestCorr = corr
+			bestTonic = tonic
+			bestScale = scale
+		} else if corr > secondCorr {
+			secondCorr = corr
+		}
+	}
+	for tonic := 0; tonic < 12; tonic++ {
+		consider(tonic, "major", correlateProfile(chroma, majorProfile, tonic))
+		consider(tonic, "minor", correlateProfile(chroma, minorProfile, tonic))
+	}
+	if math.IsInf(bestCorr, -1) {
+		return KeyResult{}, false
+	}
+
+	confidence := 0.0
+	if !math.IsInf(secondCorr, -1) && bestCorr > 0 {
+		confidence = math.Max(0, math.Min(1, (bestCorr-secondCorr)/math.Max(bestCorr, 1e-9)))
+	}
+	return KeyResult{
+		Tonic:      pitchClassNames[bestTonic],
+		Scale:      bestScale,
+		Confidence: round2(confidence),
+	}, true
+}
+
+// correlateProfile is the Pearson correlation between the chroma vector and a
+// key profile rotated so that index 0 aligns with the given tonic.
+func correlateProfile(chroma [12]float64, profile [12]float64, tonic int) float64 {
+	var rotated [12]float64
+	for i := 0; i < 12; i++ {
+		rotated[i] = profile[((i-tonic)%12+12)%12]
+	}
+	return pearson(chroma[:], rotated[:])
+}
+
+func pearson(a, b []float64) float64 {
+	n := float64(len(a))
+	var sumA, sumB float64
+	for i := range a {
+		sumA += a[i]
+		sumB += b[i]
+	}
+	meanA := sumA / n
+	meanB := sumB / n
+	var cov, varA, varB float64
+	for i := range a {
+		da := a[i] - meanA
+		db := b[i] - meanB
+		cov += da * db
+		varA += da * da
+		varB += db * db
+	}
+	if varA <= 1e-12 || varB <= 1e-12 {
+		return 0
+	}
+	return cov / math.Sqrt(varA*varB)
+}
+
+// chromagram accumulates spectral magnitude into 12 pitch classes across frames.
+func chromagram(samples []float64, sampleRate int) [12]float64 {
+	var chroma [12]float64
+	window := hannWindow(keyFrameSize)
+	buf := make([]float64, keyFrameSize)
+	minBin := int(math.Floor(keyMinFreq * float64(keyFrameSize) / float64(sampleRate)))
+	maxBin := int(math.Ceil(keyMaxFreq * float64(keyFrameSize) / float64(sampleRate)))
+	if minBin < 1 {
+		minBin = 1
+	}
+	if maxBin > keyFrameSize/2 {
+		maxBin = keyFrameSize / 2
+	}
+
+	for start := 0; start+keyFrameSize <= len(samples); start += keyHopSize {
+		for i := 0; i < keyFrameSize; i++ {
+			buf[i] = samples[start+i] * window[i]
+		}
+		re, im := fftReal(buf)
+		for bin := minBin; bin <= maxBin; bin++ {
+			mag := math.Hypot(re[bin], im[bin])
+			if mag <= 0 {
+				continue
+			}
+			freq := float64(bin) * float64(sampleRate) / float64(keyFrameSize)
+			midi := 69.0 + 12.0*math.Log2(freq/440.0)
+			pc := int(math.Round(midi)) % 12
+			if pc < 0 {
+				pc += 12
+			}
+			chroma[pc] += mag
+		}
+	}
+	return chroma
+}
+
+func hannWindow(n int) []float64 {
+	w := make([]float64, n)
+	for i := 0; i < n; i++ {
+		w[i] = 0.5 - 0.5*math.Cos(2*math.Pi*float64(i)/float64(n-1))
+	}
+	return w
+}
+
+// fftReal returns the real/imag parts of the FFT of a real-valued input. The
+// input length is padded up to the next power of two.
+func fftReal(input []float64) ([]float64, []float64) {
+	n := nextPow2(len(input))
+	re := make([]float64, n)
+	im := make([]float64, n)
+	copy(re, input)
+	fftInPlace(re, im)
+	return re, im
+}
+
+func nextPow2(n int) int {
+	p := 1
+	for p < n {
+		p <<= 1
+	}
+	return p
+}
+
+// fftInPlace is an iterative radix-2 Cooley-Tukey FFT. len(re)==len(im) must be
+// a power of two.
+func fftInPlace(re, im []float64) {
+	n := len(re)
+	if n <= 1 {
+		return
+	}
+	// Bit-reversal permutation.
+	for i, j := 1, 0; i < n; i++ {
+		bit := n >> 1
+		for ; j&bit != 0; bit >>= 1 {
+			j ^= bit
+		}
+		j ^= bit
+		if i < j {
+			re[i], re[j] = re[j], re[i]
+			im[i], im[j] = im[j], im[i]
+		}
+	}
+	for length := 2; length <= n; length <<= 1 {
+		ang := -2 * math.Pi / float64(length)
+		wRe, wIm := math.Cos(ang), math.Sin(ang)
+		for i := 0; i < n; i += length {
+			curRe, curIm := 1.0, 0.0
+			half := length >> 1
+			for j := 0; j < half; j++ {
+				uRe, uIm := re[i+j], im[i+j]
+				vRe := re[i+j+half]*curRe - im[i+j+half]*curIm
+				vIm := re[i+j+half]*curIm + im[i+j+half]*curRe
+				re[i+j], im[i+j] = uRe+vRe, uIm+vIm
+				re[i+j+half], im[i+j+half] = uRe-vRe, uIm-vIm
+				curRe, curIm = curRe*wRe-curIm*wIm, curRe*wIm+curIm*wRe
+			}
+		}
+	}
+}

--- a/internal/audioanalyze/key_test.go
+++ b/internal/audioanalyze/key_test.go
@@ -1,0 +1,77 @@
+package audioanalyze
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFFTSinePeak(t *testing.T) {
+	t.Parallel()
+
+	const n = 1024
+	const sampleRate = 8192
+	const freq = 512.0 // exactly bin 64 (freq*n/sampleRate)
+	in := make([]float64, n)
+	for i := range in {
+		in[i] = math.Sin(2 * math.Pi * freq * float64(i) / float64(sampleRate))
+	}
+	re, im := fftReal(in)
+	wantBin := int(freq * n / sampleRate)
+	peakBin, peakMag := 0, -1.0
+	for b := 1; b < n/2; b++ {
+		mag := math.Hypot(re[b], im[b])
+		if mag > peakMag {
+			peakMag, peakBin = mag, b
+		}
+	}
+	if peakBin != wantBin {
+		t.Fatalf("FFT peak bin = %d, want %d", peakBin, wantBin)
+	}
+}
+
+func TestEstimateKeyCMajorTriad(t *testing.T) {
+	t.Parallel()
+
+	// C4, E4, G4 sustained -> should read as C major.
+	samples := tones(44100, 5, 261.63, 329.63, 392.0)
+	got, ok := estimateKey(samples, 44100)
+	if !ok {
+		t.Fatal("estimateKey returned ok=false")
+	}
+	if got.Tonic != "C" || got.Scale != "major" {
+		t.Fatalf("key = %s %s (conf %.2f), want C major", got.Tonic, got.Scale, got.Confidence)
+	}
+}
+
+func TestEstimateKeyGMajorScale(t *testing.T) {
+	t.Parallel()
+
+	// G major scale tones (G A B C D E F# G).
+	freqs := []float64{392.0, 440.0, 493.88, 523.25, 587.33, 659.25, 739.99, 783.99}
+	var samples []float64
+	sr := 44100
+	for _, f := range freqs {
+		samples = append(samples, tones(sr, 1, f)...)
+	}
+	got, ok := estimateKey(samples, sr)
+	if !ok {
+		t.Fatal("estimateKey returned ok=false")
+	}
+	if got.Tonic != "G" || got.Scale != "major" {
+		t.Fatalf("key = %s %s (conf %.2f), want G major", got.Tonic, got.Scale, got.Confidence)
+	}
+}
+
+// tones synthesizes the sum of the given sine frequencies for the duration.
+func tones(sampleRate, seconds int, freqs ...float64) []float64 {
+	n := sampleRate * seconds
+	out := make([]float64, n)
+	for i := 0; i < n; i++ {
+		var v float64
+		for _, f := range freqs {
+			v += math.Sin(2 * math.Pi * f * float64(i) / float64(sampleRate))
+		}
+		out[i] = v / float64(len(freqs))
+	}
+	return out
+}

--- a/internal/tools/ableton_analyze_audio.go
+++ b/internal/tools/ableton_analyze_audio.go
@@ -24,6 +24,9 @@ type AnalyzeLocalAudioOutput struct {
 	BPMConfidence     float64 `json:"bpm_confidence"`
 	OnsetCount        int     `json:"onset_count"`
 	SuggestedWarpMode string  `json:"suggested_warp_mode"`
+	Key               string  `json:"key,omitempty"`
+	Scale             string  `json:"scale,omitempty"`
+	KeyConfidence     float64 `json:"key_confidence,omitempty"`
 	LengthBarsAtBPM   float64 `json:"length_bars_at_project_tempo,omitempty"`
 	Note              string  `json:"note"`
 	NextStep          string  `json:"next_step"`
@@ -31,7 +34,7 @@ type AnalyzeLocalAudioOutput struct {
 
 func NewAbletonAnalyzeLocalAudio(g *genkit.Genkit) ai.Tool {
 	return genkit.DefineTool(g, "ableton_analyze_local_audio",
-		"Analyze a local .wav file for sampling placement (duration, levels, estimated BPM). Does not download URLs or extract melodies/notes.",
+		"Analyze a local .wav file for sampling placement (duration, levels, estimated BPM, approximate key/scale). Does not download URLs or extract melodies/notes.",
 		func(_ *ai.ToolContext, input AnalyzeLocalAudioInput) (AnalyzeLocalAudioOutput, error) {
 			return analyzeLocalAudio(input)
 		},
@@ -59,6 +62,9 @@ func analyzeLocalAudio(input AnalyzeLocalAudioInput) (AnalyzeLocalAudioOutput, e
 		BPMConfidence:     got.BPMConfidence,
 		OnsetCount:        got.OnsetCount,
 		SuggestedWarpMode: got.SuggestedWarpMode,
+		Key:               got.Key,
+		Scale:             got.Scale,
+		KeyConfidence:     got.KeyConfidence,
 		LengthBarsAtBPM:   got.LengthBarsAtBPM,
 		Note:              got.Note,
 		NextStep:          "If you load this sample into Live, use ableton_match_clip_tempo with the suggested_warp_mode so it follows the project tempo.",

--- a/internal/tools/ableton_analyze_url.go
+++ b/internal/tools/ableton_analyze_url.go
@@ -24,6 +24,9 @@ type AnalyzeAudioURLOutput struct {
 	BPMConfidence     float64 `json:"bpm_confidence"`
 	OnsetCount        int     `json:"onset_count"`
 	SuggestedWarpMode string  `json:"suggested_warp_mode"`
+	Key               string  `json:"key,omitempty"`
+	Scale             string  `json:"scale,omitempty"`
+	KeyConfidence     float64 `json:"key_confidence,omitempty"`
 	LengthBarsAtBPM   float64 `json:"length_bars_at_project_tempo,omitempty"`
 	Note              string  `json:"note"`
 	NextStep          string  `json:"next_step"`
@@ -31,7 +34,7 @@ type AnalyzeAudioURLOutput struct {
 
 func NewAbletonAnalyzeAudioURL(g *genkit.Genkit) ai.Tool {
 	return genkit.DefineTool(g, "ableton_analyze_audio_url",
-		"Reference-analyze audio at an http(s) URL (e.g. YouTube) for tempo/length/levels. Streams a short window through yt-dlp+ffmpeg in memory, saves nothing, and never extracts melodies or notes. Requires yt-dlp and ffmpeg on PATH; you are responsible for your right to access the URL.",
+		"Reference-analyze audio at an http(s) URL (e.g. YouTube) for tempo/length/levels and approximate key/scale. Streams a short window through yt-dlp+ffmpeg in memory, saves nothing, and never extracts melodies or notes. Requires yt-dlp and ffmpeg on PATH; you are responsible for your right to access the URL.",
 		func(tc *ai.ToolContext, input AnalyzeAudioURLInput) (AnalyzeAudioURLOutput, error) {
 			projectTempo := 0.0
 			if input.ProjectTempo != nil {
@@ -53,9 +56,12 @@ func NewAbletonAnalyzeAudioURL(g *genkit.Genkit) ai.Tool {
 				BPMConfidence:     got.BPMConfidence,
 				OnsetCount:        got.OnsetCount,
 				SuggestedWarpMode: got.SuggestedWarpMode,
+				Key:               got.Key,
+				Scale:             got.Scale,
+				KeyConfidence:     got.KeyConfidence,
 				LengthBarsAtBPM:   got.LengthBarsAtBPM,
 				Note:              got.Note,
-				NextStep:          "Use the tempo/length as a reference to build your own part. This tool does not import the audio; place only samples you have the right to use.",
+				NextStep:          "Use the tempo/length/key as a reference to build your own part. This tool does not import the audio; place only samples you have the right to use.",
 			}, nil
 		},
 	)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add an approximate **key / scale** estimate to both analysis tools
(`ableton_analyze_local_audio` and `ableton_analyze_audio_url`). This is the
first step toward the "harmony reference" the workflow was heading for: enough
to start building a part in a matching key, without transcribing the source.

New output fields: `key` (e.g. `C`, `F#`), `scale` (`major`/`minor`), and
`key_confidence`.

## How

Pure Go, no new dependencies:

- Self-contained iterative radix-2 (Cooley-Tukey) FFT.
- Chromagram: Hann-windowed frames, magnitude binned into 12 pitch classes over
  a musical fundamental range.
- Key match: Pearson correlation of the chroma vector against Krumhansl-Kessler
  major/minor profiles across all 24 rotations; confidence is the margin
  between the best and next-best fit.

## Scope / honesty

- This is a **reference hint**, not ground truth. Dense, produced mixes can fool
  chroma-based key detection, so a confidence is always returned.
- Still no melody, note-for-note MIDI, or sound-design extraction — those remain
  intentionally out of scope (feasibility + copyright).

## Testing

- `go test ./...` — new tests cover FFT correctness (sine → expected bin) and
  key detection on synthesized tones (C major triad → C major; G major scale →
  G major).

## Note

Stacked on #38 (`cursor/analyze-local-audio-3711`); merge that first, then this
diff reduces to just the key-detection changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

