### PR TITLE
feat: build a MIDI chord-progression clip from a chord string

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,11 @@ service, and you are responsible for your right to use any source you analyze.
 Use results with files you have rights to use, then load into Live and call
 `ableton_match_clip_tempo` if needed.
 
+To turn a reference into a starting point, pass a `chord_summary` (or your own
+progression like `C | G | Am | F`) to `ableton_build_chord_clip`, which writes a
+block-chord MIDI clip into a MIDI track you can build on. It is a sketch, not a
+finished arrangement.
+
 ## Available Tools
 
 | Tool | Description |
@@ -340,6 +345,7 @@ Use results with files you have rights to use, then load into Live and call
 | `ableton_get_session_record` / `ableton_set_session_record` | Session Record on/off |
 | `ableton_bounce_session_pass` | Record a scene pass onto a Bounce track via Resampling (tens of seconds; does not export WAV) |
 | `ableton_setup_drum_track` | Create MIDI drum track, load kit, fill clip with preset pattern (requires browser patch) |
+| `ableton_build_chord_clip` | Write a MIDI chord-progression clip from a chord string (e.g. an analysis `chord_summary`); optional tempo + fire |
 | `ableton_osc_send` | Send raw OSC message |
 
 ## Example Usage

--- a/internal/tools/ableton_build_chord_clip.go
+++ b/internal/tools/ableton_build_chord_clip.go
@@ -1,0 +1,283 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const (
+	defaultBeatsPerChord = 4.0
+	defaultChordOctave   = 4 // C4 = MIDI 60 (standard); C3 in Ableton's display
+	defaultChordVelocity = 90
+	maxChordSlots        = 64
+)
+
+// chordClipClient is the subset of the OSC client used to build a chord clip.
+type chordClipClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+type BuildChordClipInput struct {
+	TrackIndex    int      `json:"track_index" jsonschema:"description=Existing MIDI track index to write into,minimum=0"`
+	ClipIndex     int      `json:"clip_index" jsonschema:"description=Empty clip slot index to fill,minimum=0"`
+	Progression   string   `json:"progression" jsonschema:"description=Chord names separated by space/comma/pipe (e.g. 'C G Am F' or 'C | G | Am | F'). Supports m, dim, aug, 7, maj7, m7, sus2, sus4, 5. Use N.C. or - for a rest."`
+	BeatsPerChord *float64 `json:"beats_per_chord,omitempty" jsonschema:"description=Beats each chord lasts (default 4 = one bar in 4/4),minimum=0.25,maximum=16"`
+	RootOctave    *int     `json:"root_octave,omitempty" jsonschema:"description=Octave of the chord roots (default 4; C4=MIDI 60),minimum=0,maximum=8"`
+	Velocity      *int     `json:"velocity,omitempty" jsonschema:"description=Note velocity (default 90),minimum=1,maximum=127"`
+	Tempo         *float64 `json:"tempo,omitempty" jsonschema:"description=Optional project tempo (BPM) to set before building,minimum=20,maximum=999"`
+	Fire          bool     `json:"fire,omitempty" jsonschema:"description=Fire the clip after building"`
+}
+
+type BuildChordClipOutput struct {
+	TrackIndex  int      `json:"track_index"`
+	ClipIndex   int      `json:"clip_index"`
+	Chords      []string `json:"chords"`
+	LengthBeats float64  `json:"length_beats"`
+	NotesAdded  int      `json:"notes_added"`
+	TempoSet    float64  `json:"tempo_set,omitempty"`
+	Fired       bool     `json:"fired"`
+	Note        string   `json:"note"`
+}
+
+func NewAbletonBuildChordClip(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_build_chord_clip",
+		"Ableton Live: write a MIDI chord-progression clip into an existing MIDI track from a chord string (e.g. from ableton_analyze_audio_url's chord_summary). Creates the clip, adds block chords, and optionally fires it. A starting-point sketch, not a finished arrangement.",
+		func(_ *ai.ToolContext, input BuildChordClipInput) (BuildChordClipOutput, error) {
+			return buildChordClip(client, input)
+		},
+	)
+}
+
+func buildChordClip(client chordClipClient, input BuildChordClipInput) (BuildChordClipOutput, error) {
+	if err := validateTrackClipIndices(input.TrackIndex, input.ClipIndex); err != nil {
+		return BuildChordClipOutput{}, err
+	}
+
+	chords, err := parseProgression(input.Progression)
+	if err != nil {
+		return BuildChordClipOutput{}, err
+	}
+
+	beatsPerChord := defaultBeatsPerChord
+	if input.BeatsPerChord != nil {
+		beatsPerChord = *input.BeatsPerChord
+	}
+	if beatsPerChord < 0.25 || beatsPerChord > 16 {
+		return BuildChordClipOutput{}, errors.New("beats_per_chord must be between 0.25 and 16")
+	}
+
+	octave := defaultChordOctave
+	if input.RootOctave != nil {
+		octave = *input.RootOctave
+	}
+	if octave < 0 || octave > 8 {
+		return BuildChordClipOutput{}, errors.New("root_octave must be between 0 and 8")
+	}
+
+	velocity := defaultChordVelocity
+	if input.Velocity != nil {
+		velocity = *input.Velocity
+	}
+	if velocity < 1 || velocity > 127 {
+		return BuildChordClipOutput{}, errors.New("velocity must be between 1 and 127")
+	}
+
+	notes, names := chordProgressionNotes(chords, beatsPerChord, octave, velocity)
+	if len(notes) == 0 {
+		return BuildChordClipOutput{}, errors.New("progression produced no playable notes")
+	}
+	lengthBeats := beatsPerChord * float64(len(chords))
+
+	tempoSet := 0.0
+	if input.Tempo != nil {
+		if *input.Tempo < 20 || *input.Tempo > 999 {
+			return BuildChordClipOutput{}, errors.New("tempo must be between 20 and 999")
+		}
+		if err := client.Send("/live/song/set/tempo", float32(*input.Tempo)); err != nil {
+			return BuildChordClipOutput{}, fmt.Errorf("set tempo: %w", err)
+		}
+		tempoSet = *input.Tempo
+	}
+
+	if err := client.Send("/live/clip_slot/create_clip",
+		int32(input.TrackIndex), int32(input.ClipIndex), float32(lengthBeats),
+	); err != nil {
+		return BuildChordClipOutput{}, fmt.Errorf("create clip: %w", err)
+	}
+	hasClipRes, err := client.Query("/live/clip_slot/get/has_clip", int32(input.TrackIndex), int32(input.ClipIndex))
+	if err != nil {
+		return BuildChordClipOutput{}, fmt.Errorf("verify clip: %w", err)
+	}
+	if err := ensureResponseLen(hasClipRes, 3); err != nil {
+		return BuildChordClipOutput{}, fmt.Errorf("verify clip: %w", err)
+	}
+	hasClip, err := abletonosc.AsBool(hasClipRes[2])
+	if err != nil {
+		return BuildChordClipOutput{}, fmt.Errorf("verify clip: %w", err)
+	}
+	if !hasClip {
+		return BuildChordClipOutput{}, errors.New("clip was not created (is the slot empty and the track a MIDI track?)")
+	}
+
+	if err := client.Send("/live/clip/set/name", int32(input.TrackIndex), int32(input.ClipIndex), input.Progression); err != nil {
+		return BuildChordClipOutput{}, fmt.Errorf("set clip name: %w", err)
+	}
+
+	noteArgs := []interface{}{int32(input.TrackIndex), int32(input.ClipIndex)}
+	for _, n := range notes {
+		noteArgs = append(noteArgs,
+			int32(n.Pitch), float32(n.StartTime), float32(n.Duration), int32(n.Velocity), false,
+		)
+	}
+	if err := client.Send("/live/clip/add/notes", noteArgs...); err != nil {
+		return BuildChordClipOutput{}, fmt.Errorf("add notes: %w", err)
+	}
+
+	fired := false
+	if input.Fire {
+		if err := client.Send("/live/clip_slot/fire", int32(input.TrackIndex), int32(input.ClipIndex)); err != nil {
+			return BuildChordClipOutput{}, fmt.Errorf("fire clip: %w", err)
+		}
+		fired = true
+	}
+
+	return BuildChordClipOutput{
+		TrackIndex:  input.TrackIndex,
+		ClipIndex:   input.ClipIndex,
+		Chords:      names,
+		LengthBeats: lengthBeats,
+		NotesAdded:  len(notes),
+		TempoSet:    tempoSet,
+		Fired:       fired,
+		Note:        "Block-chord sketch (root-position triads/sevenths). Use it as a harmonic starting point, then voice-lead and arrange to taste.",
+	}, nil
+}
+
+// parsedChord is a single chord in a progression.
+type parsedChord struct {
+	name      string
+	rootPC    int
+	intervals []int
+	rest      bool
+}
+
+// chordProgressionNotes lays chords out end to end and returns the MIDI notes
+// plus the resolved chord names (in order).
+func chordProgressionNotes(chords []parsedChord, beatsPerChord float64, octave, velocity int) ([]MidiNote, []string) {
+	var notes []MidiNote
+	names := make([]string, 0, len(chords))
+	for i, ch := range chords {
+		names = append(names, ch.name)
+		if ch.rest {
+			continue
+		}
+		start := float64(i) * beatsPerChord
+		rootMidi := ch.rootPC + 12*(octave+1)
+		for _, iv := range ch.intervals {
+			pitch := rootMidi + iv
+			if pitch < 0 || pitch > 127 {
+				continue
+			}
+			notes = append(notes, MidiNote{
+				Pitch:     pitch,
+				StartTime: start,
+				Duration:  beatsPerChord,
+				Velocity:  velocity,
+			})
+		}
+	}
+	return notes, names
+}
+
+func parseProgression(s string) ([]parsedChord, error) {
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		return r == ' ' || r == ',' || r == '|' || r == '\t' || r == '\n'
+	})
+	if len(fields) == 0 {
+		return nil, errors.New("progression is empty")
+	}
+	if len(fields) > maxChordSlots {
+		return nil, fmt.Errorf("too many chords (%d); max is %d", len(fields), maxChordSlots)
+	}
+	chords := make([]parsedChord, 0, len(fields))
+	for _, f := range fields {
+		ch, err := parseChordSymbol(f)
+		if err != nil {
+			return nil, err
+		}
+		chords = append(chords, ch)
+	}
+	return chords, nil
+}
+
+var chordQualityIntervals = map[string][]int{
+	"":     {0, 4, 7},
+	"maj":  {0, 4, 7},
+	"M":    {0, 4, 7},
+	"m":    {0, 3, 7},
+	"min":  {0, 3, 7},
+	"-":    {0, 3, 7},
+	"dim":  {0, 3, 6},
+	"aug":  {0, 4, 8},
+	"7":    {0, 4, 7, 10},
+	"maj7": {0, 4, 7, 11},
+	"M7":   {0, 4, 7, 11},
+	"m7":   {0, 3, 7, 10},
+	"min7": {0, 3, 7, 10},
+	"sus2": {0, 2, 7},
+	"sus4": {0, 5, 7},
+	"5":    {0, 7},
+}
+
+var noteLetterPC = map[byte]int{
+	'C': 0, 'D': 2, 'E': 4, 'F': 5, 'G': 7, 'A': 9, 'B': 11,
+}
+
+func parseChordSymbol(sym string) (parsedChord, error) {
+	trimmed := strings.TrimSpace(sym)
+	if trimmed == "" {
+		return parsedChord{}, errors.New("empty chord symbol")
+	}
+	switch strings.ToUpper(trimmed) {
+	case "N.C.", "NC", "N", "R", "REST", "-", "_":
+		return parsedChord{name: "N.C.", rest: true}, nil
+	}
+
+	letter := trimmed[0]
+	pc, ok := noteLetterPC[letter&^0x20] // uppercase the letter
+	if !ok {
+		return parsedChord{}, fmt.Errorf("invalid chord root %q", sym)
+	}
+	idx := 1
+	name := strings.ToUpper(string(letter))
+	if idx < len(trimmed) {
+		switch trimmed[idx] {
+		case '#':
+			pc = (pc + 1) % 12
+			name += "#"
+			idx++
+		case 'b':
+			pc = (pc + 11) % 12
+			name += "b"
+			idx++
+		}
+	}
+
+	quality := trimmed[idx:]
+	intervals, ok := chordQualityIntervals[quality]
+	if !ok {
+		return parsedChord{}, fmt.Errorf("unsupported chord quality %q in %q (try m, dim, aug, 7, maj7, m7, sus2, sus4, 5)", quality, sym)
+	}
+	return parsedChord{
+		name:      name + quality,
+		rootPC:    pc,
+		intervals: intervals,
+	}, nil
+}

