### PR TITLE
feat: estimate approximate chord progression in audio analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,14 @@ performance.
 Key/scale is a chroma-based estimate (Krumhansl profiles) reported with a
 confidence; treat it as a starting hint, since dense mixes can fool it.
 
+They also return an approximate **chord progression**: the audio is split into
+short windows, each matched to a major/minor triad, and consecutive matches are
+merged into a timed sequence (`chord_progression`) plus a compact summary
+(`chord_summary`, e.g. `C | G | Am | F`). Low-confidence spans are marked
+`N.C.`. This covers only major/minor triads — extended chords, inversions, and
+busy mixes will be approximated, so use it as a reference for building your own
+part, not as a transcription.
+
 - `ableton_analyze_local_audio` — inspects a **local `.wav` path you already have**. No network access.
 - `ableton_analyze_audio_url` — reference-analyzes an `http(s)` URL (e.g. YouTube). It streams at most 60s through `yt-dlp` + `ffmpeg` **in memory, analyzes it, and discards it** — nothing is written to disk.
 
@@ -287,8 +295,8 @@ Use results with files you have rights to use, then load into Live and call
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
 | `ableton_match_clip_tempo` | Enable Warp on an audio clip so it follows the project tempo (`beats` or `complex`) |
-| `ableton_analyze_local_audio` | Analyze a local `.wav` (duration, levels, estimated BPM, approx. key/scale). Rejects URLs; no melody/note extraction |
-| `ableton_analyze_audio_url` | Reference-analyze an `http(s)`/YouTube URL (tempo/length/levels, approx. key/scale). Streams via yt-dlp+ffmpeg in memory, saves nothing; requires yt-dlp+ffmpeg |
+| `ableton_analyze_local_audio` | Analyze a local `.wav` (duration, levels, BPM, approx. key/scale + chord progression). Rejects URLs; no melody/note extraction |
+| `ableton_analyze_audio_url` | Reference-analyze an `http(s)`/YouTube URL (tempo/length/levels, approx. key/scale + chord progression). Streams via yt-dlp+ffmpeg in memory, saves nothing; requires yt-dlp+ffmpeg |
 | `ableton_compare_ab_variation` | Preferred A/B entry: create one drum/bass/scene variation, audition A→B, return a preference prompt |
 | `ableton_create_drum_variation` | Create-only drum A/B variation (groove / density / fill); use when you do not want audition yet |
 | `ableton_create_bass_variation` | Create-only bass A/B variation (octave / staccato / groove) |

--- a/internal/audioanalyze/analyze.go
+++ b/internal/audioanalyze/analyze.go
@@ -21,22 +21,24 @@ const (
 )
 
 type Result struct {
-	Path              string  `json:"path"`
-	Format            string  `json:"format"`
-	DurationSec       float64 `json:"duration_sec"`
-	SampleRate        int     `json:"sample_rate"`
-	Channels          int     `json:"channels"`
-	PeakLevel         float64 `json:"peak_level"`
-	RMSLevel          float64 `json:"rms_level"`
-	EstimatedBPM      float64 `json:"estimated_bpm"`
-	BPMConfidence     float64 `json:"bpm_confidence"`
-	OnsetCount        int     `json:"onset_count"`
-	SuggestedWarpMode string  `json:"suggested_warp_mode"`
-	Key               string  `json:"key,omitempty"`
-	Scale             string  `json:"scale,omitempty"`
-	KeyConfidence     float64 `json:"key_confidence,omitempty"`
-	LengthBarsAtBPM   float64 `json:"length_bars_at_project_tempo,omitempty"`
-	Note              string  `json:"note"`
+	Path              string         `json:"path"`
+	Format            string         `json:"format"`
+	DurationSec       float64        `json:"duration_sec"`
+	SampleRate        int            `json:"sample_rate"`
+	Channels          int            `json:"channels"`
+	PeakLevel         float64        `json:"peak_level"`
+	RMSLevel          float64        `json:"rms_level"`
+	EstimatedBPM      float64        `json:"estimated_bpm"`
+	BPMConfidence     float64        `json:"bpm_confidence"`
+	OnsetCount        int            `json:"onset_count"`
+	SuggestedWarpMode string         `json:"suggested_warp_mode"`
+	Key               string         `json:"key,omitempty"`
+	Scale             string         `json:"scale,omitempty"`
+	KeyConfidence     float64        `json:"key_confidence,omitempty"`
+	ChordProgression  []ChordSegment `json:"chord_progression,omitempty"`
+	ChordSummary      string         `json:"chord_summary,omitempty"`
+	LengthBarsAtBPM   float64        `json:"length_bars_at_project_tempo,omitempty"`
+	Note              string         `json:"note"`
 }
 
 // AnalyzeFile analyzes a local WAV file already present on disk. It never
