### PR TITLE
feat: detect section structure and analyze full-length URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Compare mix balance with snapshots you can restore
 - Humanize MIDI clips with microtiming, velocity variation, and swing
 - Match an audio clip to the project tempo with Warp (e.g. after loading a sample)
-- Analyze a local `.wav`, or reference-analyze an `http(s)`/YouTube URL, for duration, levels, estimated BPM, and approximate key/scale (URL streams in memory and is never saved)
+- Analyze a local `.wav`, or reference-analyze an `http(s)`/YouTube URL, for duration, levels, BPM, approximate key/scale, chord progression, and an energy-based section map (URL streams in memory and is never saved)
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots and send raw OSC for advanced control
@@ -260,8 +260,14 @@ merged into a timed sequence (`chord_progression`) plus a compact summary
 busy mixes will be approximated, so use it as a reference for building your own
 part, not as a transcription.
 
+They also return an approximate **section map** (`sections`): the track is
+divided by a self-similarity/novelty analysis, and each span is labeled by
+relative energy (`low` / `medium` / `high`) with its start time. Use it to spot
+likely intros/breakdowns (low energy) versus drops/choruses (high energy). It is
+a coarse structural map, not a semantic labeling of the song's form.
+
 - `ableton_analyze_local_audio` — inspects a **local `.wav` path you already have**. No network access.
-- `ableton_analyze_audio_url` — reference-analyzes an `http(s)` URL (e.g. YouTube). It streams at most 60s through `yt-dlp` + `ffmpeg` **in memory, analyzes it, and discards it** — nothing is written to disk.
+- `ableton_analyze_audio_url` — reference-analyzes an `http(s)` URL (e.g. YouTube). It streams the track through `yt-dlp` + `ffmpeg` **in memory, analyzes it, and discards it** — nothing is written to disk (bounded to ~15 min for safety).
 
 `ableton_analyze_audio_url` requires `yt-dlp` and `ffmpeg` on `PATH`; this server
 never downloads on its own. Accessing some sites may violate their terms of
@@ -295,8 +301,8 @@ Use results with files you have rights to use, then load into Live and call
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
 | `ableton_match_clip_tempo` | Enable Warp on an audio clip so it follows the project tempo (`beats` or `complex`) |
-| `ableton_analyze_local_audio` | Analyze a local `.wav` (duration, levels, BPM, approx. key/scale + chord progression). Rejects URLs; no melody/note extraction |
-| `ableton_analyze_audio_url` | Reference-analyze an `http(s)`/YouTube URL (tempo/length/levels, approx. key/scale + chord progression). Streams via yt-dlp+ffmpeg in memory, saves nothing; requires yt-dlp+ffmpeg |
+| `ableton_analyze_local_audio` | Analyze a local `.wav` (duration, levels, BPM, approx. key/scale + chords + section map). Rejects URLs; no melody/note extraction |
+| `ableton_analyze_audio_url` | Reference-analyze an `http(s)`/YouTube URL (tempo/length/levels, approx. key/scale + chords + section map). Streams the full track via yt-dlp+ffmpeg in memory, saves nothing; requires yt-dlp+ffmpeg |
 | `ableton_compare_ab_variation` | Preferred A/B entry: create one drum/bass/scene variation, audition A→B, return a preference prompt |
 | `ableton_create_drum_variation` | Create-only drum A/B variation (groove / density / fill); use when you do not want audition yet |
 | `ableton_create_bass_variation` | Create-only bass A/B variation (octave / staccato / groove) |

--- a/internal/audioanalyze/analyze.go
+++ b/internal/audioanalyze/analyze.go
@@ -37,6 +37,7 @@ type Result struct {
 	KeyConfidence     float64        `json:"key_confidence,omitempty"`
 	ChordProgression  []ChordSegment `json:"chord_progression,omitempty"`
 	ChordSummary      string         `json:"chord_summary,omitempty"`
+	Sections          []Section      `json:"sections,omitempty"`
 	LengthBarsAtBPM   float64        `json:"length_bars_at_project_tempo,omitempty"`
 	Note              string         `json:"note"`
 }