--- a/internal/tools/ableton_build_chord_clip_test.go
+++ b/internal/tools/ableton_build_chord_clip_test.go
@@ -1,0 +1,134 @@
+package tools
+
+import (
+	"testing"
+)
+
+func TestParseChordSymbol(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in        string
+		wantName  string
+		wantRoot  int
+		wantCount int
+		wantRest  bool
+		wantErr   bool
+	}{
+		{in: "C", wantName: "C", wantRoot: 0, wantCount: 3},
+		{in: "Am", wantName: "Am", wantRoot: 9, wantCount: 3},
+		{in: "F#m7", wantName: "F#m7", wantRoot: 6, wantCount: 4},
+		{in: "Bb", wantName: "Bb", wantRoot: 10, wantCount: 3},
+		{in: "Gsus4", wantName: "Gsus4", wantRoot: 7, wantCount: 3},
+		{in: "C5", wantName: "C5", wantRoot: 0, wantCount: 2},
+		{in: "Gmaj7", wantName: "Gmaj7", wantRoot: 7, wantCount: 4},
+		{in: "N.C.", wantRest: true},
+		{in: "-", wantRest: true},
+		{in: "Dm", wantName: "Dm", wantRoot: 2, wantCount: 3},
+		{in: "H", wantErr: true},
+		{in: "Cxyz", wantErr: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseChordSymbol(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseChordSymbol(%q) expected error", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseChordSymbol(%q) error = %v", tc.in, err)
+			}
+			if tc.wantRest {
+				if !got.rest {
+					t.Fatalf("expected rest for %q", tc.in)
+				}
+				return
+			}
+			if got.rootPC != tc.wantRoot {
+				t.Errorf("root = %d, want %d", got.rootPC, tc.wantRoot)
+			}
+			if len(got.intervals) != tc.wantCount {
+				t.Errorf("intervals = %d, want %d", len(got.intervals), tc.wantCount)
+			}
+		})
+	}
+}
+
+func TestChordProgressionNotes(t *testing.T) {
+	t.Parallel()
+
+	chords, err := parseProgression("C | G | Am | F")
+	if err != nil {
+		t.Fatalf("parseProgression() error = %v", err)
+	}
+	notes, names := chordProgressionNotes(chords, 4, defaultChordOctave, 90)
+	if len(names) != 4 {
+		t.Fatalf("names = %v", names)
+	}
+	// 4 triads * 3 notes = 12.
+	if len(notes) != 12 {
+		t.Fatalf("notes = %d, want 12", len(notes))
+	}
+	// First chord C major at octave 4 -> root MIDI 60, so 60/64/67.
+	if notes[0].Pitch != 60 || notes[1].Pitch != 64 || notes[2].Pitch != 67 {
+		t.Errorf("C major pitches = %d/%d/%d, want 60/64/67", notes[0].Pitch, notes[1].Pitch, notes[2].Pitch)
+	}
+	// Second chord starts at beat 4.
+	if notes[3].StartTime != 4 {
+		t.Errorf("second chord start = %v, want 4", notes[3].StartTime)
+	}
+}
+
+func TestBuildChordClipStub(t *testing.T) {
+	t.Parallel()
+
+	stub := &recipeClientStub{
+		queries: map[string][]interface{}{
+			"/live/clip_slot/get/has_clip": {int32(1), int32(0), int32(1)},
+		},
+	}
+	tempo := 120.0
+	out, err := buildChordClip(stub, BuildChordClipInput{
+		TrackIndex:  1,
+		ClipIndex:   0,
+		Progression: "C G Am F",
+		Tempo:       &tempo,
+		Fire:        true,
+	})
+	if err != nil {
+		t.Fatalf("buildChordClip() error = %v", err)
+	}
+	if out.LengthBeats != 16 || out.NotesAdded != 12 {
+		t.Errorf("length/notes = %v/%d, want 16/12", out.LengthBeats, out.NotesAdded)
+	}
+	if out.TempoSet != 120 || !out.Fired {
+		t.Errorf("tempo/fired = %v/%v", out.TempoSet, out.Fired)
+	}
+	assertSent(t, stub, "/live/song/set/tempo")
+	assertSent(t, stub, "/live/clip_slot/create_clip")
+	assertSent(t, stub, "/live/clip/add/notes")
+	assertSent(t, stub, "/live/clip_slot/fire")
+}
+
+func TestBuildChordClipRejectsEmpty(t *testing.T) {
+	t.Parallel()
+
+	stub := &recipeClientStub{}
+	if _, err := buildChordClip(stub, BuildChordClipInput{TrackIndex: 0, ClipIndex: 0, Progression: "   "}); err == nil {
+		t.Fatal("expected error for empty progression")
+	}
+}
+
+func assertSent(t *testing.T, stub *recipeClientStub, address string) {
+	t.Helper()
+	for _, c := range stub.calls {
+		if c.address == address {
+			return
+		}
+	}
+	t.Errorf("expected a call to %s", address)
+}