@@ -116,6 +118,10 @@ func analyzeWAVStream(r io.Reader, projectTempo float64) (Result, error) {
 		out.Key = key.Tonic
 		out.Scale = key.Scale
 		out.KeyConfidence = key.Confidence
+	}
+	if chords, summary, ok := estimateChords(analyze, sampleRate); ok {
+		out.ChordProgression = chords
+		out.ChordSummary = summary
 	}
 	if projectTempo > 0 && duration > 0 {
 		beats := duration * (projectTempo / 60)

--- a/internal/audioanalyze/chords.go
+++ b/internal/audioanalyze/chords.go
@@ -1,0 +1,156 @@
+package audioanalyze
+
+import (
+	"math"
+	"strings"
+)
+
+// Chord detection groups frame chromas into short segments and matches each
+// against the 24 major/minor triad templates. It is an approximate reference
+// only: dense mixes, extended chords, and inversions can shift the estimate, so
+// each segment carries a confidence and low-confidence spans are marked "N.C.".
+
+const (
+	chordSegmentSec = 0.75 // window used to classify a single chord
+	chordMinConf    = 0.30 // below this a segment is treated as no-chord
+	maxChordSummary = 24   // cap chords listed in the summary string
+)
+
+// ChordSegment is one detected chord span, with timing relative to the analyzed
+// audio.
+type ChordSegment struct {
+	StartSec    float64 `json:"start_sec"`
+	DurationSec float64 `json:"duration_sec"`
+	Chord       string  `json:"chord"`
+	Confidence  float64 `json:"confidence"`
+}
+
+// estimateChords returns a merged chord progression and a compact summary
+// string (e.g. "C | G | Am | F"). It returns ok=false when the audio is too
+// short to segment.
+func estimateChords(samples []float64, sampleRate int) ([]ChordSegment, string, bool) {
+	frames := frameChromas(samples, sampleRate)
+	if len(frames) == 0 || sampleRate <= 0 {
+		return nil, "", false
+	}
+	frameSec := frameDurationSec(sampleRate)
+	framesPerSegment := int(math.Round(chordSegmentSec / frameSec))
+	if framesPerSegment < 1 {
+		framesPerSegment = 1
+	}
+
+	var raw []ChordSegment
+	for start := 0; start < len(frames); start += framesPerSegment {
+		end := start + framesPerSegment
+		if end > len(frames) {
+			end = len(frames)
+		}
+		var acc [12]float64
+		for _, f := range frames[start:end] {
+			for pc := 0; pc < 12; pc++ {
+				acc[pc] += f[pc]
+			}
+		}
+		chord, conf := classifyChord(acc)
+		raw = append(raw, ChordSegment{
+			StartSec:    round2(float64(start) * frameSec),
+			DurationSec: round2(float64(end-start) * frameSec),
+			Chord:       chord,
+			Confidence:  conf,
+		})
+	}
+	if len(raw) == 0 {
+		return nil, "", false
+	}
+
+	merged := mergeChordRuns(raw)
+	return merged, chordSummary(merged), true
+}
+
+// classifyChord matches a chroma vector against 24 triad templates.
+func classifyChord(chroma [12]float64) (string, float64) {
+	var total float64
+	for _, v := range chroma {
+		total += v
+	}
+	if total <= 0 {
+		return "N.C.", 0
+	}
+
+	bestCorr := math.Inf(-1)
+	secondCorr := math.Inf(-1)
+	bestName := "N.C."
+	for root := 0; root < 12; root++ {
+		for _, q := range chordQualities {
+			tmpl := triadTemplate(root, q.intervals)
+			corr := pearson(chroma[:], tmpl[:])
+			if corr > bestCorr {
+				secondCorr = bestCorr
+				bestCorr = corr
+				bestName = pitchClassNames[root] + q.suffix
+			} else if corr > secondCorr {
+				secondCorr = corr
+			}
+		}
+	}
+
+	conf := 0.0
+	if !math.IsInf(secondCorr, -1) && bestCorr > 0 {
+		conf = math.Max(0, math.Min(1, (bestCorr-secondCorr)/math.Max(bestCorr, 1e-9)))
+	}
+	conf = round2(conf)
+	if bestCorr <= 0 || conf < chordMinConf {
+		return "N.C.", conf
+	}
+	return bestName, conf
+}
+
+type chordQuality struct {
+	suffix    string
+	intervals [3]int
+}
+
+var chordQualities = []chordQuality{
+	{suffix: "", intervals: [3]int{0, 4, 7}},  // major
+	{suffix: "m", intervals: [3]int{0, 3, 7}}, // minor
+}
+
+func triadTemplate(root int, intervals [3]int) [12]float64 {
+	var t [12]float64
+	for _, iv := range intervals {
+		t[(root+iv)%12] = 1
+	}
+	return t
+}
+
+// mergeChordRuns collapses consecutive segments with the same chord into a
+// single span and keeps the strongest confidence seen in the run.
+func mergeChordRuns(segs []ChordSegment) []ChordSegment {
+	var out []ChordSegment
+	for _, s := range segs {
+		if len(out) > 0 && out[len(out)-1].Chord == s.Chord {
+			last := &out[len(out)-1]
+			last.DurationSec = round2(last.DurationSec + s.DurationSec)
+			if s.Confidence > last.Confidence {
+				last.Confidence = s.Confidence
+			}
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func chordSummary(segs []ChordSegment) string {
+	parts := make([]string, 0, len(segs))
+	for _, s := range segs {
+		if s.Chord == "N.C." {
+			continue
+		}
+		parts = append(parts, s.Chord)
+		if len(parts) >= maxChordSummary {
+			break
+		}
+	}
+	return strings.Join(parts, " | ")
+}

--- a/internal/audioanalyze/chords_test.go
+++ b/internal/audioanalyze/chords_test.go
@@ -1,0 +1,79 @@
+package audioanalyze
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClassifyChordCMajor(t *testing.T) {
+	t.Parallel()
+
+	// C, E, G -> C major.
+	samples := tones(44100, 2, 261.63, 329.63, 392.0)
+	chroma := chromagram(samples, 44100)
+	chord, conf := classifyChord(chroma)
+	if chord != "C" {
+		t.Fatalf("chord = %s (conf %.2f), want C", chord, conf)
+	}
+}
+
+func TestClassifyChordAMinor(t *testing.T) {
+	t.Parallel()
+
+	// A, C, E -> A minor.
+	samples := tones(44100, 2, 440.0, 523.25, 659.25)
+	chroma := chromagram(samples, 44100)
+	chord, conf := classifyChord(chroma)
+	if chord != "Am" {
+		t.Fatalf("chord = %s (conf %.2f), want Am", chord, conf)
+	}
+}
+
+func TestEstimateChordsProgression(t *testing.T) {
+	t.Parallel()
+
+	sr := 44100
+	// 2s C major then 2s G major.
+	var samples []float64
+	samples = append(samples, tones(sr, 2, 261.63, 329.63, 392.0)...)
+	samples = append(samples, tones(sr, 2, 392.0, 493.88, 587.33)...)
+
+	segs, summary, ok := estimateChords(samples, sr)
+	if !ok || len(segs) == 0 {
+		t.Fatal("estimateChords returned no result")
+	}
+	if !strings.Contains(summary, "C") || !strings.Contains(summary, "G") {
+		t.Fatalf("summary = %q, want both C and G", summary)
+	}
+	// First detected chord should be C, and the progression should move to G.
+	if segs[0].Chord != "C" {
+		t.Errorf("first chord = %s, want C", segs[0].Chord)
+	}
+	sawG := false
+	for _, s := range segs {
+		if s.Chord == "G" {
+			sawG = true
+		}
+	}
+	if !sawG {
+		t.Errorf("progression never reached G: %+v", segs)
+	}
+}
+
+func TestEstimateChordsSilenceIsNoChord(t *testing.T) {
+	t.Parallel()
+
+	samples := make([]float64, 44100*2)
+	segs, summary, ok := estimateChords(samples, 44100)
+	if !ok {
+		t.Fatal("expected ok for long-enough input")
+	}
+	if summary != "" {
+		t.Errorf("silent audio summary = %q, want empty", summary)
+	}
+	for _, s := range segs {
+		if s.Chord != "N.C." {
+			t.Errorf("silent segment chord = %s, want N.C.", s.Chord)
+		}
+	}
+}

--- a/internal/audioanalyze/key.go
+++ b/internal/audioanalyze/key.go
@@ -113,6 +113,18 @@ func pearson(a, b []float64) float64 {
 // chromagram accumulates spectral magnitude into 12 pitch classes across frames.
 func chromagram(samples []float64, sampleRate int) [12]float64 {
 	var chroma [12]float64
+	for _, frame := range frameChromas(samples, sampleRate) {
+		for pc := 0; pc < 12; pc++ {
+			chroma[pc] += frame[pc]
+		}
+	}
+	return chroma
+}
+
+// frameChromas returns a chroma vector (12 pitch-class magnitudes) per analysis
+// frame, at keyHopSize spacing. Each frame is used for both key and chord
+// estimation.
+func frameChromas(samples []float64, sampleRate int) [][12]float64 {
 	window := hannWindow(keyFrameSize)
 	buf := make([]float64, keyFrameSize)
 	minBin := int(math.Floor(keyMinFreq * float64(keyFrameSize) / float64(sampleRate)))
@@ -124,11 +136,13 @@ func chromagram(samples []float64, sampleRate int) [12]float64 {
 		maxBin = keyFrameSize / 2
 	}
 
+	var frames [][12]float64
 	for start := 0; start+keyFrameSize <= len(samples); start += keyHopSize {
 		for i := 0; i < keyFrameSize; i++ {
 			buf[i] = samples[start+i] * window[i]
 		}
 		re, im := fftReal(buf)
+		var chroma [12]float64
 		for bin := minBin; bin <= maxBin; bin++ {
 			mag := math.Hypot(re[bin], im[bin])
 			if mag <= 0 {
@@ -142,8 +156,14 @@ func chromagram(samples []float64, sampleRate int) [12]float64 {
 			}
 			chroma[pc] += mag
 		}
+		frames = append(frames, chroma)
 	}
-	return chroma
+	return frames
+}
+
+// frameDurationSec is the wall-clock spacing between consecutive frame chromas.
+func frameDurationSec(sampleRate int) float64 {
+	return float64(keyHopSize) / float64(sampleRate)
 }
 
 func hannWindow(n int) []float64 {

--- a/internal/tools/ableton_analyze_audio.go
+++ b/internal/tools/ableton_analyze_audio.go
@@ -13,28 +13,30 @@ type AnalyzeLocalAudioInput struct {
 }
 
 type AnalyzeLocalAudioOutput struct {
-	Path              string  `json:"path"`
-	Format            string  `json:"format"`
-	DurationSec       float64 `json:"duration_sec"`
-	SampleRate        int     `json:"sample_rate"`
-	Channels          int     `json:"channels"`
-	PeakLevel         float64 `json:"peak_level"`
-	RMSLevel          float64 `json:"rms_level"`
-	EstimatedBPM      float64 `json:"estimated_bpm"`
-	BPMConfidence     float64 `json:"bpm_confidence"`
-	OnsetCount        int     `json:"onset_count"`
-	SuggestedWarpMode string  `json:"suggested_warp_mode"`
-	Key               string  `json:"key,omitempty"`
-	Scale             string  `json:"scale,omitempty"`
-	KeyConfidence     float64 `json:"key_confidence,omitempty"`
-	LengthBarsAtBPM   float64 `json:"length_bars_at_project_tempo,omitempty"`
-	Note              string  `json:"note"`
-	NextStep          string  `json:"next_step"`
+	Path              string                      `json:"path"`
+	Format            string                      `json:"format"`
+	DurationSec       float64                     `json:"duration_sec"`
+	SampleRate        int                         `json:"sample_rate"`
+	Channels          int                         `json:"channels"`
+	PeakLevel         float64                     `json:"peak_level"`
+	RMSLevel          float64                     `json:"rms_level"`
+	EstimatedBPM      float64                     `json:"estimated_bpm"`
+	BPMConfidence     float64                     `json:"bpm_confidence"`
+	OnsetCount        int                         `json:"onset_count"`
+	SuggestedWarpMode string                      `json:"suggested_warp_mode"`
+	Key               string                      `json:"key,omitempty"`
+	Scale             string                      `json:"scale,omitempty"`
+	KeyConfidence     float64                     `json:"key_confidence,omitempty"`
+	ChordProgression  []audioanalyze.ChordSegment `json:"chord_progression,omitempty"`
+	ChordSummary      string                      `json:"chord_summary,omitempty"`
+	LengthBarsAtBPM   float64                     `json:"length_bars_at_project_tempo,omitempty"`
+	Note              string                      `json:"note"`
+	NextStep          string                      `json:"next_step"`
 }
 
 func NewAbletonAnalyzeLocalAudio(g *genkit.Genkit) ai.Tool {
 	return genkit.DefineTool(g, "ableton_analyze_local_audio",
-		"Analyze a local .wav file for sampling placement (duration, levels, estimated BPM, approximate key/scale). Does not download URLs or extract melodies/notes.",
+		"Analyze a local .wav file for sampling placement (duration, levels, estimated BPM, approximate key/scale and chord progression). Does not download URLs or extract melodies/notes.",
 		func(_ *ai.ToolContext, input AnalyzeLocalAudioInput) (AnalyzeLocalAudioOutput, error) {
 			return analyzeLocalAudio(input)
 		},
@@ -65,6 +67,8 @@ func analyzeLocalAudio(input AnalyzeLocalAudioInput) (AnalyzeLocalAudioOutput, e
 		Key:               got.Key,
 		Scale:             got.Scale,
 		KeyConfidence:     got.KeyConfidence,
+		ChordProgression:  got.ChordProgression,
+		ChordSummary:      got.ChordSummary,
 		LengthBarsAtBPM:   got.LengthBarsAtBPM,
 		Note:              got.Note,
 		NextStep:          "If you load this sample into Live, use ableton_match_clip_tempo with the suggested_warp_mode so it follows the project tempo.",

--- a/internal/tools/ableton_analyze_url.go
+++ b/internal/tools/ableton_analyze_url.go
@@ -13,28 +13,30 @@ type AnalyzeAudioURLInput struct {
 }
 
 type AnalyzeAudioURLOutput struct {
-	Source            string  `json:"source"`
-	Format            string  `json:"format"`
-	DurationSec       float64 `json:"duration_sec"`
-	SampleRate        int     `json:"sample_rate"`
-	Channels          int     `json:"channels"`
-	PeakLevel         float64 `json:"peak_level"`
-	RMSLevel          float64 `json:"rms_level"`
-	EstimatedBPM      float64 `json:"estimated_bpm"`
-	BPMConfidence     float64 `json:"bpm_confidence"`
-	OnsetCount        int     `json:"onset_count"`
-	SuggestedWarpMode string  `json:"suggested_warp_mode"`
-	Key               string  `json:"key,omitempty"`
-	Scale             string  `json:"scale,omitempty"`
-	KeyConfidence     float64 `json:"key_confidence,omitempty"`
-	LengthBarsAtBPM   float64 `json:"length_bars_at_project_tempo,omitempty"`
-	Note              string  `json:"note"`
-	NextStep          string  `json:"next_step"`
+	Source            string                      `json:"source"`
+	Format            string                      `json:"format"`
+	DurationSec       float64                     `json:"duration_sec"`
+	SampleRate        int                         `json:"sample_rate"`
+	Channels          int                         `json:"channels"`
+	PeakLevel         float64                     `json:"peak_level"`
+	RMSLevel          float64                     `json:"rms_level"`
+	EstimatedBPM      float64                     `json:"estimated_bpm"`
+	BPMConfidence     float64                     `json:"bpm_confidence"`
+	OnsetCount        int                         `json:"onset_count"`
+	SuggestedWarpMode string                      `json:"suggested_warp_mode"`
+	Key               string                      `json:"key,omitempty"`
+	Scale             string                      `json:"scale,omitempty"`
+	KeyConfidence     float64                     `json:"key_confidence,omitempty"`
+	ChordProgression  []audioanalyze.ChordSegment `json:"chord_progression,omitempty"`
+	ChordSummary      string                      `json:"chord_summary,omitempty"`
+	LengthBarsAtBPM   float64                     `json:"length_bars_at_project_tempo,omitempty"`
+	Note              string                      `json:"note"`
+	NextStep          string                      `json:"next_step"`
 }
 
 func NewAbletonAnalyzeAudioURL(g *genkit.Genkit) ai.Tool {
 	return genkit.DefineTool(g, "ableton_analyze_audio_url",
-		"Reference-analyze audio at an http(s) URL (e.g. YouTube) for tempo/length/levels and approximate key/scale. Streams a short window through yt-dlp+ffmpeg in memory, saves nothing, and never extracts melodies or notes. Requires yt-dlp and ffmpeg on PATH; you are responsible for your right to access the URL.",
+		"Reference-analyze audio at an http(s) URL (e.g. YouTube) for tempo/length/levels, approximate key/scale and chord progression. Streams a short window through yt-dlp+ffmpeg in memory, saves nothing, and never extracts melodies or notes. Requires yt-dlp and ffmpeg on PATH; you are responsible for your right to access the URL.",
 		func(tc *ai.ToolContext, input AnalyzeAudioURLInput) (AnalyzeAudioURLOutput, error) {
 			projectTempo := 0.0
 			if input.ProjectTempo != nil {
@@ -59,9 +61,11 @@ func NewAbletonAnalyzeAudioURL(g *genkit.Genkit) ai.Tool {
 				Key:               got.Key,
 				Scale:             got.Scale,
 				KeyConfidence:     got.KeyConfidence,
+				ChordProgression:  got.ChordProgression,
+				ChordSummary:      got.ChordSummary,
 				LengthBarsAtBPM:   got.LengthBarsAtBPM,
 				Note:              got.Note,
-				NextStep:          "Use the tempo/length/key as a reference to build your own part. This tool does not import the audio; place only samples you have the right to use.",
+				NextStep:          "Use the tempo/key/chord progression as a reference to build your own part. This tool does not import the audio; place only samples you have the right to use.",
 			}, nil
 		},
 	)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add an approximate **chord progression** to both analysis tools
(`ableton_analyze_local_audio` and `ableton_analyze_audio_url`), building on the
key/scale estimate. This gives a harmonic reference to build a part against.

New output fields:

- `chord_progression` — a timed sequence of segments (`start_sec`,
  `duration_sec`, `chord`, `confidence`).
- `chord_summary` — a compact string, e.g. `C | G | Am | F`.

## How

Pure Go, no new dependencies (reuses the FFT/chromagram from key detection):

- The per-frame chromagram is factored out and reused for both key and chords.
- Each ~0.75s window's chroma is matched (Pearson correlation) against the 24
  major/minor triad templates.
- Consecutive identical matches are merged into timed runs; low-confidence
  windows become `N.C.` (no chord).

## Scope / honesty

- **Reference only, not a transcription.** Only major/minor triads are modeled —
  extended chords, inversions, and dense mixes are approximated, so each segment
  carries a confidence.
- Still no melody or note-for-note MIDI extraction.

## Testing

- `go test ./...` — new tests cover single-chord classification (C major triad →
  `C`; A minor triad → `Am`), a two-chord progression (C→G detected in order),
  and silence (→ `N.C.`, empty summary).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