@@ -122,6 +123,11 @@ func analyzeWAVStream(r io.Reader, projectTempo float64) (Result, error) {
 	if chords, summary, ok := estimateChords(analyze, sampleRate); ok {
 		out.ChordProgression = chords
 		out.ChordSummary = summary
+	}
+	// Structure uses the full decoded audio (URL sources are already capped at
+	// fetch time), so local files get whole-track sections.
+	if sections, ok := estimateSections(mono, sampleRate); ok {
+		out.Sections = sections
 	}
 	if projectTempo > 0 && duration > 0 {
 		beats := duration * (projectTempo / 60)

--- a/internal/audioanalyze/sections.go
+++ b/internal/audioanalyze/sections.go
@@ -1,0 +1,274 @@
+package audioanalyze
+
+import "math"
+
+// Section structure detection groups frames into ~1s blocks, builds a
+// self-similarity matrix over combined harmonic+energy features, and finds
+// boundaries with a Foote checkerboard novelty function. Each resulting section
+// is labeled by relative energy (low/medium/high) so callers can spot likely
+// intros/breakdowns vs. drops/choruses. It is an approximate structural map,
+// not a semantic label of the song's form.
+
+const (
+	sectionBlockSec  = 1.0 // block resolution for structure
+	sectionKernelMax = 8   // checkerboard kernel half-size cap
+	maxSectionBlocks = 900 // bound compute (~15 min at 1s blocks)
+	minSectionBlocks = 8   // below this, structure is not meaningful
+	energyLowRatio   = 0.40
+	energyHighRatio  = 0.75
+	// sectionEnergyWeight scales the energy dimension so loudness contrasts
+	// (e.g. breakdown -> drop with the same harmony) still create boundaries.
+	sectionEnergyWeight = 3.0
+)
+
+// Section is one detected structural span.
+type Section struct {
+	StartSec    float64 `json:"start_sec"`
+	DurationSec float64 `json:"duration_sec"`
+	Energy      float64 `json:"energy"` // 0..1 relative to the loudest section
+	Label       string  `json:"label"`  // low | medium | high (energy tier)
+}
+
+// estimateSections returns a coarse structural map of the audio. It returns
+// ok=false when the audio is too short to segment meaningfully.
+func estimateSections(samples []float64, sampleRate int) ([]Section, bool) {
+	if sampleRate <= 0 {
+		return nil, false
+	}
+	frames := frameChromas(samples, sampleRate)
+	frameSec := frameDurationSec(sampleRate)
+	framesPerBlock := int(math.Round(sectionBlockSec / frameSec))
+	if framesPerBlock < 1 {
+		framesPerBlock = 1
+	}
+
+	chromas, energies := blockFeatures(frames, framesPerBlock)
+	if len(chromas) > maxSectionBlocks {
+		chromas = chromas[:maxSectionBlocks]
+		energies = energies[:maxSectionBlocks]
+	}
+	if len(chromas) < minSectionBlocks {
+		return nil, false
+	}
+	blockSec := float64(framesPerBlock) * frameSec
+
+	features := combinedFeatures(chromas, energies)
+	novelty := footeNovelty(features)
+	boundaries := pickBoundaries(novelty)
+
+	return buildSections(boundaries, energies, blockSec), true
+}
+
+// blockFeatures aggregates per-frame chroma into blocks and returns the summed
+// chroma plus the total energy of each block.
+func blockFeatures(frames [][12]float64, framesPerBlock int) ([][12]float64, []float64) {
+	var chromas [][12]float64
+	var energies []float64
+	for start := 0; start < len(frames); start += framesPerBlock {
+		end := start + framesPerBlock
+		if end > len(frames) {
+			end = len(frames)
+		}
+		var acc [12]float64
+		var energy float64
+		for _, f := range frames[start:end] {
+			for pc := 0; pc < 12; pc++ {
+				acc[pc] += f[pc]
+				energy += f[pc]
+			}
+		}
+		chromas = append(chromas, acc)
+		energies = append(energies, energy)
+	}
+	return chromas, energies
+}
+
+// combinedFeatures builds L2-normalized vectors of (harmonic shape + relative
+// energy) for similarity comparison.
+func combinedFeatures(chromas [][12]float64, energies []float64) [][]float64 {
+	maxEnergy := 0.0
+	for _, e := range energies {
+		if e > maxEnergy {
+			maxEnergy = e
+		}
+	}
+	if maxEnergy <= 0 {
+		maxEnergy = 1
+	}
+
+	out := make([][]float64, len(chromas))
+	for i := range chromas {
+		vec := make([]float64, 13)
+		var norm float64
+		for pc := 0; pc < 12; pc++ {
+			vec[pc] = chromas[i][pc]
+			norm += chromas[i][pc] * chromas[i][pc]
+		}
+		norm = math.Sqrt(norm)
+		if norm > 0 {
+			for pc := 0; pc < 12; pc++ {
+				vec[pc] /= norm
+			}
+		}
+		vec[12] = sectionEnergyWeight * energies[i] / maxEnergy
+		out[i] = vec
+	}
+	return out
+}
+
+// footeNovelty correlates a checkerboard kernel along the self-similarity
+// matrix diagonal to produce a boundary-novelty curve.
+func footeNovelty(features [][]float64) []float64 {
+	n := len(features)
+	half := sectionKernelMax
+	if half > n/2 {
+		half = n / 2
+	}
+	if half < 1 {
+		half = 1
+	}
+	kernel := checkerboardKernel(half)
+	novelty := make([]float64, n)
+	for c := 0; c < n; c++ {
+		var sum float64
+		for i := -half; i < half; i++ {
+			for j := -half; j < half; j++ {
+				ri, rj := c+i, c+j
+				if ri < 0 || rj < 0 || ri >= n || rj >= n {
+					continue
+				}
+				sum += kernel[i+half][j+half] * cosineSim(features[ri], features[rj])
+			}
+		}
+		if sum > 0 {
+			novelty[c] = sum
+		}
+	}
+	return novelty
+}
+
+func checkerboardKernel(half int) [][]float64 {
+	size := 2 * half
+	k := make([][]float64, size)
+	sigma := float64(half) / 2.0
+	for i := 0; i < size; i++ {
+		k[i] = make([]float64, size)
+		for j := 0; j < size; j++ {
+			di := float64(i-half) + 0.5
+			dj := float64(j-half) + 0.5
+			g := math.Exp(-(di*di + dj*dj) / (2 * sigma * sigma))
+			sign := 1.0
+			// Opposite quadrants are positive; adjacent are negative.
+			if (i < half) != (j < half) {
+				sign = -1.0
+			}
+			k[i][j] = sign * g
+		}
+	}
+	return k
+}
+
+func cosineSim(a, b []float64) float64 {
+	var dot, na, nb float64
+	for i := range a {
+		dot += a[i] * b[i]
+		na += a[i] * a[i]
+		nb += b[i] * b[i]
+	}
+	if na <= 1e-12 || nb <= 1e-12 {
+		return 0
+	}
+	return dot / math.Sqrt(na*nb)
+}
+
+// pickBoundaries selects novelty peaks above an adaptive threshold, always
+// including the start (block 0) as the first boundary.
+func pickBoundaries(novelty []float64) []int {
+	n := len(novelty)
+	boundaries := []int{0}
+	if n < 3 {
+		return boundaries
+	}
+	mean, std := meanStd(novelty)
+	threshold := mean + 0.6*std
+	minGap := sectionKernelMax
+	if minGap < 2 {
+		minGap = 2
+	}
+	last := 0
+	for i := 1; i < n-1; i++ {
+		if novelty[i] < threshold {
+			continue
+		}
+		if novelty[i] >= novelty[i-1] && novelty[i] >= novelty[i+1] && i-last >= minGap {
+			boundaries = append(boundaries, i)
+			last = i
+		}
+	}
+	return boundaries
+}
+
+func meanStd(v []float64) (float64, float64) {
+	if len(v) == 0 {
+		return 0, 0
+	}
+	var sum float64
+	for _, x := range v {
+		sum += x
+	}
+	mean := sum / float64(len(v))
+	var varSum float64
+	for _, x := range v {
+		d := x - mean
+		varSum += d * d
+	}
+	return mean, math.Sqrt(varSum / float64(len(v)))
+}
+
+// buildSections turns block boundaries into timed sections with energy labels.
+func buildSections(boundaries []int, energies []float64, blockSec float64) []Section {
+	maxEnergy := 0.0
+	for _, e := range energies {
+		if e > maxEnergy {
+			maxEnergy = e
+		}
+	}
+	if maxEnergy <= 0 {
+		maxEnergy = 1
+	}
+
+	var sections []Section
+	for bi, start := range boundaries {
+		end := len(energies)
+		if bi+1 < len(boundaries) {
+			end = boundaries[bi+1]
+		}
+		if end <= start {
+			continue
+		}
+		var sum float64
+		for _, e := range energies[start:end] {
+			sum += e
+		}
+		avg := sum / float64(end-start)
+		ratio := avg / maxEnergy
+		sections = append(sections, Section{
+			StartSec:    round2(float64(start) * blockSec),
+			DurationSec: round2(float64(end-start) * blockSec),
+			Energy:      round2(ratio),
+			Label:       energyLabel(ratio),
+		})
+	}
+	return sections
+}
+
+func energyLabel(ratio float64) string {
+	switch {
+	case ratio < energyLowRatio:
+		return "low"
+	case ratio < energyHighRatio:
+		return "medium"
+	default:
+		return "high"
+	}
+}

--- a/internal/audioanalyze/sections_test.go
+++ b/internal/audioanalyze/sections_test.go
@@ -1,0 +1,52 @@
+package audioanalyze
+
+import "testing"
+
+func TestEstimateSectionsTooShort(t *testing.T) {
+	t.Parallel()
+
+	samples := tones(44100, 2, 261.63)
+	if _, ok := estimateSections(samples, 44100); ok {
+		t.Fatal("expected ok=false for short audio")
+	}
+}
+
+func TestEstimateSectionsEnergyContrast(t *testing.T) {
+	t.Parallel()
+
+	sr := 44100
+	// 10s quiet C major, then 10s loud C major (same harmony, big energy jump).
+	quiet := scale(tones(sr, 10, 261.63, 329.63, 392.0), 0.1)
+	loud := tones(sr, 10, 261.63, 329.63, 392.0)
+	samples := append(quiet, loud...)
+
+	sections, ok := estimateSections(samples, sr)
+	if !ok {
+		t.Fatal("estimateSections returned ok=false")
+	}
+	if len(sections) < 2 {
+		t.Fatalf("expected at least 2 sections, got %d: %+v", len(sections), sections)
+	}
+	// A boundary should land near the 10s mark.
+	foundBoundary := false
+	for _, s := range sections[1:] {
+		if s.StartSec >= 7 && s.StartSec <= 13 {
+			foundBoundary = true
+		}
+	}
+	if !foundBoundary {
+		t.Errorf("no section boundary near the 10s energy jump: %+v", sections)
+	}
+	// The later, louder section should carry a higher energy label than the first.
+	if sections[0].Energy >= sections[len(sections)-1].Energy {
+		t.Errorf("expected energy to rise across sections: %+v", sections)
+	}
+}
+
+func scale(samples []float64, factor float64) []float64 {
+	out := make([]float64, len(samples))
+	for i, s := range samples {
+		out[i] = s * factor
+	}
+	return out
+}

--- a/internal/audioanalyze/url.go
+++ b/internal/audioanalyze/url.go
@@ -8,17 +8,15 @@ import (
 	"io"
 	"net/url"
 	"os/exec"
-	"strconv"
 	"strings"
 	"time"
 )
 
 const (
-	// urlAnalyzeSeconds bounds how much audio is streamed and decoded. We only
-	// need a short window to estimate tempo/levels, and keeping it short
-	// reinforces that this is reference analysis, not a copy of the work.
-	urlAnalyzeSeconds = 60
-	urlAnalyzeTimeout = 90 * time.Second
+	// urlAnalyzeTimeout bounds the whole fetch+decode. The full track is
+	// streamed (bounded by maxFileBytes), analyzed in memory, and discarded;
+	// nothing is written to disk.
+	urlAnalyzeTimeout = 240 * time.Second
 )
 
 // AnalyzeURL streams a short window of audio referenced by a URL through
@@ -46,7 +44,7 @@ func AnalyzeURL(ctx context.Context, rawURL string, projectTempo float64) (Resul
 	defer cancel()
 
 	dl := exec.CommandContext(ctx, ytdlp, ytDlpArgs(clean)...)
-	ff := exec.CommandContext(ctx, ffmpeg, ffmpegArgs(urlAnalyzeSeconds)...)
+	ff := exec.CommandContext(ctx, ffmpeg, ffmpegArgs()...)
 
 	dlOut, err := dl.StdoutPipe()
 	if err != nil {
@@ -71,7 +69,10 @@ func AnalyzeURL(ctx context.Context, rawURL string, projectTempo float64) (Resul
 
 	wav, readErr := io.ReadAll(io.LimitReader(ffOut, maxFileBytes+1))
 
-	// yt-dlp finishing first (or failing) closes the pipe so ffmpeg exits.
+	// Stop both processes once we have enough audio (e.g. hit the byte cap on a
+	// very long source), then reap them. yt-dlp finishing first also closes the
+	// pipe so ffmpeg exits on its own in the common case.
+	cancel()
 	dlWaitErr := dl.Wait()
 	ffWaitErr := ff.Wait()
 
@@ -92,7 +93,7 @@ func AnalyzeURL(ctx context.Context, rawURL string, projectTempo float64) (Resul
 		return Result{}, err
 	}
 	out.Path = clean
-	out.Note = fmt.Sprintf("URL reference analysis: streamed at most %ds, analyzed in memory, and discarded. Nothing was saved and no melody/notes were extracted. You are responsible for your right to use the source.", urlAnalyzeSeconds)
+	out.Note = "URL reference analysis: streamed in memory, analyzed, and discarded. Nothing was saved and no melody/notes were extracted. You are responsible for your right to use the source."
 	return out, nil
 }
 
@@ -108,8 +109,9 @@ func ytDlpArgs(u string) []string {
 	}
 }
 
-// ffmpegArgs decodes stdin to a mono 44.1kHz WAV stream, capped to seconds.
-func ffmpegArgs(seconds int) []string {
+// ffmpegArgs decodes stdin to a full-length mono 44.1kHz WAV stream. Overall
+// size is bounded downstream by maxFileBytes rather than a fixed duration.
+func ffmpegArgs() []string {
 	return []string{
 		"-hide_banner",
 		"-loglevel", "error",
@@ -117,7 +119,6 @@ func ffmpegArgs(seconds int) []string {
 		"-vn",
 		"-ac", "1",
 		"-ar", "44100",
-		"-t", strconv.Itoa(seconds),
 		"-f", "wav",
 		"pipe:1",
 	}

--- a/internal/audioanalyze/url_test.go
+++ b/internal/audioanalyze/url_test.go
@@ -47,14 +47,11 @@ func TestAnalyzeURLRejectsBadURL(t *testing.T) {
 	}
 }
 
-func TestFfmpegArgsBounded(t *testing.T) {
+func TestFfmpegArgsStreamMono(t *testing.T) {
 	t.Parallel()
 
-	args := ffmpegArgs(60)
+	args := ffmpegArgs()
 	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "-t 60") {
-		t.Errorf("ffmpeg args missing duration cap: %v", args)
-	}
 	if !strings.Contains(joined, "-ac 1") || !strings.Contains(joined, "-ar 44100") {
 		t.Errorf("ffmpeg args missing mono/44.1k downmix: %v", args)
 	}

--- a/internal/tools/ableton_analyze_audio.go
+++ b/internal/tools/ableton_analyze_audio.go
@@ -29,6 +29,7 @@ type AnalyzeLocalAudioOutput struct {
 	KeyConfidence     float64                     `json:"key_confidence,omitempty"`
 	ChordProgression  []audioanalyze.ChordSegment `json:"chord_progression,omitempty"`
 	ChordSummary      string                      `json:"chord_summary,omitempty"`
+	Sections          []audioanalyze.Section      `json:"sections,omitempty"`
 	LengthBarsAtBPM   float64                     `json:"length_bars_at_project_tempo,omitempty"`
 	Note              string                      `json:"note"`
 	NextStep          string                      `json:"next_step"`
@@ -36,7 +37,7 @@ type AnalyzeLocalAudioOutput struct {
 
 func NewAbletonAnalyzeLocalAudio(g *genkit.Genkit) ai.Tool {
 	return genkit.DefineTool(g, "ableton_analyze_local_audio",
-		"Analyze a local .wav file for sampling placement (duration, levels, estimated BPM, approximate key/scale and chord progression). Does not download URLs or extract melodies/notes.",
+		"Analyze a local .wav file for sampling placement (duration, levels, estimated BPM, approximate key/scale, chord progression, and an energy-based section map). Does not download URLs or extract melodies/notes.",
 		func(_ *ai.ToolContext, input AnalyzeLocalAudioInput) (AnalyzeLocalAudioOutput, error) {
 			return analyzeLocalAudio(input)
 		},
@@ -69,6 +70,7 @@ func analyzeLocalAudio(input AnalyzeLocalAudioInput) (AnalyzeLocalAudioOutput, e
 		KeyConfidence:     got.KeyConfidence,
 		ChordProgression:  got.ChordProgression,
 		ChordSummary:      got.ChordSummary,
+		Sections:          got.Sections,
 		LengthBarsAtBPM:   got.LengthBarsAtBPM,
 		Note:              got.Note,
 		NextStep:          "If you load this sample into Live, use ableton_match_clip_tempo with the suggested_warp_mode so it follows the project tempo.",

--- a/internal/tools/ableton_analyze_url.go
+++ b/internal/tools/ableton_analyze_url.go
@@ -29,6 +29,7 @@ type AnalyzeAudioURLOutput struct {
 	KeyConfidence     float64                     `json:"key_confidence,omitempty"`
 	ChordProgression  []audioanalyze.ChordSegment `json:"chord_progression,omitempty"`
 	ChordSummary      string                      `json:"chord_summary,omitempty"`
+	Sections          []audioanalyze.Section      `json:"sections,omitempty"`
 	LengthBarsAtBPM   float64                     `json:"length_bars_at_project_tempo,omitempty"`
 	Note              string                      `json:"note"`
 	NextStep          string                      `json:"next_step"`
@@ -36,7 +37,7 @@ type AnalyzeAudioURLOutput struct {
 
 func NewAbletonAnalyzeAudioURL(g *genkit.Genkit) ai.Tool {
 	return genkit.DefineTool(g, "ableton_analyze_audio_url",
-		"Reference-analyze audio at an http(s) URL (e.g. YouTube) for tempo/length/levels, approximate key/scale and chord progression. Streams a short window through yt-dlp+ffmpeg in memory, saves nothing, and never extracts melodies or notes. Requires yt-dlp and ffmpeg on PATH; you are responsible for your right to access the URL.",
+		"Reference-analyze audio at an http(s) URL (e.g. YouTube) for tempo/length/levels, approximate key/scale, chord progression, and an energy-based section map. Streams the full track through yt-dlp+ffmpeg in memory, saves nothing, and never extracts melodies or notes. Requires yt-dlp and ffmpeg on PATH; you are responsible for your right to access the URL.",
 		func(tc *ai.ToolContext, input AnalyzeAudioURLInput) (AnalyzeAudioURLOutput, error) {
 			projectTempo := 0.0
 			if input.ProjectTempo != nil {
@@ -63,6 +64,7 @@ func NewAbletonAnalyzeAudioURL(g *genkit.Genkit) ai.Tool {
 				KeyConfidence:     got.KeyConfidence,
 				ChordProgression:  got.ChordProgression,
 				ChordSummary:      got.ChordSummary,
+				Sections:          got.Sections,
 				LengthBarsAtBPM:   got.LengthBarsAtBPM,
 				Note:              got.Note,
 				NextStep:          "Use the tempo/key/chord progression as a reference to build your own part. This tool does not import the audio; place only samples you have the right to use.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add an approximate **section map** to both analysis tools
(`ableton_analyze_local_audio` and `ableton_analyze_audio_url`), and remove the
60s cap on URL analysis so structure covers the whole song.

New output field `sections`: a timed list of spans, each with `start_sec`,
`duration_sec`, relative `energy` (0..1), and an energy `label`
(`low` / `medium` / `high`). Use it to spot likely intros/breakdowns (low) vs.
drops/choruses (high).

## How

Pure Go, no new dependencies (reuses the FFT/chromagram):

- Frames are grouped into ~1s blocks; each block gets a harmonic (chroma) +
  energy feature vector.
- A self-similarity matrix is scanned with a Foote checkerboard novelty kernel;
  novelty peaks become boundaries. The energy dimension is weighted so loudness
  changes with unchanged harmony (breakdown → drop) still create boundaries.
- Sections are labeled by energy relative to the loudest span; compute is
  bounded (~15 min of blocks).

## URL now analyzes the full track

Per request, `ableton_analyze_audio_url` no longer caps the stream at 60s — it
streams the whole track through `yt-dlp` + `ffmpeg`, **analyzes it in memory,
and discards it** (nothing saved), bounded by `maxFileBytes` (~15 min) for
safety. Processes are cancelled once enough audio is read, and the fetch timeout
was raised accordingly. BPM/key/chord estimates still use a representative
window; section structure uses the full audio.

## Scope / honesty

- The section map is a **coarse structural map**, not a semantic labeling
  (it reports energy tiers, not "this is the chorus").
- Streaming the full track is a larger fetch than the previous 60s window;
  still nothing is written to disk, and you remain responsible for your right to
  access any source.

## Testing

- `go test ./...` — new tests cover too-short input (ok=false) and an energy
  contrast (quiet→loud with identical harmony) producing a boundary near the
  change with rising energy labels.
- Manual end-to-end smoke: served a 90s file over HTTP and confirmed the full
  90s streamed through the real `yt-dlp | ffmpeg` pipeline (no 60s cap) and was
  analyzed with nothing written to disk.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