--- a/main.go
+++ b/main.go
@@ -133,6 +133,7 @@ func main() {
 		// Recipes
 		tools.NewAbletonSetupDrumTrack(g, ableton),
 		tools.NewAbletonCompareABVariation(g, ableton),
+		tools.NewAbletonBuildChordClip(g, ableton),
 
 		// A/B comparison feedback
 		tools.NewAbletonRecordVariationPreference(g, tasteStore),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Close the loop from analysis to making music: `ableton_build_chord_clip` takes a
chord-progression string and writes a block-chord MIDI clip into an existing
MIDI track. The string can come straight from an analysis `chord_summary`
(e.g. `C | G | Am | F`) or be typed by hand.

## Behavior

- Parses a progression split on space/comma/pipe. Supported qualities: major,
  `m`/`min`/`-`, `dim`, `aug`, `7`, `maj7`/`M7`, `m7`/`min7`, `sus2`, `sus4`,
  `5` (power). `N.C.` or `-` is a rest.
- Creates the clip (length = beats-per-chord × chords), names it after the
  progression, and writes root-position block chords.
- Options: `beats_per_chord` (default 4), `root_octave` (default 4, C4=MIDI 60),
  `velocity` (default 90), optional `tempo` (sets the project BPM), and `fire`.
- Verifies the clip was actually created before adding notes, and returns a note
  that this is a starting sketch, not a finished arrangement.

## Testing

- `go test ./...` — parser cases (roots, accidentals like `Bb`/`F#`, qualities,
  rests, invalid symbols), note layout (C→G→Am→F yields 12 notes with C major at
  60/64/67 and the 2nd chord at beat 4), and a stubbed end-to-end build
  (create → name → add notes → fire, plus tempo set).
- Verified the tool is exposed over MCP (`tools/list`).

## Scope / honesty

Intentionally simple: root-position block chords, no voice leading, inversions,
rhythm, or melody. It gives a harmonic scaffold to build on, matching the
"reference, not imitation" stance of the analysis tools.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f72d3-3d23-768e-a8af-e6a76e513711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

