### PR TITLE
feat: sampling and production toolkit for Live 11.0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ Thumbs.db
 # Environment
 .env
 .env.local
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ![hero-image](./assets/hero.jpeg)
 
-An MCP (Model Context Protocol) server for controlling **Ableton Live 11+** via [AbletonOSC](https://github.com/ideoforms/AbletonOSC).
+An MCP (Model Context Protocol) server for controlling **Ableton Live** via [AbletonOSC](https://github.com/ideoforms/AbletonOSC).
 
 This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live for beat-making, music production, and creative workflows.
+
+**Primary development target: Ableton Live 11.0.12** (the Live Object Model reports `11.0`). Other Live 11/12 builds may work, but some tools depend on Live APIs that only exist (or behave differently) on newer versions — see [Supported Ableton Live versions](#supported-ableton-live-versions).
 
 ## Features
 
@@ -19,10 +21,11 @@ This enables AI assistants (Claude, Cursor, etc.) to interact with Ableton Live 
 - Search the local synced Splice library and load samples onto audio tracks (Live 12.0.5+)
 - Set up a drum track with kit + clip + pattern in one recipe
 - Run drum / bass / scene A/B comparisons through one create→audition recipe, then save taste locally
+- A/B the same clip dry vs processed by bypassing FX (`ableton_compare_fx_bypass`)
 - Compare mix balance with snapshots you can restore
 - Humanize MIDI clips with microtiming, velocity variation, and swing
 - Match an audio clip to the project tempo with Warp (e.g. after loading a sample)
-- Analyze a local `.wav`, or reference-analyze an `http(s)`/YouTube URL, for duration, levels, BPM, approximate key/scale, chord progression, an energy-based section map, and texture indicators (brightness/dynamics/stereo width) (URL streams in memory and is never saved)
+- Analyze a local `.wav`, or reference-analyze an `http(s)`/YouTube URL, for duration, levels, BPM/key alternatives, chords, section map, rhythm density, rms_per_beat, band balance, match axes, and texture (URL streams in memory and is never saved; no melody extraction)
 - Autogain tracks toward a target meter level while audio is playing
 - Diagnose AbletonOSC connection and browser/master patch readiness
 - Fire clip slots and send raw OSC for advanced control
@@ -38,6 +41,15 @@ This repo ships a small Remote Script patch under [`remote-script/`](remote-scri
 - `/live/track/load/browser_item`
 - `/live/device/load/preset`
 - `/live/clip_slot/create_audio_clip` (local audio file → session slot; Live 12.0.5+)
+- `/live/device/get/parameters/value_string` (all parameter display strings in one reply)
+- `/live/device/set/parameter/string` (set a parameter from a display string)
+- `/live/device/delete` (delete a device; confirms with before/after device count)
+- `/live/device/get|set/is_active` (device on/bypass for FX dry/wet A/B)
+- `/live/device/simpler/get` · `/set` · `/get/slices` (Simpler playback/slicing state, control, and slice map)
+- `/live/device/simpler/set/slices` (restore a saved manual slice map onto the same sample)
+- `/live/song/get/return_tracks` (list return tracks for send indices)
+- `/live/device/get|set/input_routing_type|channel` (+ available lists) for Compressor sidechain
+- `/live/clip/envelope/get|set_steps|clear|clear_all` (+ `/live/clip/get/has_envelopes`) for Session clip automation
 
 Install steps: see [remote-script/README.md](remote-script/README.md).
 After applying the patch, **restart Ableton Live** (a full restart is required the first time; `/live/api/reload` alone is not enough).
@@ -99,8 +111,31 @@ Both work well — choose based on your preference.
 
 ## Prerequisites
 
-- **Ableton Live 11** or later
+- **Ableton Live 11+** (see version notes below)
 - **AbletonOSC** installed and enabled in Live
+- This repo's **Remote Script patch** applied (see [Browser loading](#browser-loading-abletonosc-patch))
+
+## Supported Ableton Live versions
+
+| Role | Version | Notes |
+|------|---------|--------|
+| **Primary target (developed & smoke-tested against)** | **Live 11.0.12** (API label `11.0`) | Default assumption for tool behavior and docs in this repo |
+| Also intended to work | Live 11.x generally | Same LOM generation; minor UI/API differences may appear |
+| Partially supported | Live 12.x | Extra APIs unlock some tools; others still need the patch |
+
+Live's OSC/API only exposes a coarse version string (e.g. `11.0`), so this project documents the **full Suite build used in development** (11.0.12) separately from what `ableton_diagnose` reports.
+
+**Version-gated or unavailable tools (examples):**
+
+| Capability / tool area | Live 11.0.12 | Notes |
+|------------------------|--------------|--------|
+| Most transport, MIDI, browser load, Simpler slice, intents, routing, envelopes, FX bypass A/B, analysis | Available (with patch where noted) | Primary workflow |
+| `ableton_load_splice_sample` / `create_audio_clip` (path → Session slot) | **Not available** | Needs Live **12.0.5+** (`ClipSlot.create_audio_clip`) |
+| Drum Rack pad ← one-shot file load | **Not available** | Live 11 LOM cannot load a raw sample onto a single pad without replacing the rack |
+| Clip envelope breakpoint *lists* | Limited | Live 11 samples via `value_at_time`; full breakpoint lists need Live 12+ |
+| Destructive audio edit (crop / reverse / split / consolidate) | **Not exposed** | No stable LOM path; use non-destructive region extract / warp / pitch instead |
+
+Before relying on a gated feature, call **`ableton_diagnose`** and check `capabilities[]` (`ok` / `next_step`). A tool that exists in the MCP schema may still fail or be a no-op on your Live build if the underlying API or patch handler is missing.
 
 ## Installation
 
@@ -273,6 +308,13 @@ Finally, a few **texture indicators** describe the mix objectively:
 URL sources are decoded in stereo so width can be measured, then downmixed for
 the rest of the analysis.
 
+For production decisions (not melody extraction), both tools also return:
+- `bpm_alternatives` / `key_alternatives` — half/double tempo and second-best key when in range
+- `rhythm_density` — onsets per bar at the estimated tempo
+- `rms_per_beat` — per-beat energy envelope (capped) for chop / fill placement
+- `band_balance` — relative low / mid / high energy shares
+- `match_axes` — three observation axes (`drum_density`, `low_end_role`, `space_amount`) with short hints
+
 - `ableton_analyze_local_audio` — inspects a **local `.wav` path you already have**. No network access.
 - `ableton_analyze_audio_url` — reference-analyzes an `http(s)` URL (e.g. YouTube). It streams the track through `yt-dlp` + `ffmpeg` **in memory, analyzes it, and discards it** — nothing is written to disk (bounded to ~15 min for safety).
 
@@ -293,16 +335,20 @@ finished arrangement.
 | Tool | Description |
 |------|-------------|
 | `ableton_test` | Test connection to AbletonOSC |
-| `ableton_diagnose` | Diagnose AbletonOSC connection and browser/master patch availability |
+| `ableton_diagnose` | Diagnose AbletonOSC connection, browser/master patches, Live version, and feature capabilities (e.g. `create_audio_clip` needs Live 12.0.5+) |
+| `ableton_preview_destructive` | Preview a destructive action (delete track/clip/device, clear notes/scene) as a diff summary without executing |
 | `ableton_get_tempo` / `ableton_set_tempo` | Get/set tempo (BPM) |
 | `ableton_play` / `ableton_stop` / `ableton_stop_all_clips` | Transport |
 | `ableton_set_song_key` | Set root note and scale |
 | `ableton_set_metronome` | Enable/disable metronome |
 | `ableton_get_session_snapshot` | Get tempo, playback state, scene count, and indexed track names |
+| `ableton_get_sounding_snapshot` | Conversation-resume anchor: mute/solo/playing slot, device chain, clip presence grid, scene names |
 | `ableton_get_track_names` | List track names |
 | `ableton_get_track_devices` | List devices on a track |
 | `ableton_create_midi_track` | Create a MIDI track |
 | `ableton_create_audio_track` | Create an audio track |
+| `ableton_duplicate_track` | Duplicate a track (clips + devices); confirms via track count |
+| `ableton_delete_track` | Delete a track (requires `confirm=true`; preview via `ableton_preview_destructive`) |
 | `ableton_set_track_name` | Rename a track |
 | `ableton_mute_track` / `ableton_solo_track` | Mute/solo |
 | `ableton_arm_track` | Arm/disarm for recording |
@@ -313,9 +359,10 @@ finished arrangement.
 | `ableton_get_clip_notes` / `ableton_add_midi_notes` / `ableton_clear_clip_notes` | MIDI notes |
 | `ableton_humanize_clip` | Add microtiming, velocity variation, and optional swing to clip notes |
 | `ableton_match_clip_tempo` | Enable Warp on an audio clip so it follows the project tempo (`beats` or `complex`) |
-| `ableton_analyze_local_audio` | Analyze a local `.wav` (duration, levels, BPM, approx. key/scale + chords + section map + texture: brightness/dynamics/stereo width). Rejects URLs; no melody/note extraction |
-| `ableton_analyze_audio_url` | Reference-analyze an `http(s)`/YouTube URL (tempo/length/levels, approx. key/scale + chords + section map + texture). Streams the full track via yt-dlp+ffmpeg in memory, saves nothing; requires yt-dlp+ffmpeg |
+| `ableton_analyze_local_audio` | Analyze a local `.wav` (BPM/key alternatives, density, rms_per_beat, band_balance, match_axes, sections, onset grid, texture). Rejects URLs; no melody/note extraction |
+| `ableton_analyze_audio_url` | Reference-analyze an `http(s)`/YouTube URL (same production fields as local, minus the full onset list). Streams via yt-dlp+ffmpeg in memory; requires yt-dlp+ffmpeg |
 | `ableton_compare_ab_variation` | Preferred A/B entry: create one drum/bass/scene variation, audition A→B, return a preference prompt |
+| `ableton_compare_fx_bypass` | Same-clip FX A/B: bypass audio/MIDI effects (dry) then restore prior active state (wet); record with `instrument=fx variation=bypass` |
 | `ableton_create_drum_variation` | Create-only drum A/B variation (groove / density / fill); use when you do not want audition yet |
 | `ableton_create_bass_variation` | Create-only bass A/B variation (octave / staccato / groove) |
 | `ableton_create_scene_energy_variation` | Create-only scene energy variation (lift / pullback); keeps B if fire fails |
@@ -323,10 +370,41 @@ finished arrangement.
 | `ableton_record_variation_preference` | Save whether the source or variation matched your taste (drum, bass, scene, or mix) |
 | `ableton_get_taste_profile` | Summarize saved A/B choices and suggest the next comparison |
 | `ableton_fire_clip_slot` / `ableton_stop_clip` | Fire/stop a clip |
-| `ableton_duplicate_clip_to` | Duplicate clip to another slot |
+| `ableton_duplicate_clip_to` | Duplicate clip to another slot (same track, or cross-track via `target_track_index`) |
+| `ableton_delete_clip` | Delete a clip from a slot (requires `confirm=true` when a clip is present) |
 | `ableton_set_clip_name` | Rename a clip |
+| `ableton_get_clip_properties` | Get a clip's edit state: pitch/transpose, detune, warp mode, gain, markers, loop (audio + MIDI) |
+| `ableton_set_clip_pitch` | Transpose (semitones) and/or detune (cents) an audio clip |
+| `ableton_set_clip_warp` | Set an audio clip's warping on/off and warp mode (Beats/Tones/Texture/Re-Pitch/Complex/REX/Complex Pro) |
+| `ableton_set_clip_region` | Set a clip's start/end markers and loop points (beats) |
+| `ableton_extract_clip_region` | Copy a region `[start_beats, end_beats]` of an audio clip into an empty slot as a new clip (non-destructive chop) |
+| `ableton_get_clip_envelope` | Sample a Session clip automation envelope (volume/pan/send/device); Live 11 cannot list breakpoints (requires browser patch) |
+| `ableton_set_clip_envelope_steps` | Write Session clip automation steps; creates envelope if needed (requires browser patch) |
+| `ableton_clear_clip_envelope` | Clear one or all Session clip envelopes (`confirm=true`; requires browser patch) |
+| `ableton_chop_draft` | Generate a MIDI draft that rearranges chop slices without reproducing the source order (`avoid_copy`); apply with `ableton_add_midi_notes` |
 | `ableton_fire_scene` | Fire a scene |
-| `ableton_get_device_parameters` / `ableton_set_device_parameter` | Device parameters |
+| `ableton_get_scene_names` | List scene names with indices |
+| `ableton_set_scene_name` | Rename a scene (e.g. Intro, Verse, Hook) |
+| `ableton_create_named_scenes` | Append empty named scenes for section structure |
+| `ableton_set_scene_clip_presence` | Subtractive arrangement: hide (delete) or restore clips on a scene row from a source scene |
+| `ableton_get_device_parameters` | Device parameters, with human-readable `display_value` (units/enum names) and `is_quantized` (requires browser patch) |
+| `ableton_set_device_parameter` | Set a device parameter by raw numeric value |
+| `ableton_set_device_parameter_string` | Set a device parameter from a display string (e.g. `Ins`, `180 Hz`, `-3.5 dB`, `50 %`); requires browser patch |
+| `ableton_delete_device` | Delete a device (requires `confirm=true`); confirms with device name and before/after count (requires browser patch) |
+| `ableton_get_simpler` | Get Simpler state: playback/slicing mode, style, beat division, slice count, with readable names (requires browser patch) |
+| `ableton_set_simpler_playback_mode` | Set Simpler playback mode: classic / one_shot / slicing (requires browser patch) |
+| `ableton_set_simpler_slicing` | Set Simpler slicing style and/or beat division (requires browser patch) |
+| `ableton_get_simpler_slices` | Get Simpler slice map: start in samples/seconds + default C1-based MIDI note (requires browser patch) |
+| `ableton_save_slice_preset` | Save a Simpler's slice map to a reusable JSON preset (requires browser patch) |
+| `ableton_load_slice_preset` | Restore a saved slice preset onto the same sample; guards by sample length (requires browser patch) |
+| `ableton_list_slice_presets` | List saved slice presets |
+| `ableton_apply_device_intent` | Apply human-readable parameter settings (e.g. HP 180 Hz) to a device in one call, resolving params by name; optionally save/load named intents (requires browser patch) |
+| `ableton_list_intents` | List saved device intents |
+| `ableton_duplicate_track_for_processing` | Duplicate a track into a dry/wet pair (original stays dry, copy becomes processed) |
+| `ableton_get_return_tracks` | List return tracks (A/B/…) with send indices (requires browser patch) |
+| `ableton_create_return_track` | Create a new return track |
+| `ableton_get_track_sends` / `ableton_set_track_send` | Get/set send amounts to returns (~0..1; ~0.85 ≈ 0 dB) |
+| `ableton_get_device_sidechain` / `ableton_set_device_sidechain` | Compressor sidechain input routing (Live 11+; requires browser patch) |
 | `ableton_find_browser_item` | Search Live Browser (requires patch) |
 | `ableton_list_browser_folder` | List Browser roots or folder children (requires patch) |
 | `ableton_load_browser_item` | Load Drum Rack / instrument onto a track by name |

--- a/internal/audioanalyze/analyze.go
+++ b/internal/audioanalyze/analyze.go
@@ -20,29 +20,45 @@ const (
 	maxAnalyzeSamples = 44100 * 60 // analyze at most 60s of audio
 )
 
+// Onset marks a detected transient in the sample. Beat is relative to the start
+// of the analyzed audio at the estimated tempo (or the project tempo when BPM
+// detection fails). Strength is normalized 0..1 against the loudest onset.
+type Onset struct {
+	Beat     float64 `json:"beat"`
+	Sec      float64 `json:"sec"`
+	Strength float64 `json:"strength"`
+}
+
 type Result struct {
-	Path              string         `json:"path"`
-	Format            string         `json:"format"`
-	DurationSec       float64        `json:"duration_sec"`
-	SampleRate        int            `json:"sample_rate"`
-	Channels          int            `json:"channels"`
-	PeakLevel         float64        `json:"peak_level"`
-	RMSLevel          float64        `json:"rms_level"`
-	EstimatedBPM      float64        `json:"estimated_bpm"`
-	BPMConfidence     float64        `json:"bpm_confidence"`
-	OnsetCount        int            `json:"onset_count"`
-	SuggestedWarpMode string         `json:"suggested_warp_mode"`
-	Key               string         `json:"key,omitempty"`
-	Scale             string         `json:"scale,omitempty"`
-	KeyConfidence     float64        `json:"key_confidence,omitempty"`
-	ChordProgression  []ChordSegment `json:"chord_progression,omitempty"`
-	ChordSummary      string         `json:"chord_summary,omitempty"`
-	Sections          []Section      `json:"sections,omitempty"`
-	BrightnessHz      float64        `json:"brightness_hz,omitempty"`
-	CrestFactorDB     float64        `json:"crest_factor_db,omitempty"`
-	StereoWidth       float64        `json:"stereo_width"`
-	LengthBarsAtBPM   float64        `json:"length_bars_at_project_tempo,omitempty"`
-	Note              string         `json:"note"`
+	Path              string            `json:"path"`
+	Format            string            `json:"format"`
+	DurationSec       float64           `json:"duration_sec"`
+	SampleRate        int               `json:"sample_rate"`
+	Channels          int               `json:"channels"`
+	PeakLevel         float64           `json:"peak_level"`
+	RMSLevel          float64           `json:"rms_level"`
+	EstimatedBPM      float64           `json:"estimated_bpm"`
+	BPMConfidence     float64           `json:"bpm_confidence"`
+	BPMAlternatives   []TempoHypothesis `json:"bpm_alternatives,omitempty"`
+	OnsetCount        int               `json:"onset_count"`
+	Onsets            []Onset           `json:"onsets,omitempty"`
+	RhythmDensity     float64           `json:"rhythm_density,omitempty" jsonschema:"description=Onsets per bar at estimated BPM"`
+	RMSPerBeat        []float64         `json:"rms_per_beat,omitempty" jsonschema:"description=RMS level per beat for chop/energy decisions"`
+	BandBalance       *BandBalance      `json:"band_balance,omitempty"`
+	SuggestedWarpMode string            `json:"suggested_warp_mode"`
+	Key               string            `json:"key,omitempty"`
+	Scale             string            `json:"scale,omitempty"`
+	KeyConfidence     float64           `json:"key_confidence,omitempty"`
+	KeyAlternatives   []KeyHypothesis   `json:"key_alternatives,omitempty"`
+	ChordProgression  []ChordSegment    `json:"chord_progression,omitempty"`
+	ChordSummary      string            `json:"chord_summary,omitempty"`
+	Sections          []Section         `json:"sections,omitempty"`
+	MatchAxes         []MatchAxis       `json:"match_axes,omitempty" jsonschema:"description=Three production axes to match when referencing this audio"`
+	BrightnessHz      float64           `json:"brightness_hz,omitempty"`
+	CrestFactorDB     float64           `json:"crest_factor_db,omitempty"`
+	StereoWidth       float64           `json:"stereo_width"`
+	LengthBarsAtBPM   float64           `json:"length_bars_at_project_tempo,omitempty"`
+	Note              string            `json:"note"`
 }
 
 // AnalyzeFile analyzes a local WAV file already present on disk. It never
@@ -78,7 +94,7 @@ func AnalyzeFile(path string, projectTempo float64) (Result, error) {
 		return Result{}, err
 	}
 	out.Path = abs
-	out.Note = "Local-file analysis only. No download, transcription, or note extraction. Use results to place/warp a sample you already have rights to use."
+	out.Note = "Local-file analysis only. No download, transcription, or melody/note extraction — use onsets, rms_per_beat, band_balance, sections, and match_axes for placement decisions."
 	return out, nil
 }
 
@@ -103,7 +119,8 @@ func analyzeWAVStream(r io.Reader, projectTempo float64) (Result, error) {
 		analyze = analyze[:maxAnalyzeSamples]
 	}
 	bpm, confidence := estimateBPM(analyze, sampleRate)
-	onsets := countOnsets(analyze, sampleRate)
+	onsetList := detectOnsets(analyze, sampleRate)
+	onsets := len(onsetList)
 	warpMode := "beats"
 	if duration >= 8 || onsets < 8 {
 		warpMode = "complex"
@@ -118,6 +135,7 @@ func analyzeWAVStream(r io.Reader, projectTempo float64) (Result, error) {
 		RMSLevel:          rms,
 		EstimatedBPM:      bpm,
 		BPMConfidence:     confidence,
+		BPMAlternatives:   bpmAlternatives(bpm, confidence),
 		OnsetCount:        onsets,
 		SuggestedWarpMode: warpMode,
 	}
@@ -125,6 +143,15 @@ func analyzeWAVStream(r io.Reader, projectTempo float64) (Result, error) {
 		out.Key = key.Tonic
 		out.Scale = key.Scale
 		out.KeyConfidence = key.Confidence
+		alts := []KeyHypothesis{{
+			Tonic: key.Tonic, Scale: key.Scale, Confidence: key.Confidence, Label: "primary",
+		}}
+		if key.AltTonic != "" {
+			alts = append(alts, KeyHypothesis{
+				Tonic: key.AltTonic, Scale: key.AltScale, Confidence: key.AltConfidence, Label: "alternative",
+			})
+		}
+		out.KeyAlternatives = alts
 	}
 	if chords, summary, ok := estimateChords(analyze, sampleRate); ok {
 		out.ChordProgression = chords
@@ -139,6 +166,24 @@ func analyzeWAVStream(r io.Reader, projectTempo float64) (Result, error) {
 	out.BrightnessHz = tex.BrightnessHz
 	out.CrestFactorDB = tex.CrestFactorDB
 	out.StereoWidth = tex.StereoWidth
+	bands := BandBalance{}
+	if b, ok := estimateBandBalance(analyze, sampleRate); ok {
+		bands = b
+		out.BandBalance = &b
+	}
+	beatBPM := bpm
+	if beatBPM <= 0 {
+		beatBPM = projectTempo
+	}
+	if beatBPM > 0 {
+		for i := range onsetList {
+			onsetList[i].Beat = round2(onsetList[i].Sec * beatBPM / 60.0)
+		}
+		out.RMSPerBeat = rmsEnvelopePerBeat(analyze, sampleRate, beatBPM)
+		out.RhythmDensity = rhythmDensityOnsetsPerBar(onsets, duration, beatBPM)
+	}
+	out.Onsets = onsetList
+	out.MatchAxes = buildMatchAxes(out.RhythmDensity, bands, tex.StereoWidth, tex.CrestFactorDB)
 	if projectTempo > 0 && duration > 0 {
 		beats := duration * (projectTempo / 60)
 		out.LengthBarsAtBPM = beats / 4
@@ -441,10 +486,15 @@ func energyEnvelope(samples []float64, hop int) []float64 {
 	return out
 }
 
-func countOnsets(samples []float64, sampleRate int) int {
+const maxOnsets = 512
+
+// detectOnsets finds transients via peaks in the energy envelope. Each onset
+// carries its time in seconds and a strength normalized 0..1 against the loudest
+// peak. Beat is filled in by the caller once tempo is known.
+func detectOnsets(samples []float64, sampleRate int) []Onset {
 	env := energyEnvelope(samples, envelopeHop)
 	if len(env) < 3 {
-		return 0
+		return nil
 	}
 	var mean float64
 	for _, v := range env {
@@ -452,16 +502,32 @@ func countOnsets(samples []float64, sampleRate int) int {
 	}
 	mean /= float64(len(env))
 	threshold := mean * 1.5
-	count := 0
-	armed := true
-	minGap := int(math.Round(0.08 / (float64(envelopeHop) / float64(sampleRate)))) // ~80ms
+	hopSec := float64(envelopeHop) / float64(sampleRate)
+	minGap := int(math.Round(0.08 / hopSec)) // ~80ms
 	if minGap < 1 {
 		minGap = 1
 	}
+	var onsets []Onset
+	var maxStrength float64
+	armed := true
 	last := -minGap
+	// The first frame has no predecessor; treat a loud opening as an onset so a
+	// transient at time 0 is not missed.
+	if env[0] > threshold {
+		onsets = append(onsets, Onset{Sec: 0, Strength: env[0]})
+		maxStrength = env[0]
+		last = 0
+		armed = false
+	}
 	for i := 1; i < len(env)-1; i++ {
 		if armed && env[i] > threshold && env[i] >= env[i-1] && env[i] >= env[i+1] && i-last >= minGap {
-			count++
+			onsets = append(onsets, Onset{
+				Sec:      round2(float64(i) * hopSec),
+				Strength: env[i],
+			})
+			if env[i] > maxStrength {
+				maxStrength = env[i]
+			}
 			last = i
 			armed = false
 		}
@@ -469,7 +535,15 @@ func countOnsets(samples []float64, sampleRate int) int {
 			armed = true
 		}
 	}
-	return count
+	if maxStrength > 0 {
+		for i := range onsets {
+			onsets[i].Strength = round2(onsets[i].Strength / maxStrength)
+		}
+	}
+	if len(onsets) > maxOnsets {
+		onsets = onsets[:maxOnsets]
+	}
+	return onsets
 }
 
 func round1(v float64) float64 {

--- a/internal/audioanalyze/analyze_test.go
+++ b/internal/audioanalyze/analyze_test.go
@@ -42,6 +42,21 @@ func TestAnalyzeClickTrackBPM(t *testing.T) {
 	if got.LengthBarsAtBPM <= 0 {
 		t.Errorf("length_bars_at_project_tempo = %v", got.LengthBarsAtBPM)
 	}
+	if len(got.BPMAlternatives) < 1 || got.BPMAlternatives[0].Label != "primary" {
+		t.Errorf("bpm_alternatives = %+v", got.BPMAlternatives)
+	}
+	if got.RhythmDensity <= 0 {
+		t.Errorf("rhythm_density = %v", got.RhythmDensity)
+	}
+	if len(got.RMSPerBeat) < 4 {
+		t.Errorf("rms_per_beat len = %d, want >= 4", len(got.RMSPerBeat))
+	}
+	if got.BandBalance == nil {
+		t.Error("band_balance missing")
+	}
+	if len(got.MatchAxes) != 3 {
+		t.Errorf("match_axes = %+v", got.MatchAxes)
+	}
 }
 
 func writeClickWAV(t *testing.T, path string, sampleRate, bpm, seconds int) {
@@ -87,5 +102,42 @@ func writeClickWAV(t *testing.T, path string, sampleRate, bpm, seconds int) {
 	write(uint32(dataBytes))
 	for _, s := range pcm {
 		write(s)
+	}
+}
+
+func TestDetectOnsetsClickTrack(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "clicks_120.wav")
+	writeClickWAV(t, path, 44100, 120, 4)
+	got, err := AnalyzeFile(path, 120)
+	if err != nil {
+		t.Fatalf("AnalyzeFile() error = %v", err)
+	}
+	if len(got.Onsets) != got.OnsetCount {
+		t.Fatalf("len(onsets)=%d != onset_count=%d", len(got.Onsets), got.OnsetCount)
+	}
+	if len(got.Onsets) < 4 {
+		t.Fatalf("onsets = %d, want >= 4", len(got.Onsets))
+	}
+	for i, o := range got.Onsets {
+		if o.Strength < 0 || o.Strength > 1 {
+			t.Errorf("onset %d strength out of range: %v", i, o.Strength)
+		}
+		if o.Sec < 0 || o.Beat < 0 {
+			t.Errorf("onset %d has negative sec/beat: %#v", i, o)
+		}
+	}
+	// The first click sits near the start of the file.
+	if got.Onsets[0].Beat > 0.6 {
+		t.Errorf("first onset beat = %v, want near 0", got.Onsets[0].Beat)
+	}
+	// At 120 BPM clicks are 0.5s = 1 beat apart; consecutive onsets should be
+	// roughly a beat apart.
+	if len(got.Onsets) >= 2 {
+		gap := got.Onsets[1].Beat - got.Onsets[0].Beat
+		if gap < 0.5 || gap > 1.5 {
+			t.Errorf("beat gap = %v, want ~1", gap)
+		}
 	}
 }

--- a/internal/audioanalyze/key.go
+++ b/internal/audioanalyze/key.go
@@ -23,11 +23,14 @@ var (
 	minorProfile = [12]float64{6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17}
 )
 
-// KeyResult holds an approximate key estimate.
+// KeyResult holds an approximate key estimate plus the next-best alternative.
 type KeyResult struct {
-	Tonic      string  // e.g. "C", "F#"
-	Scale      string  // "major" or "minor"
-	Confidence float64 // 0..1 margin between the best and next-best fit
+	Tonic         string  // e.g. "C", "F#"
+	Scale         string  // "major" or "minor"
+	Confidence    float64 // 0..1 margin between the best and next-best fit
+	AltTonic      string
+	AltScale      string
+	AltConfidence float64
 }
 
 // estimateKey computes a chromagram and matches it to major/minor key profiles.
@@ -46,16 +49,20 @@ func estimateKey(samples []float64, sampleRate int) (KeyResult, bool) {
 
 	bestCorr := math.Inf(-1)
 	secondCorr := math.Inf(-1)
-	var bestTonic int
-	var bestScale string
+	var bestTonic, secondTonic int
+	var bestScale, secondScale string
 	consider := func(tonic int, scale string, corr float64) {
 		if corr > bestCorr {
 			secondCorr = bestCorr
+			secondTonic = bestTonic
+			secondScale = bestScale
 			bestCorr = corr
 			bestTonic = tonic
 			bestScale = scale
 		} else if corr > secondCorr {
 			secondCorr = corr
+			secondTonic = tonic
+			secondScale = scale
 		}
 	}
 	for tonic := 0; tonic < 12; tonic++ {
@@ -67,14 +74,22 @@ func estimateKey(samples []float64, sampleRate int) (KeyResult, bool) {
 	}
 
 	confidence := 0.0
+	altConfidence := 0.0
 	if !math.IsInf(secondCorr, -1) && bestCorr > 0 {
 		confidence = math.Max(0, math.Min(1, (bestCorr-secondCorr)/math.Max(bestCorr, 1e-9)))
+		altConfidence = math.Max(0, math.Min(1, secondCorr/math.Max(bestCorr, 1e-9)*0.85))
 	}
-	return KeyResult{
+	out := KeyResult{
 		Tonic:      pitchClassNames[bestTonic],
 		Scale:      bestScale,
 		Confidence: round2(confidence),
-	}, true
+	}
+	if !math.IsInf(secondCorr, -1) && secondScale != "" {
+		out.AltTonic = pitchClassNames[secondTonic]
+		out.AltScale = secondScale
+		out.AltConfidence = round2(altConfidence)
+	}
+	return out, true
 }
 
 // correlateProfile is the Pearson correlation between the chroma vector and a

--- a/internal/audioanalyze/production.go
+++ b/internal/audioanalyze/production.go
@@ -1,0 +1,208 @@
+package audioanalyze
+
+import "math"
+
+const (
+	bandLowMaxHz  = 200.0
+	bandMidMaxHz  = 2000.0
+	maxRMSBeats   = 128
+	prodFrameSize = 4096
+	prodHopSize   = 2048
+)
+
+// TempoHypothesis is one plausible tempo reading (primary / half / double).
+type TempoHypothesis struct {
+	BPM        float64 `json:"bpm"`
+	Confidence float64 `json:"confidence"`
+	Label      string  `json:"label" jsonschema:"description=primary, half_time, or double_time"`
+}
+
+// KeyHypothesis is one plausible key/scale reading.
+type KeyHypothesis struct {
+	Tonic      string  `json:"tonic"`
+	Scale      string  `json:"scale"`
+	Confidence float64 `json:"confidence"`
+	Label      string  `json:"label" jsonschema:"description=primary or alternative"`
+}
+
+// BandBalance is relative energy in low / mid / high bands (sums ≈ 1).
+type BandBalance struct {
+	Low  float64 `json:"low" jsonschema:"description=Share of energy below ~200 Hz"`
+	Mid  float64 `json:"mid" jsonschema:"description=Share of energy ~200 Hz–2 kHz"`
+	High float64 `json:"high" jsonschema:"description=Share of energy above ~2 kHz"`
+}
+
+// MatchAxis is one production decision axis for "what to match" when
+// referencing a track — not a prescription, a ranked observation.
+type MatchAxis struct {
+	Name  string  `json:"name"`
+	Score float64 `json:"score" jsonschema:"description=0..1 observation strength"`
+	Hint  string  `json:"hint"`
+}
+
+// bpmAlternatives returns primary plus half/double-time readings when in range.
+// Use when BPM confidence is low so agents can try 90 vs 180 (etc.) explicitly.
+func bpmAlternatives(bpm, confidence float64) []TempoHypothesis {
+	if bpm <= 0 {
+		return nil
+	}
+	out := []TempoHypothesis{{
+		BPM: bpm, Confidence: round2(confidence), Label: "primary",
+	}}
+	half := round1(bpm / 2)
+	if half >= minBPM {
+		out = append(out, TempoHypothesis{
+			BPM: half, Confidence: round2(confidence * 0.65), Label: "half_time",
+		})
+	}
+	dbl := round1(bpm * 2)
+	if dbl <= maxBPM {
+		out = append(out, TempoHypothesis{
+			BPM: dbl, Confidence: round2(confidence * 0.65), Label: "double_time",
+		})
+	}
+	return out
+}
+
+// estimateBandBalance accumulates spectral energy into low/mid/high bands.
+func estimateBandBalance(samples []float64, sampleRate int) (BandBalance, bool) {
+	if sampleRate <= 0 || len(samples) < prodFrameSize {
+		return BandBalance{}, false
+	}
+	window := hannWindow(prodFrameSize)
+	buf := make([]float64, prodFrameSize)
+	var lowE, midE, highE float64
+	frames := 0
+	for start := 0; start+prodFrameSize <= len(samples); start += prodHopSize {
+		for i := 0; i < prodFrameSize; i++ {
+			buf[i] = samples[start+i] * window[i]
+		}
+		re, im := fftReal(buf)
+		for bin := 1; bin < prodFrameSize/2; bin++ {
+			mag := math.Hypot(re[bin], im[bin])
+			e := mag * mag
+			freq := float64(bin) * float64(sampleRate) / float64(prodFrameSize)
+			switch {
+			case freq < bandLowMaxHz:
+				lowE += e
+			case freq < bandMidMaxHz:
+				midE += e
+			default:
+				highE += e
+			}
+		}
+		frames++
+		if frames >= 200 {
+			break
+		}
+	}
+	total := lowE + midE + highE
+	if total <= 1e-18 {
+		return BandBalance{}, false
+	}
+	return BandBalance{
+		Low:  round2(lowE / total),
+		Mid:  round2(midE / total),
+		High: round2(highE / total),
+	}, true
+}
+
+// rmsEnvelopePerBeat returns one RMS level per beat at the given tempo.
+// Caps at maxRMSBeats so replies stay small for chop placement decisions.
+func rmsEnvelopePerBeat(samples []float64, sampleRate int, bpm float64) []float64 {
+	if bpm <= 0 || sampleRate <= 0 || len(samples) == 0 {
+		return nil
+	}
+	beatSamples := int(math.Round(float64(sampleRate) * 60.0 / bpm))
+	if beatSamples < 1 {
+		return nil
+	}
+	nBeats := len(samples) / beatSamples
+	if nBeats > maxRMSBeats {
+		nBeats = maxRMSBeats
+	}
+	if nBeats < 1 {
+		return nil
+	}
+	out := make([]float64, 0, nBeats)
+	for b := 0; b < nBeats; b++ {
+		start := b * beatSamples
+		end := start + beatSamples
+		if end > len(samples) {
+			end = len(samples)
+		}
+		var sumSq float64
+		for _, s := range samples[start:end] {
+			sumSq += s * s
+		}
+		n := end - start
+		if n < 1 {
+			out = append(out, 0)
+			continue
+		}
+		out = append(out, round3(math.Sqrt(sumSq/float64(n))))
+	}
+	return out
+}
+
+// rhythmDensityOnsetsPerBar is onsets per 4-beat bar at the given tempo.
+func rhythmDensityOnsetsPerBar(onsetCount int, durationSec, bpm float64) float64 {
+	if bpm <= 0 || durationSec <= 0 || onsetCount <= 0 {
+		return 0
+	}
+	bars := durationSec * (bpm / 60.0) / 4.0
+	if bars < 0.25 {
+		bars = 0.25
+	}
+	return round2(float64(onsetCount) / bars)
+}
+
+// buildMatchAxes returns three production-oriented "what to match" axes derived
+// from density, low-end share, and space proxies (stereo + crest).
+func buildMatchAxes(densityPerBar float64, bands BandBalance, stereoWidth, crestDB float64) []MatchAxis {
+	// Density: ~2 onsets/bar = sparse, ~8 = busy 16ths-ish, ~16 = very dense.
+	densScore := clamp01((densityPerBar - 1) / 12)
+	densHint := "sparse hits — leave room; avoid filling every 16th"
+	if densScore > 0.66 {
+		densHint = "dense rhythm — match hit rate / hat motion before melody"
+	} else if densScore > 0.33 {
+		densHint = "medium density — pocket and placement matter more than busyness"
+	}
+
+	lowScore := clamp01(bands.Low / 0.45) // ~0.45 low share ≈ heavy sub role
+	lowHint := "thin low end — sub/808 may need to carry the weight"
+	if lowScore > 0.66 {
+		lowHint = "low-end forward — duck competing bass; watch kick/sub masking"
+	} else if lowScore > 0.33 {
+		lowHint = "balanced lows — keep kick and bass roles distinct"
+	}
+
+	// Space: wider stereo + lower crest (more compressed/sustained) ≈ more "wash".
+	space := clamp01(0.55*clamp01(stereoWidth) + 0.45*clamp01((12-crestDB)/12))
+	spaceHint := "dry / upfront — short amps and tight FX"
+	if space > 0.66 {
+		spaceHint = "spacious / washed — match reverb/delay amount and stereo width"
+	} else if space > 0.33 {
+		spaceHint = "moderate space — light verb/delay; keep transient edge"
+	}
+
+	return []MatchAxis{
+		{Name: "drum_density", Score: round2(densScore), Hint: densHint},
+		{Name: "low_end_role", Score: round2(lowScore), Hint: lowHint},
+		{Name: "space_amount", Score: round2(space), Hint: spaceHint},
+	}
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+func round3(v float64) float64 {
+	return math.Round(v*1000) / 1000
+}

--- a/internal/audioanalyze/production_test.go
+++ b/internal/audioanalyze/production_test.go
@@ -1,0 +1,96 @@
+package audioanalyze
+
+import (
+	"math"
+	"testing"
+)
+
+func TestBPMAlternativesIncludesHalfAndDouble(t *testing.T) {
+	// 90 → half 45 out of range; double 180 in range.
+	alts := bpmAlternatives(90, 0.5)
+	labels := map[string]float64{}
+	for _, a := range alts {
+		labels[a.Label] = a.BPM
+	}
+	if labels["primary"] != 90 {
+		t.Errorf("primary = %v", labels["primary"])
+	}
+	if labels["double_time"] != 180 {
+		t.Errorf("double_time = %v, want 180", labels["double_time"])
+	}
+	if _, ok := labels["half_time"]; ok {
+		t.Errorf("half_time should be omitted below minBPM, got %v", labels["half_time"])
+	}
+
+	// 140 → half 70 in range; double 280 out of range.
+	alts = bpmAlternatives(140, 0.5)
+	labels = map[string]float64{}
+	for _, a := range alts {
+		labels[a.Label] = a.BPM
+	}
+	if labels["half_time"] != 70 {
+		t.Errorf("half_time = %v, want 70", labels["half_time"])
+	}
+	if _, ok := labels["double_time"]; ok {
+		t.Errorf("double_time should be omitted above maxBPM, got %v", labels["double_time"])
+	}
+}
+
+func TestRMSEnvelopePerBeat(t *testing.T) {
+	sr := 44100
+	bpm := 120.0
+	beatN := sr / 2 // 0.5s at 120
+	samples := make([]float64, beatN*8)
+	for i := beatN * 4; i < len(samples); i++ {
+		samples[i] = 0.5
+	}
+	got := rmsEnvelopePerBeat(samples, sr, bpm)
+	if len(got) != 8 {
+		t.Fatalf("len = %d, want 8", len(got))
+	}
+	if got[0] > 0.01 {
+		t.Errorf("quiet beat rms = %v", got[0])
+	}
+	if got[5] < 0.4 {
+		t.Errorf("loud beat rms = %v", got[5])
+	}
+}
+
+func TestEstimateBandBalanceBassHeavy(t *testing.T) {
+	sr := 44100
+	n := sr * 2
+	samples := make([]float64, n)
+	for i := range samples {
+		samples[i] = math.Sin(2 * math.Pi * 110 * float64(i) / float64(sr))
+	}
+	got, ok := estimateBandBalance(samples, sr)
+	if !ok {
+		t.Fatal("estimateBandBalance returned ok=false")
+	}
+	if got.Low < got.Mid || got.Low < got.High {
+		t.Errorf("expected low-dominant balance, got %+v", got)
+	}
+}
+
+func TestRhythmDensityAndMatchAxes(t *testing.T) {
+	d := rhythmDensityOnsetsPerBar(16, 8.0, 120) // 8s at 120 = 4 bars → 4 onsets/bar
+	if math.Abs(d-4) > 0.1 {
+		t.Errorf("density = %v, want ~4", d)
+	}
+	axes := buildMatchAxes(d, BandBalance{Low: 0.5, Mid: 0.3, High: 0.2}, 0.8, 4)
+	if len(axes) != 3 {
+		t.Fatalf("axes len = %d", len(axes))
+	}
+	names := map[string]bool{}
+	for _, a := range axes {
+		names[a.Name] = true
+		if a.Hint == "" {
+			t.Errorf("axis %s missing hint", a.Name)
+		}
+	}
+	for _, want := range []string{"drum_density", "low_end_role", "space_amount"} {
+		if !names[want] {
+			t.Errorf("missing axis %s", want)
+		}
+	}
+}

--- a/internal/tools/ableton_analyze_audio.go
+++ b/internal/tools/ableton_analyze_audio.go
@@ -13,34 +13,41 @@ type AnalyzeLocalAudioInput struct {
 }
 
 type AnalyzeLocalAudioOutput struct {
-	Path              string                      `json:"path"`
-	Format            string                      `json:"format"`
-	DurationSec       float64                     `json:"duration_sec"`
-	SampleRate        int                         `json:"sample_rate"`
-	Channels          int                         `json:"channels"`
-	PeakLevel         float64                     `json:"peak_level"`
-	RMSLevel          float64                     `json:"rms_level"`
-	EstimatedBPM      float64                     `json:"estimated_bpm"`
-	BPMConfidence     float64                     `json:"bpm_confidence"`
-	OnsetCount        int                         `json:"onset_count"`
-	SuggestedWarpMode string                      `json:"suggested_warp_mode"`
-	Key               string                      `json:"key,omitempty"`
-	Scale             string                      `json:"scale,omitempty"`
-	KeyConfidence     float64                     `json:"key_confidence,omitempty"`
-	ChordProgression  []audioanalyze.ChordSegment `json:"chord_progression,omitempty"`
-	ChordSummary      string                      `json:"chord_summary,omitempty"`
-	Sections          []audioanalyze.Section      `json:"sections,omitempty"`
-	BrightnessHz      float64                     `json:"brightness_hz,omitempty"`
-	CrestFactorDB     float64                     `json:"crest_factor_db,omitempty"`
-	StereoWidth       float64                     `json:"stereo_width"`
-	LengthBarsAtBPM   float64                     `json:"length_bars_at_project_tempo,omitempty"`
-	Note              string                      `json:"note"`
-	NextStep          string                      `json:"next_step"`
+	Path              string                         `json:"path"`
+	Format            string                         `json:"format"`
+	DurationSec       float64                        `json:"duration_sec"`
+	SampleRate        int                            `json:"sample_rate"`
+	Channels          int                            `json:"channels"`
+	PeakLevel         float64                        `json:"peak_level"`
+	RMSLevel          float64                        `json:"rms_level"`
+	EstimatedBPM      float64                        `json:"estimated_bpm"`
+	BPMConfidence     float64                        `json:"bpm_confidence"`
+	BPMAlternatives   []audioanalyze.TempoHypothesis `json:"bpm_alternatives,omitempty"`
+	OnsetCount        int                            `json:"onset_count"`
+	Onsets            []audioanalyze.Onset           `json:"onsets,omitempty"`
+	RhythmDensity     float64                        `json:"rhythm_density,omitempty"`
+	RMSPerBeat        []float64                      `json:"rms_per_beat,omitempty"`
+	BandBalance       *audioanalyze.BandBalance      `json:"band_balance,omitempty"`
+	SuggestedWarpMode string                         `json:"suggested_warp_mode"`
+	Key               string                         `json:"key,omitempty"`
+	Scale             string                         `json:"scale,omitempty"`
+	KeyConfidence     float64                        `json:"key_confidence,omitempty"`
+	KeyAlternatives   []audioanalyze.KeyHypothesis   `json:"key_alternatives,omitempty"`
+	ChordProgression  []audioanalyze.ChordSegment    `json:"chord_progression,omitempty"`
+	ChordSummary      string                         `json:"chord_summary,omitempty"`
+	Sections          []audioanalyze.Section         `json:"sections,omitempty"`
+	MatchAxes         []audioanalyze.MatchAxis       `json:"match_axes,omitempty"`
+	BrightnessHz      float64                        `json:"brightness_hz,omitempty"`
+	CrestFactorDB     float64                        `json:"crest_factor_db,omitempty"`
+	StereoWidth       float64                        `json:"stereo_width"`
+	LengthBarsAtBPM   float64                        `json:"length_bars_at_project_tempo,omitempty"`
+	Note              string                         `json:"note"`
+	NextStep          string                         `json:"next_step"`
 }
 
 func NewAbletonAnalyzeLocalAudio(g *genkit.Genkit) ai.Tool {
 	return genkit.DefineTool(g, "ableton_analyze_local_audio",
-		"Analyze a local .wav file for sampling placement (duration, levels, estimated BPM, approximate key/scale, chord progression, an energy-based section map, and texture indicators: brightness/dynamics/stereo width). Does not download URLs or extract melodies/notes.",
+		"Analyze a local .wav for sampling placement: duration/levels, BPM (+ half/double alternatives), key/scale (+ alternative), chords, section map, onset grid {beat,sec,strength}, rhythm_density, rms_per_beat, band_balance (low/mid/high), match_axes (density/low-end/space), and texture (brightness/dynamics/stereo). No URLs, no melody/note extraction.",
 		func(_ *ai.ToolContext, input AnalyzeLocalAudioInput) (AnalyzeLocalAudioOutput, error) {
 			return analyzeLocalAudio(input)
 		},
@@ -66,19 +73,26 @@ func analyzeLocalAudio(input AnalyzeLocalAudioInput) (AnalyzeLocalAudioOutput, e
 		RMSLevel:          got.RMSLevel,
 		EstimatedBPM:      got.EstimatedBPM,
 		BPMConfidence:     got.BPMConfidence,
+		BPMAlternatives:   got.BPMAlternatives,
 		OnsetCount:        got.OnsetCount,
+		Onsets:            got.Onsets,
+		RhythmDensity:     got.RhythmDensity,
+		RMSPerBeat:        got.RMSPerBeat,
+		BandBalance:       got.BandBalance,
 		SuggestedWarpMode: got.SuggestedWarpMode,
 		Key:               got.Key,
 		Scale:             got.Scale,
 		KeyConfidence:     got.KeyConfidence,
+		KeyAlternatives:   got.KeyAlternatives,
 		ChordProgression:  got.ChordProgression,
 		ChordSummary:      got.ChordSummary,
 		Sections:          got.Sections,
+		MatchAxes:         got.MatchAxes,
 		BrightnessHz:      got.BrightnessHz,
 		CrestFactorDB:     got.CrestFactorDB,
 		StereoWidth:       got.StereoWidth,
 		LengthBarsAtBPM:   got.LengthBarsAtBPM,
 		Note:              got.Note,
-		NextStep:          "If you load this sample into Live, use ableton_match_clip_tempo with the suggested_warp_mode so it follows the project tempo.",
+		NextStep:          "Use match_axes + band_balance for arrangement decisions; for chop placement use onsets/rms_per_beat. If loading into Live, call ableton_match_clip_tempo with suggested_warp_mode.",
 	}, nil
 }

--- a/internal/tools/ableton_analyze_url.go
+++ b/internal/tools/ableton_analyze_url.go
@@ -13,34 +13,40 @@ type AnalyzeAudioURLInput struct {
 }
 
 type AnalyzeAudioURLOutput struct {
-	Source            string                      `json:"source"`
-	Format            string                      `json:"format"`
-	DurationSec       float64                     `json:"duration_sec"`
-	SampleRate        int                         `json:"sample_rate"`
-	Channels          int                         `json:"channels"`
-	PeakLevel         float64                     `json:"peak_level"`
-	RMSLevel          float64                     `json:"rms_level"`
-	EstimatedBPM      float64                     `json:"estimated_bpm"`
-	BPMConfidence     float64                     `json:"bpm_confidence"`
-	OnsetCount        int                         `json:"onset_count"`
-	SuggestedWarpMode string                      `json:"suggested_warp_mode"`
-	Key               string                      `json:"key,omitempty"`
-	Scale             string                      `json:"scale,omitempty"`
-	KeyConfidence     float64                     `json:"key_confidence,omitempty"`
-	ChordProgression  []audioanalyze.ChordSegment `json:"chord_progression,omitempty"`
-	ChordSummary      string                      `json:"chord_summary,omitempty"`
-	Sections          []audioanalyze.Section      `json:"sections,omitempty"`
-	BrightnessHz      float64                     `json:"brightness_hz,omitempty"`
-	CrestFactorDB     float64                     `json:"crest_factor_db,omitempty"`
-	StereoWidth       float64                     `json:"stereo_width"`
-	LengthBarsAtBPM   float64                     `json:"length_bars_at_project_tempo,omitempty"`
-	Note              string                      `json:"note"`
-	NextStep          string                      `json:"next_step"`
+	Source            string                         `json:"source"`
+	Format            string                         `json:"format"`
+	DurationSec       float64                        `json:"duration_sec"`
+	SampleRate        int                            `json:"sample_rate"`
+	Channels          int                            `json:"channels"`
+	PeakLevel         float64                        `json:"peak_level"`
+	RMSLevel          float64                        `json:"rms_level"`
+	EstimatedBPM      float64                        `json:"estimated_bpm"`
+	BPMConfidence     float64                        `json:"bpm_confidence"`
+	BPMAlternatives   []audioanalyze.TempoHypothesis `json:"bpm_alternatives,omitempty"`
+	OnsetCount        int                            `json:"onset_count"`
+	RhythmDensity     float64                        `json:"rhythm_density,omitempty"`
+	RMSPerBeat        []float64                      `json:"rms_per_beat,omitempty"`
+	BandBalance       *audioanalyze.BandBalance      `json:"band_balance,omitempty"`
+	SuggestedWarpMode string                         `json:"suggested_warp_mode"`
+	Key               string                         `json:"key,omitempty"`
+	Scale             string                         `json:"scale,omitempty"`
+	KeyConfidence     float64                        `json:"key_confidence,omitempty"`
+	KeyAlternatives   []audioanalyze.KeyHypothesis   `json:"key_alternatives,omitempty"`
+	ChordProgression  []audioanalyze.ChordSegment    `json:"chord_progression,omitempty"`
+	ChordSummary      string                         `json:"chord_summary,omitempty"`
+	Sections          []audioanalyze.Section         `json:"sections,omitempty"`
+	MatchAxes         []audioanalyze.MatchAxis       `json:"match_axes,omitempty"`
+	BrightnessHz      float64                        `json:"brightness_hz,omitempty"`
+	CrestFactorDB     float64                        `json:"crest_factor_db,omitempty"`
+	StereoWidth       float64                        `json:"stereo_width"`
+	LengthBarsAtBPM   float64                        `json:"length_bars_at_project_tempo,omitempty"`
+	Note              string                         `json:"note"`
+	NextStep          string                         `json:"next_step"`
 }
 
 func NewAbletonAnalyzeAudioURL(g *genkit.Genkit) ai.Tool {
 	return genkit.DefineTool(g, "ableton_analyze_audio_url",
-		"Reference-analyze audio at an http(s) URL (e.g. YouTube) for tempo/length/levels, approximate key/scale, chord progression, an energy-based section map, and texture indicators (brightness/dynamics/stereo width). Streams the full track through yt-dlp+ffmpeg in memory, saves nothing, and never extracts melodies or notes. Requires yt-dlp and ffmpeg on PATH; you are responsible for your right to access the URL.",
+		"Reference-analyze audio at an http(s) URL (e.g. YouTube) for tempo (+ half/double alternatives), key/scale (+ alternative), chords, section map, rhythm_density, rms_per_beat, band_balance, match_axes (density/low-end/space), and texture. Streams via yt-dlp+ffmpeg in memory, saves nothing, never extracts melodies/notes. Requires yt-dlp and ffmpeg on PATH; you are responsible for your right to access the URL.",
 		func(tc *ai.ToolContext, input AnalyzeAudioURLInput) (AnalyzeAudioURLOutput, error) {
 			projectTempo := 0.0
 			if input.ProjectTempo != nil {
@@ -60,20 +66,26 @@ func NewAbletonAnalyzeAudioURL(g *genkit.Genkit) ai.Tool {
 				RMSLevel:          got.RMSLevel,
 				EstimatedBPM:      got.EstimatedBPM,
 				BPMConfidence:     got.BPMConfidence,
+				BPMAlternatives:   got.BPMAlternatives,
 				OnsetCount:        got.OnsetCount,
+				RhythmDensity:     got.RhythmDensity,
+				RMSPerBeat:        got.RMSPerBeat,
+				BandBalance:       got.BandBalance,
 				SuggestedWarpMode: got.SuggestedWarpMode,
 				Key:               got.Key,
 				Scale:             got.Scale,
 				KeyConfidence:     got.KeyConfidence,
+				KeyAlternatives:   got.KeyAlternatives,
 				ChordProgression:  got.ChordProgression,
 				ChordSummary:      got.ChordSummary,
 				Sections:          got.Sections,
+				MatchAxes:         got.MatchAxes,
 				BrightnessHz:      got.BrightnessHz,
 				CrestFactorDB:     got.CrestFactorDB,
 				StereoWidth:       got.StereoWidth,
 				LengthBarsAtBPM:   got.LengthBarsAtBPM,
 				Note:              got.Note,
-				NextStep:          "Use the tempo/key/chord progression as a reference to build your own part. This tool does not import the audio; place only samples you have the right to use.",
+				NextStep:          "Use match_axes + band_balance + section map as arrangement cues; build your own part from tempo/key/chords. This tool does not import audio — place only samples you have rights to use.",
 			}, nil
 		},
 	)

--- a/internal/tools/ableton_bass_variations.go
+++ b/internal/tools/ableton_bass_variations.go
@@ -111,6 +111,7 @@ func createBassVariation(client variationClient, input CreateBassVariationInput)
 		"/live/clip_slot/duplicate_clip_to",
 		int32(input.TrackIndex),
 		int32(input.SourceClipIndex),
+		int32(input.TrackIndex),
 		int32(input.TargetClipIndex),
 	); err != nil {
 		return CreateBassVariationOutput{}, fmt.Errorf("duplicate source clip: %w", err)

--- a/internal/tools/ableton_chop.go
+++ b/internal/tools/ableton_chop.go
@@ -1,0 +1,194 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+)
+
+// chopGrids maps a step-grid name to its length in beats (4/4).
+var chopGrids = map[string]float64{
+	"1/4":  1.0,
+	"1/8":  0.5,
+	"1/16": 0.25,
+	"1/32": 0.125,
+}
+
+type ChopDraftInput struct {
+	NumSlices int      `json:"num_slices" jsonschema:"description=Number of available slices/pads to arrange,minimum=1,maximum=128"`
+	BaseNote  *int     `json:"base_note,omitempty" jsonschema:"description=MIDI note for slice 0 (default 36 = C1),minimum=0,maximum=127"`
+	Bars      *int     `json:"bars,omitempty" jsonschema:"description=Pattern length in bars (default 1),minimum=1,maximum=16"`
+	Grid      string   `json:"grid,omitempty" jsonschema:"description=Step grid: 1/4, 1/8, 1/16 (default), or 1/32"`
+	Density   *float64 `json:"density,omitempty" jsonschema:"description=Fraction of steps that get a hit, 0..1 (default 0.5)"`
+	AvoidCopy *bool    `json:"avoid_copy,omitempty" jsonschema:"description=Avoid reproducing the source's original slice order (default true)"`
+	Seed      *int64   `json:"seed,omitempty" jsonschema:"description=Random seed for a reproducible draft"`
+}
+
+type ChopDraftOutput struct {
+	Notes       []MidiNote `json:"notes"`
+	Grid        string     `json:"grid"`
+	Bars        int        `json:"bars"`
+	StepBeats   float64    `json:"step_beats"`
+	LengthBeats float64    `json:"length_beats"`
+	Seed        int64      `json:"seed"`
+	Note        string     `json:"note"`
+	NextStep    string     `json:"next_step"`
+}
+
+func NewAbletonChopDraft(g *genkit.Genkit) ai.Tool {
+	return genkit.DefineTool(g, "ableton_chop_draft",
+		"Generate a MIDI draft that arranges chop slices into a rhythmic pattern WITHOUT reproducing the source's original order (avoid_copy). This is a placement suggestion for slices/pads (e.g. a Simpler in Slice mode or a Drum Rack), not a transcription of any melody. Returns notes to review, then apply with ableton_add_midi_notes.",
+		func(_ *ai.ToolContext, input ChopDraftInput) (ChopDraftOutput, error) {
+			return generateChopDraft(input)
+		},
+	)
+}
+
+func generateChopDraft(input ChopDraftInput) (ChopDraftOutput, error) {
+	if input.NumSlices < 1 || input.NumSlices > 128 {
+		return ChopDraftOutput{}, errors.New("num_slices must be 1..128")
+	}
+	baseNote := 36
+	if input.BaseNote != nil {
+		baseNote = *input.BaseNote
+	}
+	if baseNote < 0 || baseNote > 127 {
+		return ChopDraftOutput{}, errors.New("base_note must be 0..127")
+	}
+	if baseNote+input.NumSlices-1 > 127 {
+		return ChopDraftOutput{}, fmt.Errorf("base_note %d + %d slices exceeds MIDI note 127; lower base_note or reduce num_slices", baseNote, input.NumSlices)
+	}
+
+	bars := 1
+	if input.Bars != nil {
+		bars = *input.Bars
+	}
+	if bars < 1 || bars > 16 {
+		return ChopDraftOutput{}, errors.New("bars must be 1..16")
+	}
+
+	grid := input.Grid
+	if grid == "" {
+		grid = "1/16"
+	}
+	stepBeats, ok := chopGrids[grid]
+	if !ok {
+		return ChopDraftOutput{}, fmt.Errorf("invalid grid %q; use 1/4, 1/8, 1/16, or 1/32", grid)
+	}
+
+	density := 0.5
+	if input.Density != nil {
+		density = *input.Density
+	}
+	if density < 0.05 {
+		density = 0.05
+	}
+	if density > 1 {
+		density = 1
+	}
+
+	avoidCopy := true
+	if input.AvoidCopy != nil {
+		avoidCopy = *input.AvoidCopy
+	}
+
+	seed := time.Now().UnixNano()
+	if input.Seed != nil {
+		seed = *input.Seed
+	}
+	rng := rand.New(rand.NewSource(seed)) //nolint:gosec // musical draft, not security-sensitive
+
+	lengthBeats := float64(bars) * 4.0
+	steps := int(math.Round(lengthBeats / stepBeats))
+	stepsPerBeat := int(math.Round(1.0 / stepBeats))
+	if stepsPerBeat < 1 {
+		stepsPerBeat = 1
+	}
+
+	notes := make([]MidiNote, 0, steps)
+	prevSlice := -1
+	for step := 0; step < steps; step++ {
+		if rng.Float64() > density {
+			continue
+		}
+		slice := pickChopSlice(rng, input.NumSlices, avoidCopy, prevSlice)
+		start := round4(float64(step) * stepBeats)
+		notes = append(notes, MidiNote{
+			Pitch:     baseNote + slice,
+			StartTime: start,
+			Duration:  stepBeats,
+			Velocity:  chopVelocity(rng, step, stepsPerBeat),
+		})
+		prevSlice = slice
+	}
+
+	// Guarantee at least one hit so the draft is never empty.
+	if len(notes) == 0 {
+		slice := rng.Intn(input.NumSlices)
+		notes = append(notes, MidiNote{
+			Pitch:     baseNote + slice,
+			StartTime: 0,
+			Duration:  stepBeats,
+			Velocity:  chopVelocity(rng, 0, stepsPerBeat),
+		})
+	}
+
+	return ChopDraftOutput{
+		Notes:       notes,
+		Grid:        grid,
+		Bars:        bars,
+		StepBeats:   stepBeats,
+		LengthBeats: lengthBeats,
+		Seed:        seed,
+		Note:        "Placement suggestion only: a rearrangement of slice triggers, not a transcription of the source. Review/edit before applying.",
+		NextStep:    fmt.Sprintf("Create a clip of %.0f beats, then apply with ableton_add_midi_notes(notes). Reuse the same seed to reproduce this draft.", lengthBeats),
+	}, nil
+}
+
+// pickChopSlice chooses a slice index. When avoidCopy is set it skips immediate
+// repeats and ascending-consecutive picks so the result reads as a rearrangement
+// rather than a replay of the source order.
+func pickChopSlice(rng *rand.Rand, n int, avoidCopy bool, prev int) int {
+	if n == 1 {
+		return 0
+	}
+	if !avoidCopy {
+		return rng.Intn(n)
+	}
+	for tries := 0; tries < 8; tries++ {
+		s := rng.Intn(n)
+		if s == prev {
+			continue
+		}
+		if prev >= 0 && s == prev+1 {
+			continue
+		}
+		return s
+	}
+	// Fallback: anything that is not an immediate repeat.
+	s := rng.Intn(n)
+	if s == prev {
+		s = (s + 1) % n
+	}
+	return s
+}
+
+func chopVelocity(rng *rand.Rand, step, stepsPerBeat int) int {
+	v := 92 + rng.Intn(16) // 92..107
+	if stepsPerBeat > 0 && step%stepsPerBeat == 0 {
+		v += 12 // accent on the beat
+	}
+	if v > 127 {
+		v = 127
+	}
+	return v
+}
+
+func round4(v float64) float64 {
+	return math.Round(v*10000) / 10000
+}

--- a/internal/tools/ableton_chop_test.go
+++ b/internal/tools/ableton_chop_test.go
@@ -1,0 +1,115 @@
+package tools
+
+import (
+	"math"
+	"testing"
+)
+
+func intPtr(v int) *int             { return &v }
+func int64Ptr(v int64) *int64       { return &v }
+func float64Ptr(v float64) *float64 { return &v }
+func boolPtr(v bool) *bool          { return &v }
+
+func TestGenerateChopDraftDeterministic(t *testing.T) {
+	t.Parallel()
+
+	in := ChopDraftInput{
+		NumSlices: 8,
+		Bars:      intPtr(1),
+		Grid:      "1/16",
+		Density:   float64Ptr(1.0),
+		Seed:      int64Ptr(42),
+	}
+	a, err := generateChopDraft(in)
+	if err != nil {
+		t.Fatalf("generateChopDraft() error = %v", err)
+	}
+	b, err := generateChopDraft(in)
+	if err != nil {
+		t.Fatalf("generateChopDraft() error = %v", err)
+	}
+	if len(a.Notes) != len(b.Notes) {
+		t.Fatalf("non-deterministic length: %d vs %d", len(a.Notes), len(b.Notes))
+	}
+	for i := range a.Notes {
+		if a.Notes[i] != b.Notes[i] {
+			t.Fatalf("note %d differs across identical seeds: %#v vs %#v", i, a.Notes[i], b.Notes[i])
+		}
+	}
+	// density 1.0 over 1 bar at 1/16 => 16 steps all filled.
+	if len(a.Notes) != 16 {
+		t.Fatalf("notes = %d, want 16 at density 1.0", len(a.Notes))
+	}
+	if a.LengthBeats != 4 || a.StepBeats != 0.25 {
+		t.Errorf("length/step = %v/%v, want 4/0.25", a.LengthBeats, a.StepBeats)
+	}
+}
+
+func TestGenerateChopDraftAvoidCopy(t *testing.T) {
+	t.Parallel()
+
+	in := ChopDraftInput{
+		NumSlices: 8,
+		Bars:      intPtr(2),
+		Grid:      "1/16",
+		Density:   float64Ptr(1.0),
+		AvoidCopy: boolPtr(true),
+		BaseNote:  intPtr(36),
+		Seed:      int64Ptr(7),
+	}
+	out, err := generateChopDraft(in)
+	if err != nil {
+		t.Fatalf("generateChopDraft() error = %v", err)
+	}
+	for i, n := range out.Notes {
+		if n.Pitch < 36 || n.Pitch > 43 {
+			t.Errorf("note %d pitch %d out of slice range [36,43]", i, n.Pitch)
+		}
+		if n.Velocity < 1 || n.Velocity > 127 {
+			t.Errorf("note %d velocity %d out of range", i, n.Velocity)
+		}
+		// start times align to the 1/16 grid.
+		if r := math.Mod(n.StartTime, 0.25); math.Abs(r) > 1e-9 && math.Abs(r-0.25) > 1e-9 {
+			t.Errorf("note %d start %v not on 1/16 grid", i, n.StartTime)
+		}
+		if i > 0 {
+			prev := out.Notes[i-1].Pitch
+			if n.Pitch == prev {
+				t.Errorf("note %d repeats previous slice (avoid_copy)", i)
+			}
+			if n.Pitch == prev+1 {
+				t.Errorf("note %d is ascending-consecutive to previous (avoid_copy)", i)
+			}
+		}
+	}
+}
+
+func TestGenerateChopDraftValidation(t *testing.T) {
+	t.Parallel()
+
+	if _, err := generateChopDraft(ChopDraftInput{NumSlices: 0}); err == nil {
+		t.Error("expected error for num_slices=0")
+	}
+	if _, err := generateChopDraft(ChopDraftInput{NumSlices: 120, BaseNote: intPtr(36)}); err == nil {
+		t.Error("expected error when base_note+slices exceeds 127")
+	}
+	if _, err := generateChopDraft(ChopDraftInput{NumSlices: 4, Grid: "1/3"}); err == nil {
+		t.Error("expected error for invalid grid")
+	}
+}
+
+func TestGenerateChopDraftNeverEmpty(t *testing.T) {
+	t.Parallel()
+
+	out, err := generateChopDraft(ChopDraftInput{
+		NumSlices: 4,
+		Density:   float64Ptr(0.05),
+		Seed:      int64Ptr(1),
+	})
+	if err != nil {
+		t.Fatalf("generateChopDraft() error = %v", err)
+	}
+	if len(out.Notes) == 0 {
+		t.Error("draft must contain at least one note")
+	}
+}

--- a/internal/tools/ableton_clip_edit.go
+++ b/internal/tools/ableton_clip_edit.go
@@ -1,0 +1,456 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+// clipWarpModes indexes the Live Object Model Clip.warp_mode enum.
+var clipWarpModes = []string{"Beats", "Tones", "Texture", "Re-Pitch", "Complex", "REX", "Complex Pro"}
+
+func clipGet(client *abletonosc.Client, track, clip int, prop string) (interface{}, error) {
+	res, err := client.Query("/live/clip/get/"+prop, int32(track), int32(clip))
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return nil, err
+	}
+	return res[2], nil
+}
+
+func requireAudioClip(client *abletonosc.Client, track, clip int) error {
+	v, err := clipGet(client, track, clip, "is_audio_clip")
+	if err != nil {
+		return fmt.Errorf("clip not found or slot empty: %w", err)
+	}
+	isAudio, _ := abletonosc.AsBool(v)
+	if !isAudio {
+		return errors.New("clip is not an audio clip (pitch/warp apply to audio clips only)")
+	}
+	return nil
+}
+
+func slotHasClip(client *abletonosc.Client, track, clip int) (bool, error) {
+	res, err := client.Query("/live/clip_slot/get/has_clip", int32(track), int32(clip))
+	if err != nil {
+		return false, err
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return false, err
+	}
+	return abletonosc.AsBool(res[2])
+}
+
+type ClipPropertiesInput struct {
+	TrackIndex int `json:"track_index" jsonschema:"minimum=0"`
+	ClipIndex  int `json:"clip_index" jsonschema:"minimum=0"`
+}
+
+type ClipProperties struct {
+	TrackIndex   int      `json:"track_index"`
+	ClipIndex    int      `json:"clip_index"`
+	IsAudioClip  bool     `json:"is_audio_clip"`
+	LengthBeats  float64  `json:"length_beats"`
+	FilePath     string   `json:"file_path,omitempty"`
+	Gain         *float64 `json:"gain,omitempty"`
+	GainDisplay  string   `json:"gain_display,omitempty"`
+	PitchCoarse  *int     `json:"pitch_coarse,omitempty" jsonschema:"description=Transpose in semitones (audio clips)"`
+	PitchFine    *int     `json:"pitch_fine,omitempty" jsonschema:"description=Detune in cents (audio clips)"`
+	WarpMode     *int     `json:"warp_mode,omitempty"`
+	WarpModeName string   `json:"warp_mode_name,omitempty"`
+	Warping      *bool    `json:"warping,omitempty"`
+	StartMarker  *float64 `json:"start_marker,omitempty"`
+	EndMarker    *float64 `json:"end_marker,omitempty"`
+	LoopStart    *float64 `json:"loop_start,omitempty"`
+	LoopEnd      *float64 `json:"loop_end,omitempty"`
+}
+
+func NewAbletonGetClipProperties(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_clip_properties",
+		"Ableton Live: get a clip's edit state. Audio clips: pitch_coarse (transpose semitones), pitch_fine (detune cents), warp_mode/warping, gain, file_path. Both: length, start/end markers, loop. Uses stock AbletonOSC",
+		func(_ *ai.ToolContext, input ClipPropertiesInput) (ClipProperties, error) {
+			if err := validateTrackClipIndices(input.TrackIndex, input.ClipIndex); err != nil {
+				return ClipProperties{}, err
+			}
+			t, c := input.TrackIndex, input.ClipIndex
+			out := ClipProperties{TrackIndex: t, ClipIndex: c}
+
+			v, err := clipGet(client, t, c, "is_audio_clip")
+			if err != nil {
+				return ClipProperties{}, fmt.Errorf("get clip failed (is the slot empty?): %w", err)
+			}
+			out.IsAudioClip, _ = abletonosc.AsBool(v)
+
+			if v, err := clipGet(client, t, c, "length"); err == nil {
+				out.LengthBeats, _ = abletonosc.AsFloat64(v)
+			}
+			for _, m := range []struct {
+				prop string
+				dst  **float64
+			}{
+				{"start_marker", &out.StartMarker},
+				{"end_marker", &out.EndMarker},
+				{"loop_start", &out.LoopStart},
+				{"loop_end", &out.LoopEnd},
+			} {
+				if v, err := clipGet(client, t, c, m.prop); err == nil {
+					if f, e := abletonosc.AsFloat64(v); e == nil {
+						val := f
+						*m.dst = &val
+					}
+				}
+			}
+
+			if out.IsAudioClip {
+				if v, err := clipGet(client, t, c, "file_path"); err == nil {
+					out.FilePath = fmt.Sprint(v)
+				}
+				if v, err := clipGet(client, t, c, "gain"); err == nil {
+					if f, e := abletonosc.AsFloat64(v); e == nil {
+						val := f
+						out.Gain = &val
+					}
+				}
+				if v, err := clipGet(client, t, c, "gain_display_string"); err == nil {
+					out.GainDisplay = fmt.Sprint(v)
+				}
+				if v, err := clipGet(client, t, c, "pitch_coarse"); err == nil {
+					if n, e := abletonosc.AsInt(v); e == nil {
+						val := n
+						out.PitchCoarse = &val
+					}
+				}
+				if v, err := clipGet(client, t, c, "pitch_fine"); err == nil {
+					if n, e := abletonosc.AsInt(v); e == nil {
+						val := n
+						out.PitchFine = &val
+					}
+				}
+				if v, err := clipGet(client, t, c, "warping"); err == nil {
+					if b, e := abletonosc.AsBool(v); e == nil {
+						val := b
+						out.Warping = &val
+					}
+				}
+				if v, err := clipGet(client, t, c, "warp_mode"); err == nil {
+					if n, e := abletonosc.AsInt(v); e == nil {
+						val := n
+						out.WarpMode = &val
+						out.WarpModeName = nameForIndex(clipWarpModes, n)
+					}
+				}
+			}
+			return out, nil
+		},
+	)
+}
+
+type SetClipPitchInput struct {
+	TrackIndex int  `json:"track_index" jsonschema:"minimum=0"`
+	ClipIndex  int  `json:"clip_index" jsonschema:"minimum=0"`
+	Coarse     *int `json:"coarse,omitempty" jsonschema:"description=Transpose in semitones (-48..48)"`
+	Fine       *int `json:"fine,omitempty" jsonschema:"description=Detune in cents (-50..50)"`
+}
+
+type ClipPitchOutput struct {
+	TrackIndex  int `json:"track_index"`
+	ClipIndex   int `json:"clip_index"`
+	PitchCoarse int `json:"pitch_coarse"`
+	PitchFine   int `json:"pitch_fine"`
+}
+
+func NewAbletonSetClipPitch(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_clip_pitch",
+		"Ableton Live: transpose (coarse semitones) and/or detune (fine cents) an audio clip. Key-matching by sample edit, not project tempo. Uses stock AbletonOSC",
+		func(_ *ai.ToolContext, input SetClipPitchInput) (ClipPitchOutput, error) {
+			if err := validateTrackClipIndices(input.TrackIndex, input.ClipIndex); err != nil {
+				return ClipPitchOutput{}, err
+			}
+			if input.Coarse == nil && input.Fine == nil {
+				return ClipPitchOutput{}, errors.New("provide coarse and/or fine")
+			}
+			if err := requireAudioClip(client, input.TrackIndex, input.ClipIndex); err != nil {
+				return ClipPitchOutput{}, err
+			}
+			if input.Coarse != nil {
+				if *input.Coarse < -48 || *input.Coarse > 48 {
+					return ClipPitchOutput{}, errors.New("coarse must be -48..48 semitones")
+				}
+				if err := client.Send("/live/clip/set/pitch_coarse", int32(input.TrackIndex), int32(input.ClipIndex), int32(*input.Coarse)); err != nil {
+					return ClipPitchOutput{}, err
+				}
+			}
+			if input.Fine != nil {
+				if *input.Fine < -50 || *input.Fine > 50 {
+					return ClipPitchOutput{}, errors.New("fine must be -50..50 cents")
+				}
+				if err := client.Send("/live/clip/set/pitch_fine", int32(input.TrackIndex), int32(input.ClipIndex), int32(*input.Fine)); err != nil {
+					return ClipPitchOutput{}, err
+				}
+			}
+			out := ClipPitchOutput{TrackIndex: input.TrackIndex, ClipIndex: input.ClipIndex}
+			if v, err := clipGet(client, input.TrackIndex, input.ClipIndex, "pitch_coarse"); err == nil {
+				out.PitchCoarse, _ = abletonosc.AsInt(v)
+			}
+			if v, err := clipGet(client, input.TrackIndex, input.ClipIndex, "pitch_fine"); err == nil {
+				out.PitchFine, _ = abletonosc.AsInt(v)
+			}
+			return out, nil
+		},
+	)
+}
+
+type SetClipWarpInput struct {
+	TrackIndex int    `json:"track_index" jsonschema:"minimum=0"`
+	ClipIndex  int    `json:"clip_index" jsonschema:"minimum=0"`
+	Warping    *bool  `json:"warping,omitempty" jsonschema:"description=Enable/disable warping"`
+	WarpMode   string `json:"warp_mode,omitempty" jsonschema:"description=Beats, Tones, Texture, Re-Pitch, Complex, REX, or Complex Pro"`
+}
+
+type ClipWarpOutput struct {
+	TrackIndex   int    `json:"track_index"`
+	ClipIndex    int    `json:"clip_index"`
+	Warping      bool   `json:"warping"`
+	WarpMode     int    `json:"warp_mode"`
+	WarpModeName string `json:"warp_mode_name"`
+}
+
+func NewAbletonSetClipWarp(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_clip_warp",
+		"Ableton Live: set an audio clip's warping on/off and/or warp mode (Beats/Tones/Texture/Re-Pitch/Complex/REX/Complex Pro). Uses stock AbletonOSC",
+		func(_ *ai.ToolContext, input SetClipWarpInput) (ClipWarpOutput, error) {
+			if err := validateTrackClipIndices(input.TrackIndex, input.ClipIndex); err != nil {
+				return ClipWarpOutput{}, err
+			}
+			if input.Warping == nil && input.WarpMode == "" {
+				return ClipWarpOutput{}, errors.New("provide warping and/or warp_mode")
+			}
+			if err := requireAudioClip(client, input.TrackIndex, input.ClipIndex); err != nil {
+				return ClipWarpOutput{}, err
+			}
+			if input.Warping != nil {
+				warpVal := int32(0)
+				if *input.Warping {
+					warpVal = 1
+				}
+				if err := client.Send("/live/clip/set/warping", int32(input.TrackIndex), int32(input.ClipIndex), warpVal); err != nil {
+					return ClipWarpOutput{}, err
+				}
+			}
+			if input.WarpMode != "" {
+				idx, ok := indexForName(clipWarpModes, input.WarpMode)
+				if !ok {
+					return ClipWarpOutput{}, fmt.Errorf("invalid warp_mode %q; use one of: Beats, Tones, Texture, Re-Pitch, Complex, REX, Complex Pro", input.WarpMode)
+				}
+				if err := client.Send("/live/clip/set/warp_mode", int32(input.TrackIndex), int32(input.ClipIndex), int32(idx)); err != nil {
+					return ClipWarpOutput{}, err
+				}
+			}
+			out := ClipWarpOutput{TrackIndex: input.TrackIndex, ClipIndex: input.ClipIndex}
+			if v, err := clipGet(client, input.TrackIndex, input.ClipIndex, "warping"); err == nil {
+				out.Warping, _ = abletonosc.AsBool(v)
+			}
+			if v, err := clipGet(client, input.TrackIndex, input.ClipIndex, "warp_mode"); err == nil {
+				out.WarpMode, _ = abletonosc.AsInt(v)
+				out.WarpModeName = nameForIndex(clipWarpModes, out.WarpMode)
+			}
+			return out, nil
+		},
+	)
+}
+
+type SetClipRegionInput struct {
+	TrackIndex  int      `json:"track_index" jsonschema:"minimum=0"`
+	ClipIndex   int      `json:"clip_index" jsonschema:"minimum=0"`
+	StartMarker *float64 `json:"start_marker,omitempty" jsonschema:"description=Start marker in beats"`
+	EndMarker   *float64 `json:"end_marker,omitempty" jsonschema:"description=End marker in beats"`
+	LoopStart   *float64 `json:"loop_start,omitempty" jsonschema:"description=Loop start in beats"`
+	LoopEnd     *float64 `json:"loop_end,omitempty" jsonschema:"description=Loop end in beats"`
+}
+
+type ClipRegionOutput struct {
+	TrackIndex  int     `json:"track_index"`
+	ClipIndex   int     `json:"clip_index"`
+	StartMarker float64 `json:"start_marker"`
+	EndMarker   float64 `json:"end_marker"`
+	LoopStart   float64 `json:"loop_start"`
+	LoopEnd     float64 `json:"loop_end"`
+}
+
+func NewAbletonSetClipRegion(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_clip_region",
+		"Ableton Live: set a clip's start/end markers and loop points (in beats). Non-destructive way to focus a region before cropping. Uses stock AbletonOSC",
+		func(_ *ai.ToolContext, input SetClipRegionInput) (ClipRegionOutput, error) {
+			if err := validateTrackClipIndices(input.TrackIndex, input.ClipIndex); err != nil {
+				return ClipRegionOutput{}, err
+			}
+			if input.StartMarker == nil && input.EndMarker == nil && input.LoopStart == nil && input.LoopEnd == nil {
+				return ClipRegionOutput{}, errors.New("provide at least one of start_marker, end_marker, loop_start, loop_end")
+			}
+			for _, m := range []struct {
+				prop string
+				val  *float64
+			}{
+				{"start_marker", input.StartMarker},
+				{"end_marker", input.EndMarker},
+				{"loop_start", input.LoopStart},
+				{"loop_end", input.LoopEnd},
+			} {
+				if m.val == nil {
+					continue
+				}
+				if *m.val < 0 {
+					return ClipRegionOutput{}, fmt.Errorf("%s must be >= 0", m.prop)
+				}
+				if err := client.Send("/live/clip/set/"+m.prop, int32(input.TrackIndex), int32(input.ClipIndex), float32(*m.val)); err != nil {
+					return ClipRegionOutput{}, err
+				}
+			}
+			out := ClipRegionOutput{TrackIndex: input.TrackIndex, ClipIndex: input.ClipIndex}
+			if v, err := clipGet(client, input.TrackIndex, input.ClipIndex, "start_marker"); err == nil {
+				out.StartMarker, _ = abletonosc.AsFloat64(v)
+			}
+			if v, err := clipGet(client, input.TrackIndex, input.ClipIndex, "end_marker"); err == nil {
+				out.EndMarker, _ = abletonosc.AsFloat64(v)
+			}
+			if v, err := clipGet(client, input.TrackIndex, input.ClipIndex, "loop_start"); err == nil {
+				out.LoopStart, _ = abletonosc.AsFloat64(v)
+			}
+			if v, err := clipGet(client, input.TrackIndex, input.ClipIndex, "loop_end"); err == nil {
+				out.LoopEnd, _ = abletonosc.AsFloat64(v)
+			}
+			return out, nil
+		},
+	)
+}
+
+type ExtractClipRegionInput struct {
+	TrackIndex      int     `json:"track_index" jsonschema:"minimum=0"`
+	SourceClipIndex int     `json:"source_clip_index" jsonschema:"description=Slot holding the source audio clip,minimum=0"`
+	TargetClipIndex int     `json:"target_clip_index" jsonschema:"description=Empty slot to place the extracted region,minimum=0"`
+	StartBeats      float64 `json:"start_beats" jsonschema:"description=Region start within the source clip (beats)"`
+	EndBeats        float64 `json:"end_beats" jsonschema:"description=Region end within the source clip (beats)"`
+	Name            string  `json:"name,omitempty" jsonschema:"description=Optional name for the new clip"`
+	Loop            *bool   `json:"loop,omitempty" jsonschema:"description=Loop the extracted region (default true)"`
+}
+
+type ExtractClipRegionOutput struct {
+	TrackIndex  int     `json:"track_index"`
+	ClipIndex   int     `json:"clip_index"`
+	StartMarker float64 `json:"start_marker"`
+	EndMarker   float64 `json:"end_marker"`
+	LoopStart   float64 `json:"loop_start"`
+	LoopEnd     float64 `json:"loop_end"`
+	LengthBeats float64 `json:"length_beats"`
+	Name        string  `json:"name,omitempty"`
+}
+
+func NewAbletonExtractClipRegion(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_extract_clip_region",
+		"Ableton Live: copy a region [start_beats, end_beats] of an existing audio clip into an empty slot as a new clip (non-destructive chop). Duplicates the source, then focuses markers/loop to the region. Turns one long sample into per-hit clips. Uses stock AbletonOSC",
+		func(_ *ai.ToolContext, input ExtractClipRegionInput) (ExtractClipRegionOutput, error) {
+			if err := validateTrackClipIndices(input.TrackIndex, input.SourceClipIndex); err != nil {
+				return ExtractClipRegionOutput{}, err
+			}
+			if input.TargetClipIndex < 0 {
+				return ExtractClipRegionOutput{}, errors.New("target_clip_index must be >= 0")
+			}
+			if input.TargetClipIndex == input.SourceClipIndex {
+				return ExtractClipRegionOutput{}, errors.New("target_clip_index must differ from source_clip_index")
+			}
+			if input.StartBeats < 0 {
+				return ExtractClipRegionOutput{}, errors.New("start_beats must be >= 0")
+			}
+			if input.EndBeats <= input.StartBeats {
+				return ExtractClipRegionOutput{}, errors.New("end_beats must be > start_beats")
+			}
+			if err := requireAudioClip(client, input.TrackIndex, input.SourceClipIndex); err != nil {
+				return ExtractClipRegionOutput{}, err
+			}
+			if v, err := clipGet(client, input.TrackIndex, input.SourceClipIndex, "length"); err == nil {
+				if srcLen, e := abletonosc.AsFloat64(v); e == nil && input.EndBeats > srcLen+1e-6 {
+					return ExtractClipRegionOutput{}, fmt.Errorf("end_beats %.3f exceeds source clip length %.3f beats", input.EndBeats, srcLen)
+				}
+			}
+			if has, err := slotHasClip(client, input.TrackIndex, input.TargetClipIndex); err != nil {
+				return ExtractClipRegionOutput{}, fmt.Errorf("check target slot: %w", err)
+			} else if has {
+				return ExtractClipRegionOutput{}, fmt.Errorf("target slot %d is not empty; choose an empty slot", input.TargetClipIndex)
+			}
+			// AbletonOSC expects (src_track, src_clip, target_track, target_clip).
+			if err := client.Send("/live/clip_slot/duplicate_clip_to",
+				int32(input.TrackIndex), int32(input.SourceClipIndex),
+				int32(input.TrackIndex), int32(input.TargetClipIndex)); err != nil {
+				return ExtractClipRegionOutput{}, err
+			}
+			has, err := slotHasClip(client, input.TrackIndex, input.TargetClipIndex)
+			if err != nil {
+				return ExtractClipRegionOutput{}, err
+			}
+			if !has {
+				return ExtractClipRegionOutput{}, errors.New("duplicate did not populate the target slot")
+			}
+
+			loopOn := true
+			if input.Loop != nil {
+				loopOn = *input.Loop
+			}
+			t, c := input.TrackIndex, input.TargetClipIndex
+			setClip := func(prop string, val interface{}) error {
+				return client.Send("/live/clip/set/"+prop, int32(t), int32(c), val)
+			}
+			loopVal := int32(0)
+			if loopOn {
+				loopVal = 1
+			}
+			// Focus the duplicated (full-length) clip down to the region. Order is
+			// safe because the region is a sub-range of the existing [0, length].
+			if err := setClip("looping", loopVal); err != nil {
+				return ExtractClipRegionOutput{}, err
+			}
+			if err := setClip("start_marker", float32(input.StartBeats)); err != nil {
+				return ExtractClipRegionOutput{}, err
+			}
+			if err := setClip("end_marker", float32(input.EndBeats)); err != nil {
+				return ExtractClipRegionOutput{}, err
+			}
+			if loopOn {
+				if err := setClip("loop_start", float32(input.StartBeats)); err != nil {
+					return ExtractClipRegionOutput{}, err
+				}
+				if err := setClip("loop_end", float32(input.EndBeats)); err != nil {
+					return ExtractClipRegionOutput{}, err
+				}
+			}
+			if input.Name != "" {
+				if err := setClip("name", input.Name); err != nil {
+					return ExtractClipRegionOutput{}, err
+				}
+			}
+
+			out := ExtractClipRegionOutput{TrackIndex: t, ClipIndex: c, Name: input.Name}
+			if v, err := clipGet(client, t, c, "start_marker"); err == nil {
+				out.StartMarker, _ = abletonosc.AsFloat64(v)
+			}
+			if v, err := clipGet(client, t, c, "end_marker"); err == nil {
+				out.EndMarker, _ = abletonosc.AsFloat64(v)
+			}
+			if v, err := clipGet(client, t, c, "loop_start"); err == nil {
+				out.LoopStart, _ = abletonosc.AsFloat64(v)
+			}
+			if v, err := clipGet(client, t, c, "loop_end"); err == nil {
+				out.LoopEnd, _ = abletonosc.AsFloat64(v)
+			}
+			if v, err := clipGet(client, t, c, "length"); err == nil {
+				out.LengthBeats, _ = abletonosc.AsFloat64(v)
+			}
+			return out, nil
+		},
+	)
+}

--- a/internal/tools/ableton_clip_edit_test.go
+++ b/internal/tools/ableton_clip_edit_test.go
@@ -1,0 +1,21 @@
+package tools
+
+import "testing"
+
+func TestClipWarpModeNames(t *testing.T) {
+	cases := map[int]string{0: "Beats", 3: "Re-Pitch", 5: "REX", 6: "Complex Pro"}
+	for idx, want := range cases {
+		if got := nameForIndex(clipWarpModes, idx); got != want {
+			t.Errorf("warp mode %d = %q, want %q", idx, got, want)
+		}
+	}
+	if idx, ok := indexForName(clipWarpModes, "complex pro"); !ok || idx != 6 {
+		t.Errorf("'complex pro' = (%d,%v), want (6,true)", idx, ok)
+	}
+	if idx, ok := indexForName(clipWarpModes, "2"); !ok || idx != 2 {
+		t.Errorf("numeric '2' = (%d,%v), want (2,true)", idx, ok)
+	}
+	if _, ok := indexForName(clipWarpModes, "Nonsense"); ok {
+		t.Error("unknown warp mode should not resolve")
+	}
+}

--- a/internal/tools/ableton_clips.go
+++ b/internal/tools/ableton_clips.go
@@ -17,9 +17,10 @@ type StopClipInput struct {
 }
 
 type DuplicateClipToInput struct {
-	TrackIndex      int `json:"track_index" jsonschema:"minimum=0"`
-	ClipIndex       int `json:"clip_index" jsonschema:"minimum=0"`
-	TargetClipIndex int `json:"target_clip_index" jsonschema:"description=Target clip slot index to duplicate to,minimum=0"`
+	TrackIndex       int  `json:"track_index" jsonschema:"minimum=0"`
+	ClipIndex        int  `json:"clip_index" jsonschema:"minimum=0"`
+	TargetClipIndex  int  `json:"target_clip_index" jsonschema:"description=Target clip slot (scene) index to duplicate to,minimum=0"`
+	TargetTrackIndex *int `json:"target_track_index,omitempty" jsonschema:"description=Target track index; omit to duplicate within the same track,minimum=0"`
 }
 
 type SetClipNameInput struct {
@@ -48,8 +49,9 @@ type FiredOutput struct {
 }
 
 type ClearClipNotesInput struct {
-	TrackIndex int `json:"track_index" jsonschema:"minimum=0"`
-	ClipIndex  int `json:"clip_index" jsonschema:"minimum=0"`
+	TrackIndex int  `json:"track_index" jsonschema:"minimum=0"`
+	ClipIndex  int  `json:"clip_index" jsonschema:"minimum=0"`
+	Confirm    bool `json:"confirm,omitempty" jsonschema:"description=Must be true to execute; omit/false returns a preview error without clearing"`
 }
 
 type ClearedOutput struct {
@@ -231,9 +233,14 @@ func NewAbletonFireClipSlot(g *genkit.Genkit, client *abletonosc.Client) ai.Tool
 }
 
 func NewAbletonClearClipNotes(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_clear_clip_notes", "Ableton Live: clear all notes in a clip",
+	return genkit.DefineTool(g, "ableton_clear_clip_notes",
+		"Ableton Live: clear all notes in a clip. Requires confirm=true. Prefer ableton_preview_destructive with action=clear_clip_notes first.",
 		func(_ *ai.ToolContext, input ClearClipNotesInput) (ClearedOutput, error) {
 			if err := validateTrackClipIndices(input.TrackIndex, input.ClipIndex); err != nil {
+				return ClearedOutput{}, err
+			}
+			if err := requireConfirm(input.Confirm, "clear_clip_notes",
+				fmt.Sprintf("all notes in clip [%d,%d]", input.TrackIndex, input.ClipIndex)); err != nil {
 				return ClearedOutput{}, err
 			}
 			// AbletonOSC: Passing only (track_index, clip_index) clears all notes.
@@ -312,7 +319,8 @@ func NewAbletonStopClip(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
 }
 
 func NewAbletonDuplicateClipTo(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_duplicate_clip_to", "Ableton Live: duplicate clip to another slot",
+	return genkit.DefineTool(g, "ableton_duplicate_clip_to",
+		"Ableton Live: duplicate a clip to another slot (same track by default, or cross-track when target_track_index is set)",
 		func(_ *ai.ToolContext, input DuplicateClipToInput) (SentOutput, error) {
 			if err := validateTrackClipIndices(input.TrackIndex, input.ClipIndex); err != nil {
 				return SentOutput{}, err
@@ -320,9 +328,17 @@ func NewAbletonDuplicateClipTo(g *genkit.Genkit, client *abletonosc.Client) ai.T
 			if input.TargetClipIndex < 0 {
 				return SentOutput{}, errors.New("target_clip_index must be >= 0")
 			}
+			targetTrack := input.TrackIndex
+			if input.TargetTrackIndex != nil {
+				if *input.TargetTrackIndex < 0 {
+					return SentOutput{}, errors.New("target_track_index must be >= 0")
+				}
+				targetTrack = *input.TargetTrackIndex
+			}
 			if err := client.Send("/live/clip_slot/duplicate_clip_to",
 				int32(input.TrackIndex),
 				int32(input.ClipIndex),
+				int32(targetTrack),
 				int32(input.TargetClipIndex),
 			); err != nil {
 				return SentOutput{}, err

--- a/internal/tools/ableton_devices.go
+++ b/internal/tools/ableton_devices.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
@@ -16,11 +18,13 @@ type GetDeviceParametersInput struct {
 }
 
 type DeviceParameter struct {
-	Index int     `json:"index"`
-	Name  string  `json:"name"`
-	Value float64 `json:"value"`
-	Min   float64 `json:"min"`
-	Max   float64 `json:"max"`
+	Index        int     `json:"index"`
+	Name         string  `json:"name"`
+	Value        float64 `json:"value"`
+	DisplayValue string  `json:"display_value,omitempty" jsonschema:"description=Human-readable value with units or enum name (e.g. 37.0 Hz, 1/2, Ins); requires the browser patch"`
+	Min          float64 `json:"min"`
+	Max          float64 `json:"max"`
+	IsQuantized  *bool   `json:"is_quantized,omitempty" jsonschema:"description=true for stepped/enum parameters such as filter type or mix mode"`
 }
 
 type DeviceParametersOutput struct {
@@ -36,8 +40,45 @@ type SetDeviceParameterInput struct {
 	Value          float64 `json:"value" jsonschema:"description=Parameter value to set"`
 }
 
+// buildDeviceParameters merges the parallel parameter lists returned by AbletonOSC
+// into structured parameters. displays and quantized are best-effort: they may be
+// empty (patch missing) or shorter than names, in which case those fields are left
+// unset. values/mins/maxs must all match names in length.
+func buildDeviceParameters(names []string, values, mins, maxs, displays, quantized []interface{}) ([]DeviceParameter, error) {
+	if len(values) != len(names) || len(mins) != len(names) || len(maxs) != len(names) {
+		return nil, fmt.Errorf("parameter list length mismatch: names=%d values=%d mins=%d maxs=%d",
+			len(names), len(values), len(mins), len(maxs))
+	}
+	params := make([]DeviceParameter, 0, len(names))
+	for i := range names {
+		val, err := abletonosc.AsFloat64(values[i])
+		if err != nil {
+			return nil, err
+		}
+		mn, err := abletonosc.AsFloat64(mins[i])
+		if err != nil {
+			return nil, err
+		}
+		mx, err := abletonosc.AsFloat64(maxs[i])
+		if err != nil {
+			return nil, err
+		}
+		param := DeviceParameter{Index: i, Name: names[i], Value: val, Min: mn, Max: mx}
+		if i < len(displays) {
+			param.DisplayValue = fmt.Sprint(displays[i])
+		}
+		if i < len(quantized) {
+			if q, err := abletonosc.AsBool(quantized[i]); err == nil {
+				param.IsQuantized = &q
+			}
+		}
+		params = append(params, param)
+	}
+	return params, nil
+}
+
 func NewAbletonGetDeviceParameters(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
-	return genkit.DefineTool(g, "ableton_get_device_parameters", "Ableton Live: get all parameters of a device on a track",
+	return genkit.DefineTool(g, "ableton_get_device_parameters", "Ableton Live: get all parameters of a device on a track, including human-readable display values (units/enum names) when the browser patch is installed",
 		func(_ *ai.ToolContext, input GetDeviceParametersInput) (DeviceParametersOutput, error) {
 			if input.TrackIndex < 0 {
 				return DeviceParametersOutput{}, errors.New("track_index must be >= 0")
@@ -85,32 +126,20 @@ func NewAbletonGetDeviceParameters(g *genkit.Genkit, client *abletonosc.Client) 
 			mins := minsRes[2:]
 			maxs := maxsRes[2:]
 
-			if len(names) != len(values) || len(names) != len(mins) || len(names) != len(maxs) {
-				return DeviceParametersOutput{}, fmt.Errorf("parameter list length mismatch: names=%d values=%d mins=%d maxs=%d",
-					len(names), len(values), len(mins), len(maxs))
+			// Display strings (e.g. "37.0 Hz", "1/2", "Ins") come from the browser
+			// patch's /live/device/get/parameters/value_string. is_quantized is stock
+			// AbletonOSC. Both are best-effort so numeric params still return without them.
+			var displays, quantized []interface{}
+			if dispRes, err := client.Query("/live/device/get/parameters/value_string", args...); err == nil && len(dispRes) >= 2 {
+				displays = dispRes[2:]
+			}
+			if quantRes, err := client.Query("/live/device/get/parameters/is_quantized", args...); err == nil && len(quantRes) >= 2 {
+				quantized = quantRes[2:]
 			}
 
-			params := make([]DeviceParameter, 0, len(names))
-			for i := range names {
-				val, err := abletonosc.AsFloat64(values[i])
-				if err != nil {
-					return DeviceParametersOutput{}, err
-				}
-				min, err := abletonosc.AsFloat64(mins[i])
-				if err != nil {
-					return DeviceParametersOutput{}, err
-				}
-				max, err := abletonosc.AsFloat64(maxs[i])
-				if err != nil {
-					return DeviceParametersOutput{}, err
-				}
-				params = append(params, DeviceParameter{
-					Index: i,
-					Name:  names[i],
-					Value: val,
-					Min:   min,
-					Max:   max,
-				})
+			params, err := buildDeviceParameters(names, values, mins, maxs, displays, quantized)
+			if err != nil {
+				return DeviceParametersOutput{}, err
 			}
 
 			return DeviceParametersOutput{
@@ -143,6 +172,194 @@ func NewAbletonSetDeviceParameter(g *genkit.Genkit, client *abletonosc.Client) a
 				return SentOutput{}, err
 			}
 			return SentOutput{Sent: true}, nil
+		},
+	)
+}
+
+type SetDeviceParameterStringInput struct {
+	TrackIndex     int    `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex    int    `json:"device_index" jsonschema:"minimum=0"`
+	ParameterIndex int    `json:"parameter_index" jsonschema:"description=Parameter index (from get_device_parameters),minimum=0"`
+	Value          string `json:"value" jsonschema:"description=Human-readable value: enum name (e.g. Ins) or numeric with unit (e.g. 180 Hz, -3.5 dB, 50 %)"`
+}
+
+type SetDeviceParameterStringOutput struct {
+	TrackIndex     int      `json:"track_index"`
+	DeviceIndex    int      `json:"device_index"`
+	ParameterIndex int      `json:"parameter_index"`
+	Status         string   `json:"status" jsonschema:"description=set, or no_match / invalid_* on failure"`
+	Value          float64  `json:"value,omitempty" jsonschema:"description=Resolved numeric value when status is set"`
+	DisplayValue   string   `json:"display_value,omitempty" jsonschema:"description=Resolved human-readable value when status is set"`
+	Options        []string `json:"options,omitempty" jsonschema:"description=Available enum options when status is no_match"`
+}
+
+func parseSetDeviceParameterStringResponse(res []interface{}) (SetDeviceParameterStringOutput, error) {
+	if err := ensureResponseLen(res, 4); err != nil {
+		return SetDeviceParameterStringOutput{}, err
+	}
+	trackIndex, err := abletonosc.AsInt(res[0])
+	if err != nil {
+		return SetDeviceParameterStringOutput{}, fmt.Errorf("parse track_index: %w", err)
+	}
+	deviceIndex, err := abletonosc.AsInt(res[1])
+	if err != nil {
+		return SetDeviceParameterStringOutput{}, fmt.Errorf("parse device_index: %w", err)
+	}
+	parameterIndex, err := abletonosc.AsInt(res[2])
+	if err != nil {
+		return SetDeviceParameterStringOutput{}, fmt.Errorf("parse parameter_index: %w", err)
+	}
+	status := fmt.Sprint(res[3])
+	out := SetDeviceParameterStringOutput{
+		TrackIndex:     trackIndex,
+		DeviceIndex:    deviceIndex,
+		ParameterIndex: parameterIndex,
+		Status:         status,
+	}
+	switch status {
+	case "set":
+		if len(res) >= 6 {
+			if v, err := abletonosc.AsFloat64(res[4]); err == nil {
+				out.Value = v
+			}
+			out.DisplayValue = fmt.Sprint(res[5])
+		}
+		return out, nil
+	case "no_match":
+		target := ""
+		if len(res) > 4 {
+			target = fmt.Sprint(res[4])
+		}
+		if len(res) > 5 {
+			out.Options = toStringSlice(res[5:])
+		}
+		if len(out.Options) > 0 {
+			return out, fmt.Errorf("no value matched %q; options: %s", target, strings.Join(out.Options, ", "))
+		}
+		return out, fmt.Errorf("no value matched %q for parameter index %d", target, parameterIndex)
+	default:
+		return out, fmt.Errorf("set parameter string failed: status=%s reply=%v", status, res)
+	}
+}
+
+func NewAbletonSetDeviceParameterString(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_device_parameter_string",
+		"Ableton Live: set a device parameter from a human-readable string such as an enum name (Ins) or a numeric value with unit (180 Hz, -3.5 dB, 50 %); requires the browser patch",
+		func(_ *ai.ToolContext, input SetDeviceParameterStringInput) (SetDeviceParameterStringOutput, error) {
+			if input.TrackIndex < 0 {
+				return SetDeviceParameterStringOutput{}, errors.New("track_index must be >= 0")
+			}
+			if input.DeviceIndex < 0 {
+				return SetDeviceParameterStringOutput{}, errors.New("device_index must be >= 0")
+			}
+			if input.ParameterIndex < 0 {
+				return SetDeviceParameterStringOutput{}, errors.New("parameter_index must be >= 0")
+			}
+			value := strings.TrimSpace(input.Value)
+			if value == "" {
+				return SetDeviceParameterStringOutput{}, errors.New("value is required")
+			}
+			res, err := client.QueryWithTimeout(
+				3*time.Second,
+				"/live/device/set/parameter/string",
+				int32(input.TrackIndex),
+				int32(input.DeviceIndex),
+				int32(input.ParameterIndex),
+				value,
+			)
+			if err != nil {
+				return SetDeviceParameterStringOutput{}, fmt.Errorf("set parameter string failed (browser patch required): %w", err)
+			}
+			return parseSetDeviceParameterStringResponse(res)
+		},
+	)
+}
+
+type DeleteDeviceInput struct {
+	TrackIndex  int  `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex int  `json:"device_index" jsonschema:"description=Device index on the track (from get_track_devices),minimum=0"`
+	Confirm     bool `json:"confirm,omitempty" jsonschema:"description=Must be true to execute; omit/false returns a preview error without deleting. Prefer ableton_preview_destructive first."`
+}
+
+type DeleteDeviceOutput struct {
+	TrackIndex    int    `json:"track_index"`
+	DeviceIndex   int    `json:"device_index"`
+	Status        string `json:"status" jsonschema:"description=deleted, or invalid_track_index / invalid_device_index / error on failure"`
+	DeviceName    string `json:"device_name,omitempty" jsonschema:"description=Name of the deleted device"`
+	DevicesBefore *int   `json:"devices_before,omitempty" jsonschema:"description=Device count before deletion"`
+	DevicesAfter  *int   `json:"devices_after,omitempty" jsonschema:"description=Device count after deletion; confirms success"`
+}
+
+func parseDeleteDeviceResponse(res []interface{}) (DeleteDeviceOutput, error) {
+	if err := ensureResponseLen(res, 3); err != nil {
+		return DeleteDeviceOutput{}, err
+	}
+	trackIndex, err := abletonosc.AsInt(res[0])
+	if err != nil {
+		return DeleteDeviceOutput{}, fmt.Errorf("parse track_index: %w", err)
+	}
+	deviceIndex, err := abletonosc.AsInt(res[1])
+	if err != nil {
+		return DeleteDeviceOutput{}, fmt.Errorf("parse device_index: %w", err)
+	}
+	status := fmt.Sprint(res[2])
+	out := DeleteDeviceOutput{
+		TrackIndex:  trackIndex,
+		DeviceIndex: deviceIndex,
+		Status:      status,
+	}
+	if status != "deleted" {
+		detail := ""
+		if len(res) > 3 {
+			detail = fmt.Sprint(res[3])
+		}
+		if detail != "" {
+			return out, fmt.Errorf("delete device failed: status=%s detail=%s", status, detail)
+		}
+		return out, fmt.Errorf("delete device failed: status=%s", status)
+	}
+	if len(res) >= 6 {
+		out.DeviceName = fmt.Sprint(res[3])
+		if b, err := abletonosc.AsInt(res[4]); err == nil {
+			out.DevicesBefore = &b
+		}
+		if a, err := abletonosc.AsInt(res[5]); err == nil {
+			out.DevicesAfter = &a
+		}
+	}
+	return out, nil
+}
+
+func NewAbletonDeleteDevice(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_delete_device",
+		"Ableton Live: delete a device from a track by index. Requires confirm=true. Returns device_name and devices_before/after so success is confirmed instead of fire-and-forget; requires the browser patch. To replace a device, delete then load the new one",
+		func(_ *ai.ToolContext, input DeleteDeviceInput) (DeleteDeviceOutput, error) {
+			if input.TrackIndex < 0 {
+				return DeleteDeviceOutput{}, errors.New("track_index must be >= 0")
+			}
+			if input.DeviceIndex < 0 {
+				return DeleteDeviceOutput{}, errors.New("device_index must be >= 0")
+			}
+			if err := requireConfirm(input.Confirm, "delete_device",
+				fmt.Sprintf("device %d on track %d", input.DeviceIndex, input.TrackIndex)); err != nil {
+				return DeleteDeviceOutput{}, err
+			}
+			res, err := client.QueryWithTimeout(
+				5*time.Second,
+				"/live/device/delete",
+				int32(input.TrackIndex),
+				int32(input.DeviceIndex),
+			)
+			if err != nil {
+				return DeleteDeviceOutput{}, wrapActionable(err, "delete_device_failed",
+					"Install/update the browser patch and restart Live, or delete the device manually in Live.")
+			}
+			out, perr := parseDeleteDeviceResponse(res)
+			if perr != nil {
+				return out, wrapActionable(perr, "delete_device_failed",
+					"Call ableton_get_track_devices to verify indices, then retry with confirm=true.")
+			}
+			return out, nil
 		},
 	)
 }

--- a/internal/tools/ableton_devices_test.go
+++ b/internal/tools/ableton_devices_test.go
@@ -1,0 +1,164 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildDeviceParametersMergesDisplayAndQuantized(t *testing.T) {
+	names := []string{"1 Frequency A", "1 Filter Type A"}
+	values := []interface{}{float32(0.17), int32(1)}
+	mins := []interface{}{float32(0), float32(0)}
+	maxs := []interface{}{float32(1), int32(7)}
+	displays := []interface{}{"37.0 Hz", "Low Shelf"}
+	quantized := []interface{}{false, true}
+
+	params, err := buildDeviceParameters(names, values, mins, maxs, displays, quantized)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params) != 2 {
+		t.Fatalf("expected 2 params, got %d", len(params))
+	}
+
+	if params[0].Name != "1 Frequency A" || params[0].DisplayValue != "37.0 Hz" {
+		t.Errorf("param0 = %+v, want name/display '1 Frequency A' / '37.0 Hz'", params[0])
+	}
+	if params[0].IsQuantized == nil || *params[0].IsQuantized {
+		t.Errorf("param0 IsQuantized = %v, want non-nil false", params[0].IsQuantized)
+	}
+	if params[1].DisplayValue != "Low Shelf" {
+		t.Errorf("param1 display = %q, want 'Low Shelf'", params[1].DisplayValue)
+	}
+	if params[1].IsQuantized == nil || !*params[1].IsQuantized {
+		t.Errorf("param1 IsQuantized = %v, want non-nil true", params[1].IsQuantized)
+	}
+}
+
+func TestBuildDeviceParametersBestEffortOptionalFields(t *testing.T) {
+	names := []string{"Volume", "Filter Freq"}
+	values := []interface{}{float32(0.85), float32(0.5)}
+	mins := []interface{}{float32(0), float32(0)}
+	maxs := []interface{}{float32(1), float32(1)}
+
+	// Patch missing: no display strings and no quantized flags at all.
+	params, err := buildDeviceParameters(names, values, mins, maxs, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, p := range params {
+		if p.DisplayValue != "" {
+			t.Errorf("param%d display = %q, want empty when patch missing", i, p.DisplayValue)
+		}
+		if p.IsQuantized != nil {
+			t.Errorf("param%d IsQuantized = %v, want nil when unavailable", i, p.IsQuantized)
+		}
+	}
+
+	// Shorter displays slice: only the first parameter gets a display value.
+	params, err = buildDeviceParameters(names, values, mins, maxs, []interface{}{"-6.0 dB"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params[0].DisplayValue != "-6.0 dB" {
+		t.Errorf("param0 display = %q, want '-6.0 dB'", params[0].DisplayValue)
+	}
+	if params[1].DisplayValue != "" {
+		t.Errorf("param1 display = %q, want empty (displays too short)", params[1].DisplayValue)
+	}
+}
+
+func TestBuildDeviceParametersLengthMismatch(t *testing.T) {
+	names := []string{"A", "B"}
+	values := []interface{}{float32(1)}
+	mins := []interface{}{float32(0), float32(0)}
+	maxs := []interface{}{float32(1), float32(1)}
+
+	if _, err := buildDeviceParameters(names, values, mins, maxs, nil, nil); err == nil {
+		t.Fatal("expected error on length mismatch, got nil")
+	}
+}
+
+func TestParseSetDeviceParameterStringResponseSet(t *testing.T) {
+	res := []interface{}{int32(3), int32(1), int32(12), "set", float32(1), "Ins"}
+	out, err := parseSetDeviceParameterStringResponse(res)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Status != "set" {
+		t.Errorf("status = %q, want set", out.Status)
+	}
+	if out.Value != 1 {
+		t.Errorf("value = %v, want 1", out.Value)
+	}
+	if out.DisplayValue != "Ins" {
+		t.Errorf("display = %q, want Ins", out.DisplayValue)
+	}
+}
+
+func TestParseSetDeviceParameterStringResponseNoMatchWithOptions(t *testing.T) {
+	res := []interface{}{int32(3), int32(1), int32(12), "no_match", "Xyz", "Mix", "Ins", "Gate"}
+	out, err := parseSetDeviceParameterStringResponse(res)
+	if err == nil {
+		t.Fatal("expected error for no_match, got nil")
+	}
+	if len(out.Options) != 3 || out.Options[1] != "Ins" {
+		t.Errorf("options = %v, want [Mix Ins Gate]", out.Options)
+	}
+}
+
+func TestParseSetDeviceParameterStringResponseInvalid(t *testing.T) {
+	res := []interface{}{int32(3), int32(1), int32(99), "invalid_parameter_index"}
+	out, err := parseSetDeviceParameterStringResponse(res)
+	if err == nil {
+		t.Fatal("expected error for invalid status, got nil")
+	}
+	if out.Status != "invalid_parameter_index" {
+		t.Errorf("status = %q, want invalid_parameter_index", out.Status)
+	}
+}
+
+func TestParseDeleteDeviceResponseDeleted(t *testing.T) {
+	res := []interface{}{int32(2), int32(1), "deleted", "EQ Eight", int32(3), int32(2)}
+	out, err := parseDeleteDeviceResponse(res)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Status != "deleted" {
+		t.Errorf("status = %q, want deleted", out.Status)
+	}
+	if out.DeviceName != "EQ Eight" {
+		t.Errorf("device_name = %q, want 'EQ Eight'", out.DeviceName)
+	}
+	if out.DevicesBefore == nil || *out.DevicesBefore != 3 {
+		t.Errorf("devices_before = %v, want 3", out.DevicesBefore)
+	}
+	if out.DevicesAfter == nil || *out.DevicesAfter != 2 {
+		t.Errorf("devices_after = %v, want 2", out.DevicesAfter)
+	}
+}
+
+func TestParseDeleteDeviceResponseInvalid(t *testing.T) {
+	res := []interface{}{int32(2), int32(9), "invalid_device_index"}
+	out, err := parseDeleteDeviceResponse(res)
+	if err == nil {
+		t.Fatal("expected error for invalid_device_index, got nil")
+	}
+	if out.Status != "invalid_device_index" {
+		t.Errorf("status = %q, want invalid_device_index", out.Status)
+	}
+	if out.DevicesAfter != nil {
+		t.Errorf("devices_after = %v, want nil on failure", out.DevicesAfter)
+	}
+}
+
+func TestParseDeleteDeviceResponseError(t *testing.T) {
+	res := []interface{}{int32(2), int32(0), "error", "boom"}
+	_, err := parseDeleteDeviceResponse(res)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error = %v, want to contain detail 'boom'", err)
+	}
+}

--- a/internal/tools/ableton_diagnose.go
+++ b/internal/tools/ableton_diagnose.go
@@ -31,11 +31,26 @@ type DiagnoseCheck struct {
 	Detail string `json:"detail"`
 }
 
+type LiveVersionInfo struct {
+	Major int    `json:"major"`
+	Minor int    `json:"minor"`
+	Label string `json:"label" jsonschema:"description=e.g. 11.0 (bugfix not reported by Live's API)"`
+}
+
+type CapabilityInfo struct {
+	Name     string `json:"name"`
+	OK       bool   `json:"ok"`
+	Detail   string `json:"detail"`
+	NextStep string `json:"next_step,omitempty" jsonschema:"description=What to do when ok=false"`
+}
+
 type DiagnoseOutput struct {
 	Ready           bool                 `json:"ready" jsonschema:"description=true when AbletonOSC, browser patch, and master patch all respond"`
 	Connected       bool                 `json:"connected" jsonschema:"description=true when stock AbletonOSC /live/test responds"`
 	BrowserPatch    bool                 `json:"browser_patch"`
 	MasterPatch     bool                 `json:"master_patch"`
+	LiveVersion     *LiveVersionInfo     `json:"live_version,omitempty"`
+	Capabilities    []CapabilityInfo     `json:"capabilities" jsonschema:"description=Feature availability so agents can avoid unsupported paths before they fail"`
 	Config          DiagnoseConfigOutput `json:"config"`
 	Checks          []DiagnoseCheck      `json:"checks"`
 	Recommendations []string             `json:"recommendations"`
@@ -47,7 +62,7 @@ type diagnoseQuerier interface {
 
 func NewAbletonDiagnose(g *genkit.Genkit, client *abletonosc.Client, settings DiagnoseSettings) ai.Tool {
 	return genkit.DefineTool(g, "ableton_diagnose",
-		"Ableton Live: diagnose AbletonOSC connection and browser/master patch availability",
+		"Ableton Live: diagnose AbletonOSC connection, browser/master patches, Live version, and feature capabilities (e.g. create_audio_clip needs Live 12.0.5+)",
 		func(_ *ai.ToolContext, _ EmptyInput) (DiagnoseOutput, error) {
 			return diagnoseAbleton(client, settings), nil
 		},
@@ -67,7 +82,8 @@ func diagnoseAbleton(client diagnoseQuerier, settings DiagnoseSettings) Diagnose
 			ClientPort: settings.ClientPort,
 			TimeoutMs:  int(timeout / time.Millisecond),
 		},
-		Checks:          make([]DiagnoseCheck, 0, 3),
+		Checks:          make([]DiagnoseCheck, 0, 4),
+		Capabilities:    []CapabilityInfo{},
 		Recommendations: []string{},
 	}
 
@@ -83,6 +99,16 @@ func diagnoseAbleton(client diagnoseQuerier, settings DiagnoseSettings) Diagnose
 	out.Checks = append(out.Checks, masterCheck)
 	out.MasterPatch = masterCheck.OK
 
+	if out.Connected {
+		if ver, check := probeLiveVersion(client); ver != nil {
+			out.LiveVersion = ver
+			out.Checks = append(out.Checks, check)
+		} else {
+			out.Checks = append(out.Checks, check)
+		}
+	}
+
+	out.Capabilities = probeCapabilities(client, out)
 	out.Ready = out.Connected && out.BrowserPatch && out.MasterPatch
 	out.Recommendations = buildDiagnoseRecommendations(out)
 	return out
@@ -165,6 +191,115 @@ func probeMasterPatch(client diagnoseQuerier) DiagnoseCheck {
 	}
 }
 
+func probeLiveVersion(client diagnoseQuerier) (*LiveVersionInfo, DiagnoseCheck) {
+	res, err := client.Query("/live/application/get/version")
+	if err != nil {
+		return nil, DiagnoseCheck{
+			Name:   "live_version",
+			OK:     false,
+			Detail: formatProbeError(err),
+		}
+	}
+	if err := ensureResponseLen(res, 2); err != nil {
+		return nil, DiagnoseCheck{Name: "live_version", OK: false, Detail: err.Error()}
+	}
+	major, err := abletonosc.AsInt(res[0])
+	if err != nil {
+		return nil, DiagnoseCheck{Name: "live_version", OK: false, Detail: err.Error()}
+	}
+	minor, err := abletonosc.AsInt(res[1])
+	if err != nil {
+		return nil, DiagnoseCheck{Name: "live_version", OK: false, Detail: err.Error()}
+	}
+	ver := &LiveVersionInfo{
+		Major: major,
+		Minor: minor,
+		Label: fmt.Sprintf("%d.%d", major, minor),
+	}
+	return ver, DiagnoseCheck{Name: "live_version", OK: true, Detail: ver.Label}
+}
+
+// handlerPresent treats a quick reply (including missing_args / error) as proof
+// the OSC handler is registered. Timeout/no-response means missing.
+func handlerPresent(client diagnoseQuerier, address string) bool {
+	_, err := client.Query(address)
+	if err == nil {
+		return true
+	}
+	msg := err.Error()
+	return !strings.Contains(msg, "no response received to query")
+}
+
+func probeCapabilities(client diagnoseQuerier, diag DiagnoseOutput) []CapabilityInfo {
+	caps := make([]CapabilityInfo, 0, 8)
+
+	// create_audio_clip: handler in browser patch; Live API only on 12.0.5+.
+	// Live only reports major.minor, so we treat major>=12 as "likely".
+	createHandler := diag.BrowserPatch && handlerPresent(client, "/live/clip_slot/create_audio_clip")
+	createAPI := diag.LiveVersion != nil && diag.LiveVersion.Major >= 12
+	switch {
+	case createHandler && createAPI:
+		caps = append(caps, CapabilityInfo{
+			Name:   "create_audio_clip",
+			OK:     true,
+			Detail: "handler present; Live " + diag.LiveVersion.Label + " (needs 12.0.5+ bugfix)",
+		})
+	case createHandler && !createAPI:
+		label := "unknown"
+		if diag.LiveVersion != nil {
+			label = diag.LiveVersion.Label
+		}
+		caps = append(caps, CapabilityInfo{
+			Name:     "create_audio_clip",
+			OK:       false,
+			Detail:   "handler present but Live " + label + " lacks ClipSlot.create_audio_clip",
+			NextStep: "Use ableton_load_browser_path onto an audio track, or upgrade to Live 12.0.5+.",
+		})
+	default:
+		caps = append(caps, CapabilityInfo{
+			Name:     "create_audio_clip",
+			OK:       false,
+			Detail:   "browser patch handler missing or AbletonOSC not connected",
+			NextStep: "Install remote-script/ browser patch and restart Live.",
+		})
+	}
+
+	type patchCap struct {
+		name, address, next string
+	}
+	for _, p := range []patchCap{
+		{"parameter_value_string", "/live/device/get/parameters/value_string", "Install/update the browser patch (value_string handler), then restart Live."},
+		{"parameter_set_string", "/live/device/set/parameter/string", "Install/update the browser patch (set/parameter/string), then restart Live."},
+		{"delete_device_confirmed", "/live/device/delete", "Install/update the browser patch (device/delete), then restart Live."},
+		{"simpler_control", "/live/device/simpler/get", "Install/update the browser patch (simpler handlers), then restart Live."},
+		{"slice_preset_restore", "/live/device/simpler/set/slices", "Install/update the browser patch (simpler/set/slices), then restart Live."},
+		{"return_tracks_list", "/live/song/get/return_tracks", "Install/update the browser patch (return_tracks handler), then restart or hot-reload AbletonOSC."},
+		{"device_sidechain", "/live/device/get/available_input_routing_types", "Install/update the browser patch (device sidechain handlers), then restart or hot-reload AbletonOSC."},
+		{"clip_envelope", "/live/clip/envelope/get", "Install/update the browser patch (clip envelope handlers), then restart or hot-reload AbletonOSC."},
+		{"device_is_active", "/live/device/get/is_active", "Install/update the browser patch (device is_active handlers), then restart or hot-reload AbletonOSC."},
+	} {
+		ok := diag.BrowserPatch && handlerPresent(client, p.address)
+		info := CapabilityInfo{Name: p.name, OK: ok}
+		if ok {
+			info.Detail = "handler present"
+		} else {
+			info.Detail = "handler missing or patch not loaded"
+			info.NextStep = p.next
+		}
+		caps = append(caps, info)
+	}
+
+	// Explicitly document Live API impossibility (removed after validation).
+	caps = append(caps, CapabilityInfo{
+		Name:     "drum_pad_sample_load",
+		OK:       false,
+		Detail:   "not available: Live 11 LOM cannot load a raw sample onto a specific Drum Rack pad without replacing the rack",
+		NextStep: "Load a kit with filled pads in Live, or drag samples onto pads manually.",
+	})
+
+	return caps
+}
+
 func formatProbeError(err error) string {
 	msg := err.Error()
 	if strings.Contains(msg, "no response received to query") {
@@ -174,7 +309,7 @@ func formatProbeError(err error) string {
 }
 
 func buildDiagnoseRecommendations(out DiagnoseOutput) []string {
-	recs := make([]string, 0, 4)
+	recs := make([]string, 0, 6)
 
 	if !out.Connected {
 		recs = append(recs,
@@ -192,13 +327,24 @@ func buildDiagnoseRecommendations(out DiagnoseOutput) []string {
 			"Install the master patch from remote-script/ (copy master.py and apply manager patch), then fully restart Ableton Live.",
 		)
 	}
+	if out.LiveVersion != nil && out.LiveVersion.Major < 12 {
+		recs = append(recs,
+			fmt.Sprintf("Live %s: create_audio_clip and Splice path-load into Session slots are unavailable — prefer browser load or upgrade to Live 12.0.5+.", out.LiveVersion.Label),
+		)
+	}
+	for _, c := range out.Capabilities {
+		if !c.OK && c.Name == "create_audio_clip" && c.NextStep != "" && out.LiveVersion != nil && out.LiveVersion.Major < 12 {
+			// already covered above
+			break
+		}
+	}
 	if (!out.Connected || !out.BrowserPatch || !out.MasterPatch) && out.Config.TimeoutMs <= 500 {
 		recs = append(recs,
 			"If the set is heavy, try raising ABLETON_OSC_TIMEOUT_MS (for example 2000).",
 		)
 	}
 	if out.Ready {
-		recs = append(recs, "AbletonOSC and both patches look ready.")
+		recs = append(recs, "AbletonOSC and both patches look ready. Check capabilities[] before using Live-version-gated features.")
 	}
 	return recs
 }

--- a/internal/tools/ableton_diagnose_test.go
+++ b/internal/tools/ableton_diagnose_test.go
@@ -17,15 +17,15 @@ type diagnoseQuerierStub struct {
 func (s diagnoseQuerierStub) Query(address string, _ ...interface{}) ([]interface{}, error) {
 	result, ok := s.results[address]
 	if !ok {
-		return nil, errors.New("unexpected query: " + address)
+		// Unknown address → simulate missing handler (no response).
+		return nil, errors.New("no response received to query: " + address)
 	}
 	return result.values, result.err
 }
 
-func TestDiagnoseAbletonReady(t *testing.T) {
-	t.Parallel()
-
-	client := diagnoseQuerierStub{results: map[string]struct {
+func readyDiagnoseStub() diagnoseQuerierStub {
+	missingArgs := []interface{}{"error", "missing_args"}
+	return diagnoseQuerierStub{results: map[string]struct {
 		values []interface{}
 		err    error
 	}{
@@ -35,10 +35,24 @@ func TestDiagnoseAbletonReady(t *testing.T) {
 			"Drums|loadable=False|folder=True",
 			"Instruments|loadable=False|folder=True",
 		}},
-		"/live/master/get/volume": {values: []interface{}{float32(0.85)}},
+		"/live/master/get/volume":                        {values: []interface{}{float32(0.85)}},
+		"/live/application/get/version":                  {values: []interface{}{int32(11), int32(0)}},
+		"/live/clip_slot/create_audio_clip":              {values: missingArgs},
+		"/live/device/get/parameters/value_string":       {values: missingArgs},
+		"/live/device/set/parameter/string":              {values: missingArgs},
+		"/live/device/delete":                            {values: missingArgs},
+		"/live/device/simpler/get":                       {values: missingArgs},
+		"/live/device/simpler/set/slices":                {values: missingArgs},
+		"/live/song/get/return_tracks":                   {values: []interface{}{int32(0)}},
+		"/live/device/get/available_input_routing_types": {values: missingArgs},
+		"/live/clip/envelope/get":                        {values: missingArgs},
 	}}
+}
 
-	got := diagnoseAbleton(client, DiagnoseSettings{
+func TestDiagnoseAbletonReady(t *testing.T) {
+	t.Parallel()
+
+	got := diagnoseAbleton(readyDiagnoseStub(), DiagnoseSettings{
 		Host:       "127.0.0.1",
 		Port:       11000,
 		ClientPort: 11001,
@@ -49,14 +63,36 @@ func TestDiagnoseAbletonReady(t *testing.T) {
 		t.Fatalf("diagnoseAbleton() flags = ready=%v connected=%v browser=%v master=%v",
 			got.Ready, got.Connected, got.BrowserPatch, got.MasterPatch)
 	}
+	if got.LiveVersion == nil || got.LiveVersion.Label != "11.0" {
+		t.Fatalf("LiveVersion = %+v, want 11.0", got.LiveVersion)
+	}
 	if got.Config.TimeoutMs != 500 {
 		t.Errorf("TimeoutMs = %d, want 500", got.Config.TimeoutMs)
 	}
-	if len(got.Checks) != 3 {
-		t.Fatalf("Checks len = %d, want 3", len(got.Checks))
+	if len(got.Checks) < 4 {
+		t.Fatalf("Checks len = %d, want >= 4", len(got.Checks))
 	}
-	if len(got.Recommendations) == 0 || !strings.Contains(got.Recommendations[0], "ready") {
-		t.Errorf("Recommendations = %v, want ready message", got.Recommendations)
+
+	caps := map[string]CapabilityInfo{}
+	for _, c := range got.Capabilities {
+		caps[c.Name] = c
+	}
+	if caps["create_audio_clip"].OK {
+		t.Error("create_audio_clip should be false on Live 11")
+	}
+	if caps["create_audio_clip"].NextStep == "" {
+		t.Error("create_audio_clip should include next_step")
+	}
+	if !caps["simpler_control"].OK {
+		t.Error("simpler_control should be present")
+	}
+	if caps["drum_pad_sample_load"].OK {
+		t.Error("drum_pad_sample_load must stay unavailable")
+	}
+
+	joined := strings.Join(got.Recommendations, "\n")
+	if !strings.Contains(joined, "create_audio_clip") && !strings.Contains(joined, "12.0.5") {
+		t.Errorf("recommendations should mention Live 11 limitation: %s", joined)
 	}
 }
 
@@ -74,6 +110,7 @@ func TestDiagnoseAbletonReportsMissingPieces(t *testing.T) {
 		"/live/master/get/volume": {
 			err: errors.New("no response received to query: /live/master/get/volume"),
 		},
+		"/live/application/get/version": {values: []interface{}{int32(11), int32(0)}},
 	}}
 
 	got := diagnoseAbleton(client, DiagnoseSettings{
@@ -125,17 +162,30 @@ func TestDiagnoseAbletonConnectionFailure(t *testing.T) {
 		Host:       "127.0.0.1",
 		Port:       11000,
 		ClientPort: 11001,
-		Timeout:    time.Second,
+		Timeout:    500 * time.Millisecond,
 	})
 
 	if got.Connected || got.Ready {
-		t.Fatalf("expected connection failure, got connected=%v ready=%v", got.Connected, got.Ready)
+		t.Fatalf("should be disconnected: connected=%v ready=%v", got.Connected, got.Ready)
 	}
 	joined := strings.Join(got.Recommendations, "\n")
-	if !strings.Contains(joined, "Enable AbletonOSC") {
-		t.Errorf("recommendations missing AbletonOSC guidance: %s", joined)
+	if !strings.Contains(joined, "Control Surface") {
+		t.Errorf("recommendations missing connection guidance: %s", joined)
 	}
-	if strings.Contains(joined, "ABLETON_OSC_TIMEOUT_MS") {
-		t.Errorf("timeout tip should be skipped when timeout > 500ms: %s", joined)
+}
+
+func TestDiagnoseCreateAudioClipOnLive12(t *testing.T) {
+	t.Parallel()
+	stub := readyDiagnoseStub()
+	stub.results["/live/application/get/version"] = struct {
+		values []interface{}
+		err    error
+	}{values: []interface{}{int32(12), int32(1)}}
+
+	got := diagnoseAbleton(stub, DiagnoseSettings{Timeout: 500 * time.Millisecond})
+	for _, c := range got.Capabilities {
+		if c.Name == "create_audio_clip" && !c.OK {
+			t.Fatalf("create_audio_clip should be ok on Live 12: %+v", c)
+		}
 	}
 }

--- a/internal/tools/ableton_envelope.go
+++ b/internal/tools/ableton_envelope.go
@@ -1,0 +1,330 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+// Mixer envelope parameter indices when device_index is -1.
+const (
+	MixerParamVolume  = 0
+	MixerParamPanning = 1
+	// MixerParamSendBase + N selects send N (return A = 2, B = 3, …).
+	MixerParamSendBase = 2
+)
+
+// EnvelopeStep is one automation step: hold `value` from `time` for `duration` beats.
+type EnvelopeStep struct {
+	Time     float64 `json:"time" jsonschema:"description=Start time in beats"`
+	Duration float64 `json:"duration" jsonschema:"description=Step length in beats (use a small value e.g. 0.01 for a point)"`
+	Value    float64 `json:"value" jsonschema:"description=Normalized parameter value (same scale as device/mixer params)"`
+}
+
+type EnvelopeSample struct {
+	Time  float64 `json:"time"`
+	Value float64 `json:"value"`
+}
+
+type ClipEnvelopeTarget struct {
+	TrackIndex     int `json:"track_index" jsonschema:"minimum=0"`
+	ClipIndex      int `json:"clip_index" jsonschema:"minimum=0"`
+	DeviceIndex    int `json:"device_index" jsonschema:"description=Device index, or -1 for mixer (volume/panning/sends)"`
+	ParameterIndex int `json:"parameter_index" jsonschema:"description=For mixer (-1): 0=volume, 1=panning, 2+N=send N. For devices: parameter index from get_device_parameters"`
+}
+
+type GetClipEnvelopeInput struct {
+	ClipEnvelopeTarget
+	StartBeats *float64 `json:"start_beats,omitempty" jsonschema:"description=Sample window start (default 0)"`
+	EndBeats   *float64 `json:"end_beats,omitempty" jsonschema:"description=Sample window end (default clip length)"`
+	StepBeats  *float64 `json:"step_beats,omitempty" jsonschema:"description=Sample step (default 0.25 beats)"`
+}
+
+type GetClipEnvelopeOutput struct {
+	TrackIndex     int              `json:"track_index"`
+	ClipIndex      int              `json:"clip_index"`
+	DeviceIndex    int              `json:"device_index"`
+	ParameterIndex int              `json:"parameter_index"`
+	ParamName      string           `json:"param_name,omitempty"`
+	Exists         bool             `json:"exists"`
+	Samples        []EnvelopeSample `json:"samples,omitempty" jsonschema:"description=Sampled envelope via value_at_time (Live 11 cannot list breakpoints)"`
+	Hint           string           `json:"hint,omitempty"`
+}
+
+func parseEnvelopeGet(res []interface{}, deviceIndex, parameterIndex int) (GetClipEnvelopeOutput, error) {
+	if err := ensureResponseLen(res, 3); err != nil {
+		return GetClipEnvelopeOutput{}, err
+	}
+	track, _ := abletonosc.AsInt(res[0])
+	clip, _ := abletonosc.AsInt(res[1])
+	status := fmt.Sprint(res[2])
+	out := GetClipEnvelopeOutput{
+		TrackIndex:     track,
+		ClipIndex:      clip,
+		DeviceIndex:    deviceIndex,
+		ParameterIndex: parameterIndex,
+		Samples:        []EnvelopeSample{},
+	}
+	switch status {
+	case "ok":
+		if len(res) < 4 {
+			return out, errors.New("envelope get missing param name")
+		}
+		out.Exists = true
+		out.ParamName = fmt.Sprint(res[3])
+		rest := res[4:]
+		if len(rest)%2 != 0 {
+			return out, fmt.Errorf("odd sample payload length: %d", len(rest))
+		}
+		for i := 0; i < len(rest); i += 2 {
+			t, err := abletonosc.AsFloat64(rest[i])
+			if err != nil {
+				return out, err
+			}
+			v, err := abletonosc.AsFloat64(rest[i+1])
+			if err != nil {
+				return out, err
+			}
+			out.Samples = append(out.Samples, EnvelopeSample{Time: t, Value: v})
+		}
+		out.Hint = "Live 11 samples value_at_time; breakpoint lists require Live 12+."
+		return out, nil
+	case "missing":
+		if len(res) >= 4 {
+			out.ParamName = fmt.Sprint(res[3])
+		}
+		out.Exists = false
+		out.Hint = "No envelope yet. Call ableton_set_clip_envelope_steps to create one."
+		return out, nil
+	case "no_clip":
+		return out, actionable("no_clip", "clip slot is empty",
+			"Create or select a Session clip first, then retry.")
+	case "invalid_track_index", "invalid_clip_index", "invalid_device_index",
+		"invalid_parameter_index", "invalid_send_index":
+		return out, actionable(status, status,
+			"Check track/clip/device/parameter indices (mixer uses device_index=-1).")
+	default:
+		detail := ""
+		if len(res) > 3 {
+			detail = fmt.Sprint(res[3])
+		}
+		return out, fmt.Errorf("envelope get failed: status=%s %s", status, detail)
+	}
+}
+
+func NewAbletonGetClipEnvelope(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_clip_envelope",
+		"Ableton Live: sample a Session clip automation envelope (volume/panning/send or device param). Live 11 cannot list breakpoints — returns a time/value grid via value_at_time. device_index=-1 selects mixer (0=volume, 1=panning, 2+N=send N). Requires the browser patch.",
+		func(_ *ai.ToolContext, input GetClipEnvelopeInput) (GetClipEnvelopeOutput, error) {
+			if err := validateEnvelopeTarget(input.ClipEnvelopeTarget); err != nil {
+				return GetClipEnvelopeOutput{}, err
+			}
+			args := []interface{}{
+				int32(input.TrackIndex), int32(input.ClipIndex),
+				int32(input.DeviceIndex), int32(input.ParameterIndex),
+			}
+			// Optional window: only sent when start or end is provided (step alone uses defaults).
+			if input.StartBeats != nil || input.EndBeats != nil {
+				start := 0.0
+				if input.StartBeats != nil {
+					start = *input.StartBeats
+				}
+				end := start + 4.0
+				if input.EndBeats != nil {
+					end = *input.EndBeats
+				}
+				step := 0.25
+				if input.StepBeats != nil && *input.StepBeats > 0 {
+					step = *input.StepBeats
+				}
+				args = append(args, float32(start), float32(end), float32(step))
+			}
+			res, err := client.QueryWithTimeout(3*time.Second, "/live/clip/envelope/get", args...)
+			if err != nil {
+				return GetClipEnvelopeOutput{}, wrapActionable(err, "envelope_unavailable",
+					"Install/update the browser patch and restart or hot-reload AbletonOSC, then retry.")
+			}
+			return parseEnvelopeGet(res, input.DeviceIndex, input.ParameterIndex)
+		},
+	)
+}
+
+type SetClipEnvelopeStepsInput struct {
+	ClipEnvelopeTarget
+	Steps []EnvelopeStep `json:"steps" jsonschema:"description=Automation steps to insert (time/duration/value)"`
+	Clear bool           `json:"clear,omitempty" jsonschema:"description=If true, clear the existing envelope before inserting"`
+}
+
+type SetClipEnvelopeStepsOutput struct {
+	TrackIndex     int    `json:"track_index"`
+	ClipIndex      int    `json:"clip_index"`
+	DeviceIndex    int    `json:"device_index"`
+	ParameterIndex int    `json:"parameter_index"`
+	ParamName      string `json:"param_name,omitempty"`
+	StepsSet       int    `json:"steps_set"`
+}
+
+func parseEnvelopeSetSteps(res []interface{}) (SetClipEnvelopeStepsOutput, error) {
+	if err := ensureResponseLen(res, 3); err != nil {
+		return SetClipEnvelopeStepsOutput{}, err
+	}
+	track, _ := abletonosc.AsInt(res[0])
+	clip, _ := abletonosc.AsInt(res[1])
+	status := fmt.Sprint(res[2])
+	out := SetClipEnvelopeStepsOutput{TrackIndex: track, ClipIndex: clip}
+	switch status {
+	case "ok":
+		if len(res) >= 5 {
+			n, _ := abletonosc.AsInt(res[3])
+			out.StepsSet = n
+			out.ParamName = fmt.Sprint(res[4])
+		}
+		return out, nil
+	case "no_clip":
+		return out, actionable("no_clip", "clip slot is empty",
+			"Create a Session clip first, then retry.")
+	case "error":
+		where, detail := "", ""
+		if len(res) > 3 {
+			where = fmt.Sprint(res[3])
+		}
+		if len(res) > 4 {
+			detail = fmt.Sprint(res[4])
+		}
+		msg := strings.TrimSpace(where + " " + detail)
+		return out, actionable("envelope_write_failed", msg,
+			"Use a Session clip (not Arrangement), ensure the parameter is on the same track, then retry.")
+	default:
+		return out, actionable(status, status,
+			"Check track/clip/device/parameter indices (mixer uses device_index=-1).")
+	}
+}
+
+func NewAbletonSetClipEnvelopeSteps(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_clip_envelope_steps",
+		"Ableton Live: write Session clip automation steps (volume, panning, send, or device param). Creates the envelope if needed. Optional clear=true replaces existing points. device_index=-1 is mixer (0=volume, 1=panning, 2+N=send N). Requires the browser patch. Arrangement clips are not supported.",
+		func(_ *ai.ToolContext, input SetClipEnvelopeStepsInput) (SetClipEnvelopeStepsOutput, error) {
+			if err := validateEnvelopeTarget(input.ClipEnvelopeTarget); err != nil {
+				return SetClipEnvelopeStepsOutput{}, err
+			}
+			if len(input.Steps) == 0 {
+				return SetClipEnvelopeStepsOutput{}, errors.New("steps must not be empty")
+			}
+			clearFlag := int32(0)
+			if input.Clear {
+				clearFlag = 1
+			}
+			args := []interface{}{
+				int32(input.TrackIndex), int32(input.ClipIndex),
+				int32(input.DeviceIndex), int32(input.ParameterIndex),
+				clearFlag,
+			}
+			for _, s := range input.Steps {
+				if s.Duration < 0 {
+					return SetClipEnvelopeStepsOutput{}, errors.New("step duration must be >= 0")
+				}
+				args = append(args, float32(s.Time), float32(s.Duration), float32(s.Value))
+			}
+			res, err := client.QueryWithTimeout(5*time.Second, "/live/clip/envelope/set_steps", args...)
+			if err != nil {
+				return SetClipEnvelopeStepsOutput{}, wrapActionable(err, "envelope_unavailable",
+					"Install/update the browser patch and restart or hot-reload AbletonOSC, then retry.")
+			}
+			out, err := parseEnvelopeSetSteps(res)
+			out.DeviceIndex = input.DeviceIndex
+			out.ParameterIndex = input.ParameterIndex
+			return out, err
+		},
+	)
+}
+
+type ClearClipEnvelopeInput struct {
+	ClipEnvelopeTarget
+	All     bool `json:"all,omitempty" jsonschema:"description=If true, clear every envelope on the clip (ignores device/parameter)"`
+	Confirm bool `json:"confirm,omitempty" jsonschema:"description=Must be true to execute"`
+}
+
+type ClearClipEnvelopeOutput struct {
+	TrackIndex int    `json:"track_index"`
+	ClipIndex  int    `json:"clip_index"`
+	Status     string `json:"status"`
+	ParamName  string `json:"param_name,omitempty"`
+}
+
+func NewAbletonClearClipEnvelope(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_clear_clip_envelope",
+		"Ableton Live: clear one Session clip envelope (or all with all=true). Requires confirm=true. Requires the browser patch.",
+		func(_ *ai.ToolContext, input ClearClipEnvelopeInput) (ClearClipEnvelopeOutput, error) {
+			if input.TrackIndex < 0 || input.ClipIndex < 0 {
+				return ClearClipEnvelopeOutput{}, errors.New("track_index and clip_index must be >= 0")
+			}
+			summary := fmt.Sprintf("clear envelopes on clip [%d,%d]", input.TrackIndex, input.ClipIndex)
+			if !input.All {
+				summary = fmt.Sprintf("clear envelope device=%d param=%d on clip [%d,%d]",
+					input.DeviceIndex, input.ParameterIndex, input.TrackIndex, input.ClipIndex)
+			}
+			if err := requireConfirm(input.Confirm, "clear_clip_envelope", summary); err != nil {
+				return ClearClipEnvelopeOutput{}, err
+			}
+			out := ClearClipEnvelopeOutput{TrackIndex: input.TrackIndex, ClipIndex: input.ClipIndex}
+			if input.All {
+				res, err := client.Query("/live/clip/envelope/clear_all",
+					int32(input.TrackIndex), int32(input.ClipIndex))
+				if err != nil {
+					return out, wrapActionable(err, "envelope_unavailable",
+						"Install/update the browser patch and restart or hot-reload AbletonOSC, then retry.")
+				}
+				if err := ensureResponseLen(res, 3); err != nil {
+					return out, err
+				}
+				out.Status = fmt.Sprint(res[2])
+				if out.Status == "error" {
+					return out, actionable("envelope_clear_failed", fmt.Sprint(res),
+						"Retry on a Session clip, or clear the envelope manually in Live.")
+				}
+				return out, nil
+			}
+			if err := validateEnvelopeTarget(input.ClipEnvelopeTarget); err != nil {
+				return out, err
+			}
+			res, err := client.Query("/live/clip/envelope/clear",
+				int32(input.TrackIndex), int32(input.ClipIndex),
+				int32(input.DeviceIndex), int32(input.ParameterIndex))
+			if err != nil {
+				return out, wrapActionable(err, "envelope_unavailable",
+					"Install/update the browser patch and restart or hot-reload AbletonOSC, then retry.")
+			}
+			if err := ensureResponseLen(res, 3); err != nil {
+				return out, err
+			}
+			out.Status = fmt.Sprint(res[2])
+			if len(res) >= 4 {
+				out.ParamName = fmt.Sprint(res[3])
+			}
+			if out.Status == "error" {
+				return out, actionable("envelope_clear_failed", out.ParamName,
+					"Retry on a Session clip, or clear the envelope manually in Live.")
+			}
+			return out, nil
+		},
+	)
+}
+
+func validateEnvelopeTarget(t ClipEnvelopeTarget) error {
+	if t.TrackIndex < 0 || t.ClipIndex < 0 {
+		return errors.New("track_index and clip_index must be >= 0")
+	}
+	if t.DeviceIndex < -1 {
+		return errors.New("device_index must be >= -1 (-1 = mixer)")
+	}
+	if t.ParameterIndex < 0 {
+		return errors.New("parameter_index must be >= 0")
+	}
+	return nil
+}

--- a/internal/tools/ableton_envelope_test.go
+++ b/internal/tools/ableton_envelope_test.go
@@ -1,0 +1,70 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseEnvelopeGetOK(t *testing.T) {
+	res := []interface{}{
+		int32(0), int32(1), "ok", "Volume",
+		float32(0), float32(0.5),
+		float32(1), float32(0.8),
+	}
+	out, err := parseEnvelopeGet(res, -1, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.Exists || out.ParamName != "Volume" || len(out.Samples) != 2 {
+		t.Fatalf("out = %+v", out)
+	}
+	if out.Samples[1].Time != 1 || out.Samples[1].Value < 0.79 || out.Samples[1].Value > 0.81 {
+		t.Errorf("sample1 = %+v", out.Samples[1])
+	}
+}
+
+func TestParseEnvelopeGetMissing(t *testing.T) {
+	out, err := parseEnvelopeGet([]interface{}{int32(0), int32(0), "missing", "Volume"}, -1, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Exists {
+		t.Error("expected exists=false")
+	}
+	if !strings.Contains(out.Hint, "set_clip_envelope") {
+		t.Errorf("hint = %q", out.Hint)
+	}
+}
+
+func TestParseEnvelopeGetNoClip(t *testing.T) {
+	_, err := parseEnvelopeGet([]interface{}{int32(0), int32(0), "no_clip"}, -1, 0)
+	if err == nil || !strings.Contains(err.Error(), "no_clip") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestParseEnvelopeSetStepsOK(t *testing.T) {
+	out, err := parseEnvelopeSetSteps([]interface{}{int32(0), int32(0), "ok", int32(3), "Volume"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.StepsSet != 3 || out.ParamName != "Volume" {
+		t.Fatalf("out = %+v", out)
+	}
+}
+
+func TestParseEnvelopeSetStepsCreateError(t *testing.T) {
+	_, err := parseEnvelopeSetSteps([]interface{}{int32(0), int32(0), "error", "create", "boom"})
+	if err == nil || !strings.Contains(err.Error(), "envelope_write_failed") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestValidateEnvelopeTarget(t *testing.T) {
+	if err := validateEnvelopeTarget(ClipEnvelopeTarget{TrackIndex: 0, ClipIndex: 0, DeviceIndex: -1, ParameterIndex: 0}); err != nil {
+		t.Fatalf("valid mixer target failed: %v", err)
+	}
+	if err := validateEnvelopeTarget(ClipEnvelopeTarget{TrackIndex: 0, ClipIndex: 0, DeviceIndex: -2, ParameterIndex: 0}); err == nil {
+		t.Fatal("expected error for device_index < -1")
+	}
+}

--- a/internal/tools/ableton_fx_ab.go
+++ b/internal/tools/ableton_fx_ab.go
@@ -1,0 +1,336 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+// Live Device.type values (LOM DeviceType).
+const (
+	liveDeviceTypeInstrument  = 1
+	liveDeviceTypeAudioEffect = 2
+	liveDeviceTypeMIDIEffect  = 3
+)
+
+type CompareFXBypassInput struct {
+	TrackIndex     int   `json:"track_index" jsonschema:"description=Track with the clip and FX chain,minimum=0"`
+	ClipIndex      int   `json:"clip_index" jsonschema:"description=Session clip slot to fire for both A and B,minimum=0"`
+	DeviceIndices  []int `json:"device_indices,omitempty" jsonschema:"description=FX devices to toggle; omit to use all audio/MIDI effects (instruments skipped)"`
+	BarsPerVersion *int  `json:"bars_per_version,omitempty" jsonschema:"description=Bars to hear each version (default 2),minimum=1,maximum=8"`
+	Cycles         *int  `json:"cycles,omitempty" jsonschema:"description=How many dry→wet cycles (default 1),minimum=1,maximum=4"`
+	BeatsPerBar    *int  `json:"beats_per_bar,omitempty" jsonschema:"description=Override beats per bar (default: Live signature numerator),minimum=1,maximum=16"`
+	StartPlayback  bool  `json:"start_playback,omitempty" jsonschema:"description=Start Live playback before the audition (also auto-starts when transport is stopped)"`
+	StopAfter      bool  `json:"stop_after,omitempty" jsonschema:"description=Stop playback after the final wet version"`
+}
+
+type FXDeviceState struct {
+	DeviceIndex int    `json:"device_index"`
+	Name        string `json:"name,omitempty"`
+	Type        int    `json:"type"`
+	WasActive   bool   `json:"was_active"`
+}
+
+type CompareFXBypassOutput struct {
+	TrackIndex       int             `json:"track_index"`
+	ClipIndex        int             `json:"clip_index"`
+	Devices          []FXDeviceState `json:"devices"`
+	BarsPerVersion   int             `json:"bars_per_version"`
+	Cycles           int             `json:"cycles"`
+	BeatsPerBar      int             `json:"beats_per_bar"`
+	TempoBPM         float64         `json:"tempo_bpm"`
+	DurationSec      float64         `json:"duration_sec"`
+	PlaybackStarted  bool            `json:"playback_started"`
+	Restored         bool            `json:"restored"`
+	TimingNote       string          `json:"timing_note"`
+	PreferencePrompt string          `json:"preference_prompt"`
+	NextStep         string          `json:"next_step"`
+}
+
+type fxABClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+func NewAbletonCompareFXBypass(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_compare_fx_bypass",
+		"Ableton Live: A/B the same Session clip dry vs processed — bypass selected FX (A/source), then restore their prior active state (B/variation), on song time. Does not record taste; follow with ableton_record_variation_preference instrument=fx variation=bypass.",
+		func(_ *ai.ToolContext, input CompareFXBypassInput) (CompareFXBypassOutput, error) {
+			return compareFXBypass(client, input, time.Sleep)
+		},
+	)
+}
+
+func compareFXBypass(client fxABClient, input CompareFXBypassInput, sleep auditionSleeper) (CompareFXBypassOutput, error) {
+	if input.TrackIndex < 0 || input.ClipIndex < 0 {
+		return CompareFXBypassOutput{}, errors.New("track_index and clip_index must be >= 0")
+	}
+	bars := defaultAuditionBarsPerVersion
+	if input.BarsPerVersion != nil {
+		bars = *input.BarsPerVersion
+	}
+	cycles := defaultAuditionCycles
+	if input.Cycles != nil {
+		cycles = *input.Cycles
+	}
+	if bars < 1 || bars > 8 {
+		return CompareFXBypassOutput{}, errors.New("bars_per_version must be between 1 and 8")
+	}
+	if cycles < 1 || cycles > 4 {
+		return CompareFXBypassOutput{}, errors.New("cycles must be between 1 and 4")
+	}
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+
+	devices, err := resolveFXBypassDevices(client, input.TrackIndex, input.DeviceIndices)
+	if err != nil {
+		return CompareFXBypassOutput{}, err
+	}
+	if len(devices) == 0 {
+		return CompareFXBypassOutput{}, actionable(
+			"no_fx_devices",
+			"No audio/MIDI effect devices found to bypass on this track.",
+			"Load an Audio Effect (or pass device_indices from ableton_get_track_devices), then retry.",
+		)
+	}
+
+	tempo, err := queryAuditionTempo(client)
+	if err != nil {
+		return CompareFXBypassOutput{}, err
+	}
+	beatsPerBar := 0
+	if input.BeatsPerBar != nil {
+		beatsPerBar = *input.BeatsPerBar
+		if beatsPerBar < 1 || beatsPerBar > 16 {
+			return CompareFXBypassOutput{}, errors.New("beats_per_bar must be between 1 and 16")
+		}
+	} else {
+		beatsPerBar, err = queryAuditionBeatsPerBar(client)
+		if err != nil {
+			return CompareFXBypassOutput{}, err
+		}
+	}
+
+	playbackStarted, err := ensureAuditionPlayback(client, input.StartPlayback)
+	if err != nil {
+		return CompareFXBypassOutput{}, err
+	}
+
+	prevQuant, err := queryClipTriggerQuantization(client)
+	if err != nil {
+		return CompareFXBypassOutput{}, err
+	}
+	if err := client.Send("/live/song/set/clip_trigger_quantization", int32(auditionBarQuantization)); err != nil {
+		return CompareFXBypassOutput{}, fmt.Errorf("set clip trigger quantization: %w", err)
+	}
+	restoreQuant := true
+	restored := false
+	defer func() {
+		_ = applyFXActiveStates(client, input.TrackIndex, devices, true)
+		restored = true
+		if restoreQuant {
+			_ = client.Send("/live/song/set/clip_trigger_quantization", int32(prevQuant))
+		}
+	}()
+
+	now, err := queryCurrentSongTime(client)
+	if err != nil {
+		return CompareFXBypassOutput{}, err
+	}
+	if err := client.Send("/live/clip_slot/fire", int32(input.TrackIndex), int32(input.ClipIndex)); err != nil {
+		return CompareFXBypassOutput{}, fmt.Errorf("fire clip: %w", err)
+	}
+	cursor := ceilBarBeat(now, beatsPerBar)
+	if err := waitUntilSongTime(client, sleep, cursor, tempo); err != nil {
+		return CompareFXBypassOutput{}, fmt.Errorf("wait for clip launch: %w", err)
+	}
+
+	heardBeats := 0.0
+	barBeats := float64(bars * beatsPerBar)
+	for i := 0; i < cycles; i++ {
+		// A / source = dry (FX bypassed)
+		if err := applyFXActiveStates(client, input.TrackIndex, devices, false); err != nil {
+			return CompareFXBypassOutput{}, fmt.Errorf("bypass FX (cycle %d): %w", i+1, err)
+		}
+		endA := cursor + barBeats
+		if err := waitUntilSongTime(client, sleep, endA, tempo); err != nil {
+			return CompareFXBypassOutput{}, fmt.Errorf("hear dry (cycle %d): %w", i+1, err)
+		}
+		heardBeats += barBeats
+		cursor = endA
+
+		// B / variation = prior active states (processed)
+		if err := applyFXActiveStates(client, input.TrackIndex, devices, true); err != nil {
+			return CompareFXBypassOutput{}, fmt.Errorf("restore FX (cycle %d): %w", i+1, err)
+		}
+		endB := cursor + barBeats
+		if err := waitUntilSongTime(client, sleep, endB, tempo); err != nil {
+			return CompareFXBypassOutput{}, fmt.Errorf("hear wet (cycle %d): %w", i+1, err)
+		}
+		heardBeats += barBeats
+		cursor = endB
+	}
+
+	if input.StopAfter {
+		if err := client.Send("/live/song/stop_playing"); err != nil {
+			return CompareFXBypassOutput{}, fmt.Errorf("stop playback: %w", err)
+		}
+	}
+
+	if err := applyFXActiveStates(client, input.TrackIndex, devices, true); err != nil {
+		return CompareFXBypassOutput{}, fmt.Errorf("restore FX after audition: %w", err)
+	}
+	restored = true
+	if err := client.Send("/live/song/set/clip_trigger_quantization", int32(prevQuant)); err != nil {
+		return CompareFXBypassOutput{}, fmt.Errorf("restore clip trigger quantization: %w", err)
+	}
+	restoreQuant = false
+
+	return CompareFXBypassOutput{
+		TrackIndex:       input.TrackIndex,
+		ClipIndex:        input.ClipIndex,
+		Devices:          devices,
+		BarsPerVersion:   bars,
+		Cycles:           cycles,
+		BeatsPerBar:      beatsPerBar,
+		TempoBPM:         tempo,
+		DurationSec:      heardBeats * 60 / tempo,
+		PlaybackStarted:  playbackStarted,
+		Restored:         restored,
+		TimingNote:       "A=dry (FX bypassed), B=wet (prior is_active restored). Same clip; switches land on bar boundaries with 1-bar clip trigger quantization.",
+		PreferencePrompt: "Which was closer to your ideal: dry (source) or processed (variation)? Record with ableton_record_variation_preference using instrument=fx variation=bypass.",
+		NextStep:         "Call ableton_record_variation_preference with instrument=fx variation=bypass preferred=source|variation after the listener chooses.",
+	}, nil
+}
+
+func resolveFXBypassDevices(client fxABClient, trackIndex int, requested []int) ([]FXDeviceState, error) {
+	nameRes, err := client.Query("/live/track/get/devices/name", int32(trackIndex))
+	if err != nil {
+		return nil, fmt.Errorf("get device names: %w", err)
+	}
+	typeRes, err := client.Query("/live/track/get/devices/type", int32(trackIndex))
+	if err != nil {
+		return nil, fmt.Errorf("get device types: %w", err)
+	}
+	if err := ensureResponseLen(nameRes, 1); err != nil {
+		return nil, fmt.Errorf("get device names: %w", err)
+	}
+	if err := ensureResponseLen(typeRes, 1); err != nil {
+		return nil, fmt.Errorf("get device types: %w", err)
+	}
+	names := toStringSlice(nameRes[1:])
+	types := make([]int, 0, len(typeRes)-1)
+	for _, v := range typeRes[1:] {
+		n, err := abletonosc.AsInt(v)
+		if err != nil {
+			return nil, fmt.Errorf("device type: %w", err)
+		}
+		types = append(types, n)
+	}
+	if len(names) != len(types) {
+		return nil, fmt.Errorf("device list length mismatch: names=%d types=%d", len(names), len(types))
+	}
+
+	pick := map[int]bool{}
+	if len(requested) > 0 {
+		for _, idx := range requested {
+			if idx < 0 || idx >= len(types) {
+				return nil, fmt.Errorf("device_indices contains invalid index %d (track has %d devices)", idx, len(types))
+			}
+			if types[idx] == liveDeviceTypeInstrument {
+				return nil, actionable(
+					"instrument_not_bypassable",
+					fmt.Sprintf("device_index %d is an instrument; FX bypass A/B only toggles audio/MIDI effects.", idx),
+					"Omit instruments from device_indices, or omit device_indices to auto-select effects.",
+				)
+			}
+			pick[idx] = true
+		}
+	} else {
+		for i, typ := range types {
+			if typ == liveDeviceTypeAudioEffect || typ == liveDeviceTypeMIDIEffect {
+				pick[i] = true
+			}
+		}
+	}
+
+	out := make([]FXDeviceState, 0, len(pick))
+	for i := 0; i < len(types); i++ {
+		if !pick[i] {
+			continue
+		}
+		active, err := queryDeviceIsActive(client, trackIndex, i)
+		if err != nil {
+			return nil, err
+		}
+		name := ""
+		if i < len(names) {
+			name = names[i]
+		}
+		out = append(out, FXDeviceState{
+			DeviceIndex: i,
+			Name:        name,
+			Type:        types[i],
+			WasActive:   active,
+		})
+	}
+	return out, nil
+}
+
+func queryDeviceIsActive(client fxABClient, trackIndex, deviceIndex int) (bool, error) {
+	res, err := client.Query("/live/device/get/is_active", int32(trackIndex), int32(deviceIndex))
+	if err != nil {
+		return false, actionable(
+			"device_is_active_unavailable",
+			fmt.Sprintf("could not read is_active for device %d: %v", deviceIndex, err),
+			"Install/update the browser patch (device get/set is_active), then restart Live or send /live/api/reload.",
+		)
+	}
+	if len(res) >= 3 {
+		if status, ok := res[2].(string); ok && status != "" {
+			return false, actionable(
+				"device_is_active_error",
+				fmt.Sprintf("get is_active failed: %s", status),
+				"Check track_index/device_index with ableton_get_track_devices, then retry.",
+			)
+		}
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return false, fmt.Errorf("get is_active: %w", err)
+	}
+	active, err := abletonosc.AsInt(res[2])
+	if err != nil {
+		return false, fmt.Errorf("get is_active: %w", err)
+	}
+	return active != 0, nil
+}
+
+// applyFXActiveStates sets each device active=false (bypass) or restores WasActive when restore=true.
+func applyFXActiveStates(client fxABClient, trackIndex int, devices []FXDeviceState, restore bool) error {
+	for _, d := range devices {
+		want := false
+		if restore {
+			want = d.WasActive
+		}
+		activeArg := int32(0)
+		if want {
+			activeArg = 1
+		}
+		res, err := client.Query("/live/device/set/is_active", int32(trackIndex), int32(d.DeviceIndex), activeArg)
+		if err != nil {
+			return fmt.Errorf("set is_active device %d: %w", d.DeviceIndex, err)
+		}
+		if len(res) >= 3 {
+			if status, ok := res[2].(string); ok && status != "ok" {
+				return fmt.Errorf("set is_active device %d: %s", d.DeviceIndex, status)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/tools/ableton_fx_ab_test.go
+++ b/internal/tools/ableton_fx_ab_test.go
@@ -1,0 +1,114 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+type fxABStub struct {
+	active    map[int]int // device_index -> 0/1
+	songTime  float64
+	calls     []string
+	setActive []int
+}
+
+func (s *fxABStub) Query(address string, args ...interface{}) ([]interface{}, error) {
+	s.calls = append(s.calls, address)
+	switch address {
+	case "/live/track/get/devices/name":
+		return []interface{}{int32(0), "Simpler", "Reverb", "Delay"}, nil
+	case "/live/track/get/devices/type":
+		return []interface{}{int32(0), int32(1), int32(2), int32(2)}, nil
+	case "/live/device/get/is_active":
+		idx := int(args[1].(int32))
+		return []interface{}{int32(0), int32(idx), int32(s.active[idx])}, nil
+	case "/live/device/set/is_active":
+		idx := int(args[1].(int32))
+		val := int(args[2].(int32))
+		s.active[idx] = val
+		s.setActive = append(s.setActive, val)
+		return []interface{}{int32(0), int32(idx), "ok", int32(val)}, nil
+	case "/live/song/get/tempo":
+		return []interface{}{float32(120)}, nil
+	case "/live/song/get/signature_numerator":
+		return []interface{}{int32(4)}, nil
+	case "/live/song/get/is_playing":
+		return []interface{}{true}, nil
+	case "/live/song/get/clip_trigger_quantization":
+		return []interface{}{int32(4)}, nil
+	case "/live/song/get/current_song_time":
+		// Advance a bit each poll so waitUntilSongTime completes quickly.
+		s.songTime += 2
+		return []interface{}{s.songTime}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (s *fxABStub) Send(address string, args ...interface{}) error {
+	s.calls = append(s.calls, "send:"+address)
+	return nil
+}
+
+func TestCompareFXBypassDryThenWet(t *testing.T) {
+	t.Parallel()
+
+	client := &fxABStub{active: map[int]int{1: 1, 2: 1}}
+	nopSleep := func(time.Duration) {}
+	got, err := compareFXBypass(client, CompareFXBypassInput{
+		TrackIndex:     0,
+		ClipIndex:      0,
+		BarsPerVersion: intPtr(1),
+		Cycles:         intPtr(1),
+	}, nopSleep)
+	if err != nil {
+		t.Fatalf("compareFXBypass() error = %v", err)
+	}
+	if len(got.Devices) != 2 {
+		t.Fatalf("devices = %+v, want Reverb+Delay", got.Devices)
+	}
+	if got.Devices[0].DeviceIndex != 1 || got.Devices[1].DeviceIndex != 2 {
+		t.Errorf("device indices = %+v", got.Devices)
+	}
+	// Pattern: bypass(0), restore(1) per cycle, plus final restore(1).
+	// setActive records every set is_active value in order.
+	if len(client.setActive) < 4 {
+		t.Fatalf("setActive calls = %v", client.setActive)
+	}
+	if client.setActive[0] != 0 || client.setActive[1] != 0 {
+		t.Errorf("first cycle should bypass both FX, got %v", client.setActive[:2])
+	}
+	if !strings.Contains(got.PreferencePrompt, "instrument=fx variation=bypass") {
+		t.Errorf("prompt = %q", got.PreferencePrompt)
+	}
+	if !got.Restored {
+		t.Error("expected Restored=true")
+	}
+}
+
+func TestResolveFXBypassRejectsInstrument(t *testing.T) {
+	t.Parallel()
+
+	client := &fxABStub{active: map[int]int{0: 1}}
+	_, err := resolveFXBypassDevices(client, 0, []int{0})
+	if err == nil || !strings.Contains(err.Error(), "instrument_not_bypassable") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestValidateTasteFXBypass(t *testing.T) {
+	t.Parallel()
+
+	got, err := validateTastePreference(RecordVariationPreferenceInput{
+		Instrument: "fx",
+		Variation:  "bypass",
+		Preferred:  "source",
+	})
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if got.Instrument != "fx" || got.Variation != "bypass" {
+		t.Errorf("got %#v", got)
+	}
+}

--- a/internal/tools/ableton_intent.go
+++ b/internal/tools/ableton_intent.go
@@ -1,0 +1,273 @@
+package tools
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const intentVersion = 1
+
+// IntentSetting is one human-readable parameter target within an intent.
+type IntentSetting struct {
+	Param string `json:"param" jsonschema:"description=Parameter name (e.g. Frequency) or numeric index"`
+	Value string `json:"value" jsonschema:"description=Human-readable value (e.g. 180 Hz, HP, 60 %)"`
+}
+
+// Intent is a named recipe of parameter settings, applied on top of raw
+// parameter tweaking to give an intent -> settings layer.
+type Intent struct {
+	Version  int             `json:"version"`
+	Name     string          `json:"name"`
+	Settings []IntentSetting `json:"settings"`
+	SavedAt  time.Time       `json:"saved_at"`
+}
+
+var intentNameSanitize = regexp.MustCompile(`[^a-zA-Z0-9_.\- ]+`)
+
+func intentDir() string {
+	dir, err := os.UserConfigDir()
+	if err != nil || dir == "" {
+		dir = os.TempDir()
+	}
+	return filepath.Join(dir, "ableton-osc-mcp", "intents")
+}
+
+func intentPath(name string) (string, error) {
+	clean := strings.TrimSpace(name)
+	if clean == "" {
+		return "", errors.New("intent name is required")
+	}
+	clean = intentNameSanitize.ReplaceAllString(clean, "_")
+	return filepath.Join(intentDir(), clean+".json"), nil
+}
+
+func writeIntent(path string, intent Intent) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create intent dir: %w", err)
+	}
+	data, err := json.MarshalIndent(intent, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode intent: %w", err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}
+
+func readIntent(path string) (Intent, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return Intent{}, fmt.Errorf("intent not found: %s", strings.TrimSuffix(filepath.Base(path), ".json"))
+	}
+	if err != nil {
+		return Intent{}, fmt.Errorf("read intent: %w", err)
+	}
+	var intent Intent
+	if err := json.Unmarshal(data, &intent); err != nil {
+		return Intent{}, fmt.Errorf("parse intent: %w", err)
+	}
+	if intent.Version != intentVersion {
+		return Intent{}, fmt.Errorf("unsupported intent version: %d", intent.Version)
+	}
+	return intent, nil
+}
+
+// resolveParamIndex maps a name or numeric string to a parameter index,
+// trying exact, case-insensitive, then substring matches.
+func resolveParamIndex(names []string, q string) (int, bool) {
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return 0, false
+	}
+	if n, err := strconv.Atoi(q); err == nil {
+		if n >= 0 && n < len(names) {
+			return n, true
+		}
+		return 0, false
+	}
+	ql := strings.ToLower(q)
+	for i, n := range names {
+		if n == q {
+			return i, true
+		}
+	}
+	for i, n := range names {
+		if strings.ToLower(n) == ql {
+			return i, true
+		}
+	}
+	for i, n := range names {
+		if strings.Contains(strings.ToLower(n), ql) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+type ApplyIntentResult struct {
+	Param        string  `json:"param"`
+	ParamIndex   int     `json:"param_index"`
+	Requested    string  `json:"requested"`
+	Status       string  `json:"status"`
+	Value        float64 `json:"value,omitempty"`
+	DisplayValue string  `json:"display_value,omitempty"`
+	Error        string  `json:"error,omitempty"`
+}
+
+type ApplyDeviceIntentInput struct {
+	TrackIndex  int             `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex int             `json:"device_index" jsonschema:"minimum=0"`
+	Name        string          `json:"name,omitempty" jsonschema:"description=Intent name. With settings: also save under this name. Without settings: load and apply this saved intent"`
+	Settings    []IntentSetting `json:"settings,omitempty" jsonschema:"description=Inline parameter settings to apply (and save when name is given)"`
+}
+
+type ApplyDeviceIntentOutput struct {
+	TrackIndex  int                 `json:"track_index"`
+	DeviceIndex int                 `json:"device_index"`
+	Name        string              `json:"name,omitempty"`
+	Applied     int                 `json:"applied"`
+	Failed      int                 `json:"failed"`
+	Results     []ApplyIntentResult `json:"results"`
+	SavedPath   string              `json:"saved_path,omitempty"`
+}
+
+func NewAbletonApplyDeviceIntent(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_apply_device_intent",
+		"Ableton Live: apply a set of human-readable parameter settings (an intent, e.g. HP 180 Hz, or Beat Repeat Insert / 1/16 / Chance 60%) to a device in one call, resolving parameters by name. Provide inline settings and/or a name to save (with settings) or load+apply (without settings). Requires the browser patch",
+		func(_ *ai.ToolContext, input ApplyDeviceIntentInput) (ApplyDeviceIntentOutput, error) {
+			if input.TrackIndex < 0 || input.DeviceIndex < 0 {
+				return ApplyDeviceIntentOutput{}, errors.New("track_index and device_index must be >= 0")
+			}
+			name := strings.TrimSpace(input.Name)
+			settings := input.Settings
+			saveIt := false
+			switch {
+			case len(settings) == 0 && name == "":
+				return ApplyDeviceIntentOutput{}, errors.New("provide settings and/or a saved intent name")
+			case len(settings) == 0:
+				path, err := intentPath(name)
+				if err != nil {
+					return ApplyDeviceIntentOutput{}, err
+				}
+				loaded, err := readIntent(path)
+				if err != nil {
+					return ApplyDeviceIntentOutput{}, err
+				}
+				settings = loaded.Settings
+			case name != "":
+				saveIt = true
+			}
+			if len(settings) == 0 {
+				return ApplyDeviceIntentOutput{}, errors.New("intent has no settings")
+			}
+
+			namesRes, err := client.Query("/live/device/get/parameters/name",
+				int32(input.TrackIndex), int32(input.DeviceIndex))
+			if err != nil {
+				return ApplyDeviceIntentOutput{}, fmt.Errorf("get parameter names: %w", err)
+			}
+			if err := ensureResponseLen(namesRes, 2); err != nil {
+				return ApplyDeviceIntentOutput{}, err
+			}
+			names := toStringSlice(namesRes[2:])
+
+			out := ApplyDeviceIntentOutput{
+				TrackIndex:  input.TrackIndex,
+				DeviceIndex: input.DeviceIndex,
+				Name:        name,
+			}
+			for _, s := range settings {
+				r := ApplyIntentResult{Param: s.Param, Requested: s.Value, ParamIndex: -1}
+				idx, ok := resolveParamIndex(names, s.Param)
+				if !ok {
+					r.Status = "unknown_param"
+					r.Error = "no parameter matched"
+					out.Failed++
+					out.Results = append(out.Results, r)
+					continue
+				}
+				r.ParamIndex = idx
+				value := strings.TrimSpace(s.Value)
+				res, err := client.QueryWithTimeout(3*time.Second, "/live/device/set/parameter/string",
+					int32(input.TrackIndex), int32(input.DeviceIndex), int32(idx), value)
+				if err != nil {
+					r.Status = "error"
+					r.Error = err.Error()
+					out.Failed++
+					out.Results = append(out.Results, r)
+					continue
+				}
+				parsed, perr := parseSetDeviceParameterStringResponse(res)
+				r.Status = parsed.Status
+				if perr != nil {
+					r.Error = perr.Error()
+					out.Failed++
+				} else {
+					r.Value = parsed.Value
+					r.DisplayValue = parsed.DisplayValue
+					out.Applied++
+				}
+				out.Results = append(out.Results, r)
+			}
+
+			if saveIt {
+				path, err := intentPath(name)
+				if err != nil {
+					return out, err
+				}
+				if err := writeIntent(path, Intent{
+					Version:  intentVersion,
+					Name:     name,
+					Settings: settings,
+					SavedAt:  time.Now().UTC(),
+				}); err != nil {
+					return out, err
+				}
+				out.SavedPath = path
+			}
+			return out, nil
+		},
+	)
+}
+
+type ListIntentsOutput struct {
+	Dir     string   `json:"dir"`
+	Intents []string `json:"intents"`
+}
+
+func NewAbletonListIntents(g *genkit.Genkit) ai.Tool {
+	return genkit.DefineTool(g, "ableton_list_intents",
+		"Ableton Live: list saved device intents (names) available for ableton_apply_device_intent.",
+		func(_ *ai.ToolContext, _ struct{}) (ListIntentsOutput, error) {
+			dir := intentDir()
+			out := ListIntentsOutput{Dir: dir, Intents: []string{}}
+			entries, err := os.ReadDir(dir)
+			if errors.Is(err, os.ErrNotExist) {
+				return out, nil
+			}
+			if err != nil {
+				return ListIntentsOutput{}, fmt.Errorf("read intent dir: %w", err)
+			}
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+					continue
+				}
+				out.Intents = append(out.Intents, strings.TrimSuffix(e.Name(), ".json"))
+			}
+			sort.Strings(out.Intents)
+			return out, nil
+		},
+	)
+}

--- a/internal/tools/ableton_intent_test.go
+++ b/internal/tools/ableton_intent_test.go
@@ -1,0 +1,87 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveParamIndex(t *testing.T) {
+	names := []string{"Device On", "Frequency", "Filter Type", "Dry/Wet"}
+	cases := []struct {
+		q      string
+		want   int
+		wantOK bool
+	}{
+		{"Frequency", 1, true},    // exact
+		{"frequency", 1, true},    // case-insensitive
+		{"freq", 1, true},         // substring
+		{"filter", 2, true},       // substring
+		{"2", 2, true},            // numeric index
+		{"dry/wet", 3, true},      // ci with slash
+		{"nonexistent", 0, false}, // no match
+		{"9", 0, false},           // out of range index
+		{"", 0, false},            // empty
+	}
+	for _, c := range cases {
+		got, ok := resolveParamIndex(names, c.q)
+		if ok != c.wantOK || (ok && got != c.want) {
+			t.Errorf("resolveParamIndex(%q) = (%d,%v), want (%d,%v)", c.q, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestIntentPathSanitize(t *testing.T) {
+	path, err := intentPath("HP 180Hz / bright!")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	base := filepath.Base(path)
+	if base != "HP 180Hz _ bright_.json" {
+		t.Errorf("sanitized base = %q", base)
+	}
+	if _, err := intentPath("   "); err == nil {
+		t.Error("expected error for blank name")
+	}
+}
+
+func TestIntentRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.json")
+	in := Intent{
+		Version: intentVersion,
+		Name:    "hp-clean",
+		Settings: []IntentSetting{
+			{Param: "Filter Type", Value: "HP"},
+			{Param: "Frequency", Value: "180 Hz"},
+		},
+	}
+	if err := writeIntent(path, in); err != nil {
+		t.Fatalf("writeIntent: %v", err)
+	}
+	got, err := readIntent(path)
+	if err != nil {
+		t.Fatalf("readIntent: %v", err)
+	}
+	if got.Name != "hp-clean" || len(got.Settings) != 2 {
+		t.Fatalf("round trip = %+v", got)
+	}
+	if got.Settings[1].Param != "Frequency" || got.Settings[1].Value != "180 Hz" {
+		t.Errorf("settings not preserved: %+v", got.Settings)
+	}
+}
+
+func TestReadIntentMissing(t *testing.T) {
+	if _, err := readIntent(filepath.Join(t.TempDir(), "nope.json")); err == nil {
+		t.Fatal("expected error for missing intent")
+	}
+}
+
+func TestReadIntentBadVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte(`{"version":99,"name":"x","settings":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readIntent(path); err == nil {
+		t.Fatal("expected error for unsupported version")
+	}
+}

--- a/internal/tools/ableton_preview.go
+++ b/internal/tools/ableton_preview.go
@@ -1,0 +1,193 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+type PreviewDestructiveInput struct {
+	Action       string `json:"action" jsonschema:"description=One of: delete_track, delete_clip, delete_device, clear_clip_notes, clear_scene_clips"`
+	TrackIndex   *int   `json:"track_index,omitempty" jsonschema:"minimum=0"`
+	DeviceIndex  *int   `json:"device_index,omitempty" jsonschema:"minimum=0"`
+	ClipIndex    *int   `json:"clip_index,omitempty" jsonschema:"minimum=0"`
+	SceneIndex   *int   `json:"scene_index,omitempty" jsonschema:"minimum=0"`
+	TrackIndices []int  `json:"track_indices,omitempty" jsonschema:"description=For clear_scene_clips: tracks to affect; omit = all"`
+}
+
+type PreviewDestructiveOutput struct {
+	Action      string   `json:"action"`
+	Summary     string   `json:"summary"`
+	Details     []string `json:"details"`
+	Destructive bool     `json:"destructive"`
+	Hint        string   `json:"hint" jsonschema:"description=How to execute after reviewing the preview"`
+}
+
+func previewDestructive(client oscQuerier, input PreviewDestructiveInput) (PreviewDestructiveOutput, error) {
+	action := strings.TrimSpace(strings.ToLower(input.Action))
+	out := PreviewDestructiveOutput{
+		Action:      action,
+		Details:     []string{},
+		Destructive: true,
+	}
+
+	switch action {
+	case "delete_track":
+		if input.TrackIndex == nil {
+			return out, actionable("missing_args", "track_index is required for delete_track", "Pass track_index of the track to preview.")
+		}
+		idx := *input.TrackIndex
+		name, err := queryTrackName(client, idx)
+		if err != nil {
+			return out, wrapActionable(err, "query_failed", "Check that AbletonOSC is connected, then retry.")
+		}
+		devs := previewDeviceNames(client, idx)
+		out.Summary = fmt.Sprintf("delete track %d %q (%d devices)", idx, name, len(devs))
+		out.Details = append(out.Details, fmt.Sprintf("track: [%d] %s", idx, name))
+		if len(devs) == 0 {
+			out.Details = append(out.Details, "devices: (none)")
+		} else {
+			out.Details = append(out.Details, "devices: "+strings.Join(devs, ", "))
+		}
+		out.Hint = "Call ableton_delete_track with the same track_index and confirm=true."
+
+	case "delete_clip":
+		if input.TrackIndex == nil || input.ClipIndex == nil {
+			return out, actionable("missing_args", "track_index and clip_index are required for delete_clip", "Pass both indices of the clip slot to preview.")
+		}
+		t, c := *input.TrackIndex, *input.ClipIndex
+		has, err := queryHasClip(client, t, c)
+		if err != nil {
+			return out, wrapActionable(err, "query_failed", "Check AbletonOSC connectivity, then retry.")
+		}
+		clipName := ""
+		if has {
+			if res, err := client.Query("/live/clip/get/name", int32(t), int32(c)); err == nil && len(res) >= 3 {
+				clipName = fmt.Sprint(res[2])
+			}
+		}
+		if !has {
+			out.Summary = fmt.Sprintf("slot [%d,%d] is already empty (no-op)", t, c)
+			out.Destructive = false
+			out.Details = append(out.Details, "has_clip: false")
+			out.Hint = "Nothing to delete."
+		} else {
+			out.Summary = fmt.Sprintf("delete clip on track %d slot %d", t, c)
+			if clipName != "" {
+				out.Summary += fmt.Sprintf(" (%q)", clipName)
+				out.Details = append(out.Details, "clip_name: "+clipName)
+			}
+			out.Details = append(out.Details, "has_clip: true → would become empty")
+			out.Hint = "Call ableton_delete_clip with the same indices and confirm=true."
+		}
+
+	case "delete_device":
+		if input.TrackIndex == nil || input.DeviceIndex == nil {
+			return out, actionable("missing_args", "track_index and device_index are required for delete_device", "Pass both indices of the device to preview.")
+		}
+		t, d := *input.TrackIndex, *input.DeviceIndex
+		devs := previewDeviceNames(client, t)
+		if d < 0 || d >= len(devs) {
+			return out, actionable("invalid_device_index",
+				fmt.Sprintf("device_index %d out of range (%d devices on track %d)", d, len(devs), t),
+				"Call ableton_get_track_devices first and pick a valid device_index.")
+		}
+		out.Summary = fmt.Sprintf("delete device %d %q from track %d", d, devs[d], t)
+		out.Details = append(out.Details, fmt.Sprintf("device: [%d] %s", d, devs[d]))
+		out.Details = append(out.Details, fmt.Sprintf("devices_before: %d → after: %d", len(devs), len(devs)-1))
+		out.Hint = "Call ableton_delete_device with the same indices and confirm=true."
+
+	case "clear_clip_notes":
+		if input.TrackIndex == nil || input.ClipIndex == nil {
+			return out, actionable("missing_args", "track_index and clip_index are required for clear_clip_notes", "Pass both indices of the MIDI clip to preview.")
+		}
+		t, c := *input.TrackIndex, *input.ClipIndex
+		has, err := queryHasClip(client, t, c)
+		if err != nil {
+			return out, wrapActionable(err, "query_failed", "Check AbletonOSC connectivity, then retry.")
+		}
+		if !has {
+			return out, actionable("no_clip",
+				fmt.Sprintf("no clip in slot [%d,%d]", t, c),
+				"Create or select a MIDI clip first, then retry.")
+		}
+		n := 0
+		if res, err := client.Query("/live/clip/get/notes", int32(t), int32(c)); err == nil {
+			// Stock reply starts with track, clip, then flat note fields (5 per note).
+			if len(res) >= 2 {
+				n = (len(res) - 2) / 5
+			}
+		}
+		out.Summary = fmt.Sprintf("clear all notes in clip [%d,%d] (~%d notes)", t, c, n)
+		out.Details = append(out.Details, fmt.Sprintf("estimated_notes: %d", n))
+		out.Hint = "Call ableton_clear_clip_notes with the same indices and confirm=true."
+
+	case "clear_scene_clips":
+		if input.SceneIndex == nil {
+			return out, actionable("missing_args", "scene_index is required for clear_scene_clips", "Pass the scene row to clear.")
+		}
+		scene := *input.SceneIndex
+		numTracks, err := queryNumTracks(client)
+		if err != nil {
+			return out, wrapActionable(err, "query_failed", "Check AbletonOSC connectivity, then retry.")
+		}
+		tracks := input.TrackIndices
+		if len(tracks) == 0 {
+			tracks = make([]int, numTracks)
+			for i := range tracks {
+				tracks[i] = i
+			}
+		}
+		occupied := 0
+		for _, t := range tracks {
+			has, err := queryHasClip(client, t, scene)
+			if err != nil {
+				return out, wrapActionable(err, "query_failed", "Check AbletonOSC connectivity, then retry.")
+			}
+			if has {
+				occupied++
+				name, _ := queryTrackName(client, t)
+				out.Details = append(out.Details, fmt.Sprintf("track %d %q scene %d: has clip → delete", t, name, scene))
+			}
+		}
+		out.Summary = fmt.Sprintf("clear %d clip(s) on scene %d across %d track(s)", occupied, scene, len(tracks))
+		if occupied == 0 {
+			out.Destructive = false
+			out.Hint = "Nothing to delete."
+		} else {
+			out.Hint = "Call ableton_set_scene_clip_presence with present=false, the same scene_index/track_indices, and confirm=true."
+		}
+
+	default:
+		return out, actionable("unknown_action",
+			fmt.Sprintf("unsupported action %q", input.Action),
+			"Use delete_track, delete_clip, delete_device, clear_clip_notes, or clear_scene_clips.")
+	}
+
+	return out, nil
+}
+
+func previewDeviceNames(client oscQuerier, trackIndex int) []string {
+	res, err := client.Query("/live/track/get/devices/name", int32(trackIndex))
+	if err != nil || len(res) < 1 {
+		return nil
+	}
+	return toStringSlice(res[1:])
+}
+
+func NewAbletonPreviewDestructive(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_preview_destructive",
+		"Ableton Live: preview a destructive action (delete track/clip/device, clear notes, clear scene clips) as a diff summary without executing. Review the summary, then call the matching tool with confirm=true.",
+		func(_ *ai.ToolContext, input PreviewDestructiveInput) (PreviewDestructiveOutput, error) {
+			if strings.TrimSpace(input.Action) == "" {
+				return PreviewDestructiveOutput{}, errors.New("action is required")
+			}
+			return previewDestructive(client, input)
+		},
+	)
+}

--- a/internal/tools/ableton_preview_test.go
+++ b/internal/tools/ableton_preview_test.go
@@ -1,0 +1,129 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+type previewFakeClient struct {
+	trackName string
+	devices   []string
+	hasClip   bool
+	clipName  string
+	numTracks int
+}
+
+func (f *previewFakeClient) Query(address string, args ...interface{}) ([]interface{}, error) {
+	switch address {
+	case "/live/track/get/name":
+		return []interface{}{args[0], f.trackName}, nil
+	case "/live/track/get/devices/name":
+		out := []interface{}{args[0]}
+		for _, d := range f.devices {
+			out = append(out, d)
+		}
+		return out, nil
+	case "/live/song/get/num_tracks":
+		return []interface{}{int32(f.numTracks)}, nil
+	case "/live/clip_slot/get/has_clip":
+		return []interface{}{args[0], args[1], f.hasClip}, nil
+	case "/live/clip/get/name":
+		return []interface{}{args[0], args[1], f.clipName}, nil
+	case "/live/clip/get/notes":
+		// track, clip, + 2 notes × 5 fields
+		return []interface{}{args[0], args[1],
+			int32(60), float32(0), float32(0.5), int32(100), false,
+			int32(62), float32(1), float32(0.5), int32(90), false,
+		}, nil
+	}
+	return nil, nil
+}
+
+func TestPreviewDeleteTrack(t *testing.T) {
+	c := &previewFakeClient{trackName: "Drums", devices: []string{"Kit", "EQ"}, numTracks: 4}
+	idx := 0
+	out, err := previewDestructive(c, PreviewDestructiveInput{Action: "delete_track", TrackIndex: &idx})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.Destructive || !strings.Contains(out.Summary, "Drums") {
+		t.Errorf("out = %+v", out)
+	}
+	if !strings.Contains(out.Hint, "confirm=true") {
+		t.Errorf("hint = %q", out.Hint)
+	}
+}
+
+func TestPreviewDeleteClipEmpty(t *testing.T) {
+	c := &previewFakeClient{hasClip: false}
+	tIdx, cIdx := 0, 1
+	out, err := previewDestructive(c, PreviewDestructiveInput{
+		Action: "delete_clip", TrackIndex: &tIdx, ClipIndex: &cIdx,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Destructive {
+		t.Error("empty slot should not be marked destructive")
+	}
+}
+
+func TestPreviewDeleteDevice(t *testing.T) {
+	c := &previewFakeClient{devices: []string{"EQ Eight", "Reverb"}}
+	tIdx, dIdx := 0, 1
+	out, err := previewDestructive(c, PreviewDestructiveInput{
+		Action: "delete_device", TrackIndex: &tIdx, DeviceIndex: &dIdx,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.Summary, "Reverb") {
+		t.Errorf("summary = %q", out.Summary)
+	}
+}
+
+func TestPreviewClearScene(t *testing.T) {
+	c := &previewFakeClient{numTracks: 2, hasClip: true, trackName: "A"}
+	scene := 3
+	out, err := previewDestructive(c, PreviewDestructiveInput{
+		Action: "clear_scene_clips", SceneIndex: &scene,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.Summary, "2 clip") {
+		t.Errorf("summary = %q", out.Summary)
+	}
+}
+
+func TestPreviewUnknownAction(t *testing.T) {
+	_, err := previewDestructive(&previewFakeClient{}, PreviewDestructiveInput{Action: "explode"})
+	if err == nil || !strings.Contains(err.Error(), "unknown_action") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestRequireConfirm(t *testing.T) {
+	if err := requireConfirm(true, "delete_track", "x"); err != nil {
+		t.Fatalf("confirm true should pass: %v", err)
+	}
+	err := requireConfirm(false, "delete_track", "track 0")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	ae, ok := err.(*ActionableError)
+	if !ok || ae.Code != "confirm_required" {
+		t.Fatalf("got %#v", err)
+	}
+	if !strings.Contains(err.Error(), "next:") {
+		t.Errorf("error missing next step: %v", err)
+	}
+}
+
+func TestActionableErrorFormat(t *testing.T) {
+	err := actionable("no_clip", "slot empty", "Create a clip first.")
+	got := err.Error()
+	if !strings.Contains(got, "no_clip:") || !strings.Contains(got, "next: Create a clip first.") {
+		t.Errorf("format = %q", got)
+	}
+}

--- a/internal/tools/ableton_routing.go
+++ b/internal/tools/ableton_routing.go
@@ -1,0 +1,430 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+// --- Return tracks ---
+
+type ReturnTrack struct {
+	Index int    `json:"index"`
+	Name  string `json:"name"`
+}
+
+type GetReturnTracksOutput struct {
+	Returns []ReturnTrack `json:"returns"`
+}
+
+func parseReturnTracks(res []interface{}) (GetReturnTracksOutput, error) {
+	if err := ensureResponseLen(res, 1); err != nil {
+		return GetReturnTracksOutput{}, err
+	}
+	n, err := abletonosc.AsInt(res[0])
+	if err != nil {
+		return GetReturnTracksOutput{}, fmt.Errorf("parse count: %w", err)
+	}
+	names := toStringSlice(res[1:])
+	if n != len(names) {
+		// Prefer the names we got if Live's count mismatches for any reason.
+		n = len(names)
+	}
+	out := GetReturnTracksOutput{Returns: make([]ReturnTrack, 0, n)}
+	for i := 0; i < n; i++ {
+		name := ""
+		if i < len(names) {
+			name = names[i]
+		}
+		out.Returns = append(out.Returns, ReturnTrack{Index: i, Name: name})
+	}
+	return out, nil
+}
+
+func NewAbletonGetReturnTracks(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_return_tracks",
+		"Ableton Live: list return tracks (A/B/C…) with indices used as send_index. Requires the browser patch.",
+		func(_ *ai.ToolContext, _ struct{}) (GetReturnTracksOutput, error) {
+			res, err := client.Query("/live/song/get/return_tracks")
+			if err != nil {
+				return GetReturnTracksOutput{}, wrapActionable(err, "return_tracks_unavailable",
+					"Install/update the browser patch and restart (or hot-reload) AbletonOSC, then retry.")
+			}
+			return parseReturnTracks(res)
+		},
+	)
+}
+
+type CreateReturnTrackOutput struct {
+	Index        int    `json:"index"`
+	Name         string `json:"name"`
+	ReturnsAfter int    `json:"returns_after"`
+}
+
+func NewAbletonCreateReturnTrack(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_create_return_track",
+		"Ableton Live: create a new return track at the end of the return rack. Prefer ableton_get_return_tracks afterward for the name (A/B/…). Requires AbletonOSC.",
+		func(_ *ai.ToolContext, _ struct{}) (CreateReturnTrackOutput, error) {
+			before := 0
+			if res, err := client.Query("/live/song/get/return_tracks"); err == nil {
+				if parsed, perr := parseReturnTracks(res); perr == nil {
+					before = len(parsed.Returns)
+				}
+			}
+			if err := client.Send("/live/song/create_return_track"); err != nil {
+				return CreateReturnTrackOutput{}, fmt.Errorf("create return track: %w", err)
+			}
+			res, err := client.Query("/live/song/get/return_tracks")
+			if err != nil {
+				// Stock create may have worked even without the list patch.
+				return CreateReturnTrackOutput{Index: before, ReturnsAfter: before + 1}, nil
+			}
+			parsed, err := parseReturnTracks(res)
+			if err != nil {
+				return CreateReturnTrackOutput{}, err
+			}
+			after := len(parsed.Returns)
+			if after != before+1 && before > 0 {
+				return CreateReturnTrackOutput{}, fmt.Errorf("create return track count mismatch (before=%d after=%d)", before, after)
+			}
+			idx := after - 1
+			if idx < 0 {
+				return CreateReturnTrackOutput{}, errors.New("no return tracks after create")
+			}
+			return CreateReturnTrackOutput{
+				Index:        idx,
+				Name:         parsed.Returns[idx].Name,
+				ReturnsAfter: after,
+			}, nil
+		},
+	)
+}
+
+// --- Sends ---
+
+type TrackSend struct {
+	SendIndex  int     `json:"send_index"`
+	ReturnName string  `json:"return_name,omitempty"`
+	Value      float64 `json:"value" jsonschema:"description=Normalized send amount (~0..1; ~0.85 ≈ 0 dB)"`
+}
+
+type GetTrackSendsInput struct {
+	TrackIndex int `json:"track_index" jsonschema:"minimum=0"`
+}
+
+type GetTrackSendsOutput struct {
+	TrackIndex int         `json:"track_index"`
+	Sends      []TrackSend `json:"sends"`
+}
+
+func NewAbletonGetTrackSends(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_track_sends",
+		"Ableton Live: get all send amounts on a track. send_index matches return track order (0=A, 1=B, …). Values are normalized (~0..1).",
+		func(_ *ai.ToolContext, input GetTrackSendsInput) (GetTrackSendsOutput, error) {
+			if input.TrackIndex < 0 {
+				return GetTrackSendsOutput{}, errors.New("track_index must be >= 0")
+			}
+			returns := []ReturnTrack{}
+			if res, err := client.Query("/live/song/get/return_tracks"); err == nil {
+				if parsed, perr := parseReturnTracks(res); perr == nil {
+					returns = parsed.Returns
+				}
+			}
+			n := len(returns)
+			if n == 0 {
+				// Fall back: probe send 0; if it fails, no returns.
+				if _, err := client.Query("/live/track/get/send", int32(input.TrackIndex), int32(0)); err != nil {
+					return GetTrackSendsOutput{TrackIndex: input.TrackIndex, Sends: []TrackSend{}}, nil
+				}
+				n = 1
+			}
+			sends := make([]TrackSend, 0, n)
+			for i := 0; i < n; i++ {
+				res, err := client.Query("/live/track/get/send", int32(input.TrackIndex), int32(i))
+				if err != nil {
+					break
+				}
+				if err := ensureResponseLen(res, 3); err != nil {
+					return GetTrackSendsOutput{}, err
+				}
+				val, err := abletonosc.AsFloat64(res[2])
+				if err != nil {
+					return GetTrackSendsOutput{}, err
+				}
+				s := TrackSend{SendIndex: i, Value: val}
+				if i < len(returns) {
+					s.ReturnName = returns[i].Name
+				}
+				sends = append(sends, s)
+			}
+			return GetTrackSendsOutput{TrackIndex: input.TrackIndex, Sends: sends}, nil
+		},
+	)
+}
+
+type SetTrackSendInput struct {
+	TrackIndex int     `json:"track_index" jsonschema:"minimum=0"`
+	SendIndex  int     `json:"send_index" jsonschema:"description=Return index (0=A, 1=B, …),minimum=0"`
+	Value      float64 `json:"value" jsonschema:"description=Normalized send amount (~0..1; ~0.85 ≈ 0 dB)"`
+}
+
+type SetTrackSendOutput struct {
+	TrackIndex int     `json:"track_index"`
+	SendIndex  int     `json:"send_index"`
+	Value      float64 `json:"value"`
+}
+
+func NewAbletonSetTrackSend(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_track_send",
+		"Ableton Live: set a track's send amount to a return (send_index 0=A, 1=B, …). Value is normalized (~0..1; ~0.85 ≈ 0 dB). Confirms by reading back.",
+		func(_ *ai.ToolContext, input SetTrackSendInput) (SetTrackSendOutput, error) {
+			if input.TrackIndex < 0 || input.SendIndex < 0 {
+				return SetTrackSendOutput{}, errors.New("track_index and send_index must be >= 0")
+			}
+			if err := client.Send("/live/track/set/send",
+				int32(input.TrackIndex), int32(input.SendIndex), float32(input.Value),
+			); err != nil {
+				return SetTrackSendOutput{}, err
+			}
+			res, err := client.Query("/live/track/get/send", int32(input.TrackIndex), int32(input.SendIndex))
+			if err != nil {
+				return SetTrackSendOutput{
+					TrackIndex: input.TrackIndex,
+					SendIndex:  input.SendIndex,
+					Value:      input.Value,
+				}, nil
+			}
+			if err := ensureResponseLen(res, 3); err != nil {
+				return SetTrackSendOutput{}, err
+			}
+			val, err := abletonosc.AsFloat64(res[2])
+			if err != nil {
+				return SetTrackSendOutput{}, err
+			}
+			return SetTrackSendOutput{
+				TrackIndex: input.TrackIndex,
+				SendIndex:  input.SendIndex,
+				Value:      val,
+			}, nil
+		},
+	)
+}
+
+// --- Device sidechain (Compressor input routing) ---
+
+type DeviceSidechainInput struct {
+	TrackIndex  int `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex int `json:"device_index" jsonschema:"description=Usually a Compressor (or other device with Sidechain input routing),minimum=0"`
+}
+
+type DeviceSidechainOutput struct {
+	TrackIndex        int      `json:"track_index"`
+	DeviceIndex       int      `json:"device_index"`
+	RoutingType       string   `json:"routing_type"`
+	RoutingChannel    string   `json:"routing_channel,omitempty"`
+	AvailableTypes    []string `json:"available_types"`
+	AvailableChannels []string `json:"available_channels,omitempty"`
+}
+
+func parseDeviceRoutingList(res []interface{}) (track, device int, names []string, err error) {
+	if err = ensureResponseLen(res, 3); err != nil {
+		return
+	}
+	track, err = abletonosc.AsInt(res[0])
+	if err != nil {
+		return
+	}
+	device, err = abletonosc.AsInt(res[1])
+	if err != nil {
+		return
+	}
+	status := fmt.Sprint(res[2])
+	switch status {
+	case "ok":
+		names = toStringSlice(res[3:])
+		return
+	case "unsupported":
+		err = actionable("unsupported_device",
+			"device has no sidechain/input routing (need Compressor or similar)",
+			"Load Ableton Compressor on the track, enable Sidechain, then retry.")
+		return
+	case "invalid_track_index", "invalid_device_index":
+		err = actionable(status, status,
+			"Call ableton_get_track_devices and pick a valid Compressor device_index.")
+		return
+	default:
+		err = fmt.Errorf("device routing list failed: status=%s reply=%v", status, res)
+		return
+	}
+}
+
+func parseDeviceRoutingValue(res []interface{}) (track, device int, value string, err error) {
+	if err = ensureResponseLen(res, 3); err != nil {
+		return
+	}
+	track, err = abletonosc.AsInt(res[0])
+	if err != nil {
+		return
+	}
+	device, err = abletonosc.AsInt(res[1])
+	if err != nil {
+		return
+	}
+	status := fmt.Sprint(res[2])
+	switch status {
+	case "ok":
+		if len(res) < 4 {
+			err = errors.New("missing routing value")
+			return
+		}
+		value = fmt.Sprint(res[3])
+		return
+	case "unsupported":
+		err = actionable("unsupported_device",
+			"device has no sidechain/input routing",
+			"Load Ableton Compressor on the track, enable Sidechain, then retry.")
+		return
+	default:
+		err = fmt.Errorf("device routing get failed: status=%s", status)
+		return
+	}
+}
+
+func parseDeviceRoutingSet(res []interface{}) (string, error) {
+	if err := ensureResponseLen(res, 3); err != nil {
+		return "", err
+	}
+	status := fmt.Sprint(res[2])
+	switch status {
+	case "set":
+		if len(res) >= 4 {
+			return fmt.Sprint(res[3]), nil
+		}
+		return "", nil
+	case "not_found":
+		target := ""
+		if len(res) > 3 {
+			target = fmt.Sprint(res[3])
+		}
+		opts := toStringSlice(res[4:])
+		return "", actionable("routing_not_found",
+			fmt.Sprintf("no routing matched %q", target),
+			fmt.Sprintf("Pick one of: %s", strings.Join(opts, ", ")))
+	case "unsupported":
+		return "", actionable("unsupported_device",
+			"device has no sidechain/input routing",
+			"Load Ableton Compressor on the track, enable Sidechain, then retry.")
+	default:
+		return "", fmt.Errorf("device routing set failed: status=%s reply=%v", status, res)
+	}
+}
+
+func NewAbletonGetDeviceSidechain(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_device_sidechain",
+		"Ableton Live: get a device's sidechain input routing (Compressor on Live 11+) — current type/channel and available options. Requires the browser patch.",
+		func(_ *ai.ToolContext, input DeviceSidechainInput) (DeviceSidechainOutput, error) {
+			if input.TrackIndex < 0 || input.DeviceIndex < 0 {
+				return DeviceSidechainOutput{}, errors.New("track_index and device_index must be >= 0")
+			}
+			args := []interface{}{int32(input.TrackIndex), int32(input.DeviceIndex)}
+			typesRes, err := client.Query("/live/device/get/available_input_routing_types", args...)
+			if err != nil {
+				return DeviceSidechainOutput{}, wrapActionable(err, "sidechain_unavailable",
+					"Install/update the browser patch and restart (or hot-reload) AbletonOSC, then retry.")
+			}
+			_, _, types, err := parseDeviceRoutingList(typesRes)
+			if err != nil {
+				return DeviceSidechainOutput{}, err
+			}
+			typeRes, err := client.Query("/live/device/get/input_routing_type", args...)
+			if err != nil {
+				return DeviceSidechainOutput{}, err
+			}
+			_, _, curType, err := parseDeviceRoutingValue(typeRes)
+			if err != nil {
+				return DeviceSidechainOutput{}, err
+			}
+			out := DeviceSidechainOutput{
+				TrackIndex:     input.TrackIndex,
+				DeviceIndex:    input.DeviceIndex,
+				RoutingType:    curType,
+				AvailableTypes: types,
+			}
+			if chList, err := client.Query("/live/device/get/available_input_routing_channels", args...); err == nil {
+				if _, _, chans, perr := parseDeviceRoutingList(chList); perr == nil {
+					out.AvailableChannels = chans
+				}
+			}
+			if chRes, err := client.Query("/live/device/get/input_routing_channel", args...); err == nil {
+				if _, _, ch, perr := parseDeviceRoutingValue(chRes); perr == nil {
+					out.RoutingChannel = ch
+				}
+			}
+			return out, nil
+		},
+	)
+}
+
+type SetDeviceSidechainInput struct {
+	TrackIndex     int    `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex    int    `json:"device_index" jsonschema:"minimum=0"`
+	RoutingType    string `json:"routing_type,omitempty" jsonschema:"description=Sidechain source track name (from available_types), e.g. the kick track"`
+	RoutingChannel string `json:"routing_channel,omitempty" jsonschema:"description=Optional channel within the source (from available_channels)"`
+}
+
+type SetDeviceSidechainOutput struct {
+	TrackIndex     int    `json:"track_index"`
+	DeviceIndex    int    `json:"device_index"`
+	RoutingType    string `json:"routing_type,omitempty"`
+	RoutingChannel string `json:"routing_channel,omitempty"`
+}
+
+func NewAbletonSetDeviceSidechain(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_device_sidechain",
+		"Ableton Live: set a device's sidechain input routing (Compressor). Pass routing_type (source track display name) and optionally routing_channel. Then enable Sidechain on the device via ableton_set_device_parameter_string if needed. Requires the browser patch.",
+		func(_ *ai.ToolContext, input SetDeviceSidechainInput) (SetDeviceSidechainOutput, error) {
+			if input.TrackIndex < 0 || input.DeviceIndex < 0 {
+				return SetDeviceSidechainOutput{}, errors.New("track_index and device_index must be >= 0")
+			}
+			typeName := strings.TrimSpace(input.RoutingType)
+			channelName := strings.TrimSpace(input.RoutingChannel)
+			if typeName == "" && channelName == "" {
+				return SetDeviceSidechainOutput{}, errors.New("routing_type and/or routing_channel is required")
+			}
+			out := SetDeviceSidechainOutput{TrackIndex: input.TrackIndex, DeviceIndex: input.DeviceIndex}
+			if typeName != "" {
+				res, err := client.QueryWithTimeout(3*time.Second, "/live/device/set/input_routing_type",
+					int32(input.TrackIndex), int32(input.DeviceIndex), typeName)
+				if err != nil {
+					return out, wrapActionable(err, "sidechain_unavailable",
+						"Install/update the browser patch and restart (or hot-reload) AbletonOSC, then retry.")
+				}
+				set, err := parseDeviceRoutingSet(res)
+				if err != nil {
+					return out, err
+				}
+				out.RoutingType = set
+			}
+			if channelName != "" {
+				res, err := client.QueryWithTimeout(3*time.Second, "/live/device/set/input_routing_channel",
+					int32(input.TrackIndex), int32(input.DeviceIndex), channelName)
+				if err != nil {
+					return out, wrapActionable(err, "sidechain_unavailable",
+						"Install/update the browser patch and restart (or hot-reload) AbletonOSC, then retry.")
+				}
+				set, err := parseDeviceRoutingSet(res)
+				if err != nil {
+					return out, err
+				}
+				out.RoutingChannel = set
+			}
+			return out, nil
+		},
+	)
+}

--- a/internal/tools/ableton_routing_test.go
+++ b/internal/tools/ableton_routing_test.go
@@ -1,0 +1,67 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseReturnTracks(t *testing.T) {
+	res := []interface{}{int32(2), "A", "B"}
+	out, err := parseReturnTracks(res)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Returns) != 2 || out.Returns[0].Name != "A" || out.Returns[1].Index != 1 {
+		t.Fatalf("out = %+v", out)
+	}
+}
+
+func TestParseReturnTracksEmpty(t *testing.T) {
+	out, err := parseReturnTracks([]interface{}{int32(0)})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Returns == nil || len(out.Returns) != 0 {
+		t.Fatalf("want empty list, got %+v", out.Returns)
+	}
+}
+
+func TestParseDeviceRoutingListOK(t *testing.T) {
+	res := []interface{}{int32(1), int32(0), "ok", "Drums", "Kick"}
+	track, device, names, err := parseDeviceRoutingList(res)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if track != 1 || device != 0 || len(names) != 2 || names[0] != "Drums" {
+		t.Fatalf("got %d %d %v", track, device, names)
+	}
+}
+
+func TestParseDeviceRoutingListUnsupported(t *testing.T) {
+	res := []interface{}{int32(0), int32(0), "unsupported"}
+	_, _, _, err := parseDeviceRoutingList(res)
+	if err == nil || !strings.Contains(err.Error(), "unsupported_device") {
+		t.Fatalf("got %v", err)
+	}
+	if !strings.Contains(err.Error(), "next:") {
+		t.Errorf("missing next step: %v", err)
+	}
+}
+
+func TestParseDeviceRoutingSetNotFound(t *testing.T) {
+	res := []interface{}{int32(0), int32(0), "not_found", "Ghost", "Drums", "Bass"}
+	_, err := parseDeviceRoutingSet(res)
+	if err == nil || !strings.Contains(err.Error(), "routing_not_found") {
+		t.Fatalf("got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Drums") {
+		t.Errorf("options missing from error: %v", err)
+	}
+}
+
+func TestParseDeviceRoutingSetOK(t *testing.T) {
+	got, err := parseDeviceRoutingSet([]interface{}{int32(0), int32(0), "set", "Drums"})
+	if err != nil || got != "Drums" {
+		t.Fatalf("got %q err=%v", got, err)
+	}
+}

--- a/internal/tools/ableton_scene_ops.go
+++ b/internal/tools/ableton_scene_ops.go
@@ -1,0 +1,258 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+type sceneOpsClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+func querySceneNames(client oscQuerier) ([]string, error) {
+	res, err := client.Query("/live/song/get/scenes/name")
+	if err != nil {
+		return nil, err
+	}
+	return toStringSlice(res), nil
+}
+
+type GetSceneNamesOutput struct {
+	Scenes []SceneNameEntry `json:"scenes"`
+}
+
+type SceneNameEntry struct {
+	Index int    `json:"index"`
+	Name  string `json:"name"`
+}
+
+func NewAbletonGetSceneNames(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_scene_names",
+		"Ableton Live: list scene names with indices (Intro/Verse/Hook anchors)",
+		func(_ *ai.ToolContext, _ struct{}) (GetSceneNamesOutput, error) {
+			names, err := querySceneNames(client)
+			if err != nil {
+				return GetSceneNamesOutput{}, fmt.Errorf("get scene names: %w", err)
+			}
+			out := GetSceneNamesOutput{Scenes: make([]SceneNameEntry, 0, len(names))}
+			for i, n := range names {
+				out.Scenes = append(out.Scenes, SceneNameEntry{Index: i, Name: n})
+			}
+			return out, nil
+		},
+	)
+}
+
+type SetSceneNameInput struct {
+	SceneIndex int    `json:"scene_index" jsonschema:"minimum=0"`
+	Name       string `json:"name" jsonschema:"description=New scene name (e.g. Intro, Verse, Hook)"`
+}
+
+func NewAbletonSetSceneName(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_scene_name",
+		"Ableton Live: rename a scene (e.g. Intro, Verse, Hook)",
+		func(_ *ai.ToolContext, input SetSceneNameInput) (SentOutput, error) {
+			if input.SceneIndex < 0 {
+				return SentOutput{}, errors.New("scene_index must be >= 0")
+			}
+			name := strings.TrimSpace(input.Name)
+			if name == "" {
+				return SentOutput{}, errors.New("name is required")
+			}
+			if err := client.Send("/live/scene/set/name", int32(input.SceneIndex), name); err != nil {
+				return SentOutput{}, err
+			}
+			return SentOutput{Sent: true}, nil
+		},
+	)
+}
+
+type CreateNamedScenesInput struct {
+	Names []string `json:"names" jsonschema:"description=Scene names to create at the end of the session (e.g. Intro, Verse, Hook, Outro)"`
+}
+
+type CreateNamedScenesOutput struct {
+	Created     []SceneNameEntry `json:"created"`
+	ScenesAfter int              `json:"scenes_after"`
+}
+
+func createNamedScenes(client sceneOpsClient, names []string) (CreateNamedScenesOutput, error) {
+	cleaned := make([]string, 0, len(names))
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			return CreateNamedScenesOutput{}, errors.New("names must not contain empty strings")
+		}
+		cleaned = append(cleaned, n)
+	}
+	if len(cleaned) == 0 {
+		return CreateNamedScenesOutput{}, errors.New("names is required")
+	}
+
+	before, err := queryNumScenes(client)
+	if err != nil {
+		return CreateNamedScenesOutput{}, fmt.Errorf("get num scenes: %w", err)
+	}
+
+	created := make([]SceneNameEntry, 0, len(cleaned))
+	for i, name := range cleaned {
+		if err := client.Send("/live/song/create_scene", int32(-1)); err != nil {
+			return CreateNamedScenesOutput{}, fmt.Errorf("create scene %q: %w", name, err)
+		}
+		index := before + i
+		if err := client.Send("/live/scene/set/name", int32(index), name); err != nil {
+			return CreateNamedScenesOutput{}, fmt.Errorf("name scene %q: %w", name, err)
+		}
+		created = append(created, SceneNameEntry{Index: index, Name: name})
+	}
+
+	after, err := queryNumScenes(client)
+	if err != nil {
+		return CreateNamedScenesOutput{}, fmt.Errorf("verify scenes: %w", err)
+	}
+	if after != before+len(cleaned) {
+		return CreateNamedScenesOutput{}, fmt.Errorf("create scenes count mismatch (before=%d after=%d want=%d)", before, after, before+len(cleaned))
+	}
+	return CreateNamedScenesOutput{Created: created, ScenesAfter: after}, nil
+}
+
+func NewAbletonCreateNamedScenes(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_create_named_scenes",
+		"Ableton Live: append empty named scenes (e.g. Intro, Verse, Hook) for section structure. Fill clips afterward, or use ableton_set_scene_clip_presence for subtractive arrangement from a full source scene.",
+		func(_ *ai.ToolContext, input CreateNamedScenesInput) (CreateNamedScenesOutput, error) {
+			return createNamedScenes(client, input.Names)
+		},
+	)
+}
+
+type SetSceneClipPresenceInput struct {
+	SceneIndex       int   `json:"scene_index" jsonschema:"description=Target scene (clip-slot row) to show/hide clips on,minimum=0"`
+	TrackIndices     []int `json:"track_indices,omitempty" jsonschema:"description=Tracks to affect; omit or empty = all tracks"`
+	Present          bool  `json:"present" jsonschema:"description=false deletes clips in the scene (subtractive); true copies from source_scene_index"`
+	SourceSceneIndex *int  `json:"source_scene_index,omitempty" jsonschema:"description=Required when present=true: scene to copy clips from,minimum=0"`
+	Confirm          bool  `json:"confirm,omitempty" jsonschema:"description=Required when present=false (destructive delete). Omit/false returns a preview error."`
+}
+
+type SceneClipPresenceChange struct {
+	TrackIndex int    `json:"track_index"`
+	Action     string `json:"action" jsonschema:"description=deleted, restored, skipped_empty, skipped_already_present, skipped_no_source"`
+}
+
+type SetSceneClipPresenceOutput struct {
+	SceneIndex int                       `json:"scene_index"`
+	Present    bool                      `json:"present"`
+	Changes    []SceneClipPresenceChange `json:"changes"`
+}
+
+func setSceneClipPresence(client sceneOpsClient, input SetSceneClipPresenceInput) (SetSceneClipPresenceOutput, error) {
+	if input.SceneIndex < 0 {
+		return SetSceneClipPresenceOutput{}, errors.New("scene_index must be >= 0")
+	}
+	if input.Present {
+		if input.SourceSceneIndex == nil {
+			return SetSceneClipPresenceOutput{}, errors.New("source_scene_index is required when present=true")
+		}
+		if *input.SourceSceneIndex < 0 {
+			return SetSceneClipPresenceOutput{}, errors.New("source_scene_index must be >= 0")
+		}
+		if *input.SourceSceneIndex == input.SceneIndex {
+			return SetSceneClipPresenceOutput{}, errors.New("source_scene_index must differ from scene_index")
+		}
+	} else if err := requireConfirm(input.Confirm, "clear_scene_clips",
+		fmt.Sprintf("delete clips on scene %d", input.SceneIndex)); err != nil {
+		return SetSceneClipPresenceOutput{}, err
+	}
+
+	numTracks, err := queryNumTracks(client)
+	if err != nil {
+		return SetSceneClipPresenceOutput{}, fmt.Errorf("get num tracks: %w", err)
+	}
+	tracks := input.TrackIndices
+	if len(tracks) == 0 {
+		tracks = make([]int, numTracks)
+		for i := range tracks {
+			tracks[i] = i
+		}
+	}
+	for _, t := range tracks {
+		if t < 0 || t >= numTracks {
+			return SetSceneClipPresenceOutput{}, fmt.Errorf("track_index %d out of range (%d tracks)", t, numTracks)
+		}
+	}
+
+	out := SetSceneClipPresenceOutput{
+		SceneIndex: input.SceneIndex,
+		Present:    input.Present,
+		Changes:    make([]SceneClipPresenceChange, 0, len(tracks)),
+	}
+
+	for _, track := range tracks {
+		if !input.Present {
+			has, err := queryHasClip(client, track, input.SceneIndex)
+			if err != nil {
+				return SetSceneClipPresenceOutput{}, err
+			}
+			if !has {
+				out.Changes = append(out.Changes, SceneClipPresenceChange{TrackIndex: track, Action: "skipped_empty"})
+				continue
+			}
+			if err := client.Send("/live/clip_slot/delete_clip", int32(track), int32(input.SceneIndex)); err != nil {
+				return SetSceneClipPresenceOutput{}, fmt.Errorf("delete clip track %d: %w", track, err)
+			}
+			out.Changes = append(out.Changes, SceneClipPresenceChange{TrackIndex: track, Action: "deleted"})
+			continue
+		}
+
+		src := *input.SourceSceneIndex
+		srcHas, err := queryHasClip(client, track, src)
+		if err != nil {
+			return SetSceneClipPresenceOutput{}, err
+		}
+		if !srcHas {
+			out.Changes = append(out.Changes, SceneClipPresenceChange{TrackIndex: track, Action: "skipped_no_source"})
+			continue
+		}
+		dstHas, err := queryHasClip(client, track, input.SceneIndex)
+		if err != nil {
+			return SetSceneClipPresenceOutput{}, err
+		}
+		if dstHas {
+			out.Changes = append(out.Changes, SceneClipPresenceChange{TrackIndex: track, Action: "skipped_already_present"})
+			continue
+		}
+		if err := client.Send("/live/clip_slot/duplicate_clip_to",
+			int32(track), int32(src), int32(track), int32(input.SceneIndex),
+		); err != nil {
+			return SetSceneClipPresenceOutput{}, fmt.Errorf("restore clip track %d: %w", track, err)
+		}
+		out.Changes = append(out.Changes, SceneClipPresenceChange{TrackIndex: track, Action: "restored"})
+	}
+	return out, nil
+}
+
+func queryHasClip(client oscQuerier, track, clip int) (bool, error) {
+	res, err := client.Query("/live/clip_slot/get/has_clip", int32(track), int32(clip))
+	if err != nil {
+		return false, fmt.Errorf("has_clip track %d clip %d: %w", track, clip, err)
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return false, err
+	}
+	return abletonosc.AsBool(res[2])
+}
+
+func NewAbletonSetSceneClipPresence(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_scene_clip_presence",
+		"Ableton Live: subtractive arrangement helper — hide (delete) or restore clips on a scene row. present=false clears the scene; present=true copies from source_scene_index into empty slots. Use track_indices to affect a subset of tracks.",
+		func(_ *ai.ToolContext, input SetSceneClipPresenceInput) (SetSceneClipPresenceOutput, error) {
+			return setSceneClipPresence(client, input)
+		},
+	)
+}

--- a/internal/tools/ableton_scene_ops_test.go
+++ b/internal/tools/ableton_scene_ops_test.go
@@ -1,0 +1,167 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+type fakeSceneClient struct {
+	numScenes   int
+	sceneNames  []string
+	numTracks   int
+	hasClip     map[[2]int]bool
+	sent        []string
+	createFails bool
+}
+
+func (f *fakeSceneClient) Send(address string, args ...interface{}) error {
+	f.sent = append(f.sent, address)
+	switch address {
+	case "/live/song/create_scene":
+		if f.createFails {
+			return nil
+		}
+		f.numScenes++
+		f.sceneNames = append(f.sceneNames, "")
+	case "/live/scene/set/name":
+		idx := int(args[0].(int32))
+		for len(f.sceneNames) <= idx {
+			f.sceneNames = append(f.sceneNames, "")
+		}
+		f.sceneNames[idx] = args[1].(string)
+	case "/live/clip_slot/delete_clip":
+		key := [2]int{int(args[0].(int32)), int(args[1].(int32))}
+		f.hasClip[key] = false
+	case "/live/clip_slot/duplicate_clip_to":
+		srcT, srcC := int(args[0].(int32)), int(args[1].(int32))
+		dstT, dstC := int(args[2].(int32)), int(args[3].(int32))
+		if f.hasClip[[2]int{srcT, srcC}] {
+			f.hasClip[[2]int{dstT, dstC}] = true
+		}
+	}
+	return nil
+}
+
+func (f *fakeSceneClient) Query(address string, args ...interface{}) ([]interface{}, error) {
+	switch address {
+	case "/live/song/get/num_scenes":
+		return []interface{}{int32(f.numScenes)}, nil
+	case "/live/song/get/scenes/name":
+		out := make([]interface{}, len(f.sceneNames))
+		for i, n := range f.sceneNames {
+			out[i] = n
+		}
+		return out, nil
+	case "/live/song/get/num_tracks":
+		return []interface{}{int32(f.numTracks)}, nil
+	case "/live/clip_slot/get/has_clip":
+		key := [2]int{int(args[0].(int32)), int(args[1].(int32))}
+		return []interface{}{args[0], args[1], f.hasClip[key]}, nil
+	}
+	return nil, nil
+}
+
+func TestCreateNamedScenes(t *testing.T) {
+	c := &fakeSceneClient{numScenes: 1, sceneNames: []string{"Untitled"}}
+	out, err := createNamedScenes(c, []string{"Intro", "Verse", "Hook"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.ScenesAfter != 4 || len(out.Created) != 3 {
+		t.Fatalf("out = %+v", out)
+	}
+	if out.Created[0].Index != 1 || out.Created[0].Name != "Intro" {
+		t.Errorf("first created = %+v", out.Created[0])
+	}
+	if out.Created[2].Name != "Hook" || out.Created[2].Index != 3 {
+		t.Errorf("last created = %+v", out.Created[2])
+	}
+}
+
+func TestCreateNamedScenesRejectsEmpty(t *testing.T) {
+	c := &fakeSceneClient{}
+	if _, err := createNamedScenes(c, []string{"Intro", "  "}); err == nil {
+		t.Fatal("expected error for blank name")
+	}
+}
+
+func TestSetSceneClipPresenceDelete(t *testing.T) {
+	c := &fakeSceneClient{
+		numTracks: 3,
+		numScenes: 2,
+		hasClip: map[[2]int]bool{
+			{0, 1}: true,
+			{1, 1}: true,
+			{2, 1}: false,
+		},
+	}
+	out, err := setSceneClipPresence(c, SetSceneClipPresenceInput{
+		SceneIndex: 1,
+		Present:    false,
+		Confirm:    true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	actions := map[int]string{}
+	for _, ch := range out.Changes {
+		actions[ch.TrackIndex] = ch.Action
+	}
+	if actions[0] != "deleted" || actions[1] != "deleted" || actions[2] != "skipped_empty" {
+		t.Errorf("actions = %v", actions)
+	}
+	if c.hasClip[[2]int{0, 1}] || c.hasClip[[2]int{1, 1}] {
+		t.Error("clips should be deleted")
+	}
+}
+
+func TestSetSceneClipPresenceRestore(t *testing.T) {
+	src := 0
+	c := &fakeSceneClient{
+		numTracks: 2,
+		numScenes: 2,
+		hasClip: map[[2]int]bool{
+			{0, 0}: true,
+			{1, 0}: true,
+			{0, 1}: false,
+			{1, 1}: true, // already present → skip
+		},
+	}
+	out, err := setSceneClipPresence(c, SetSceneClipPresenceInput{
+		SceneIndex:       1,
+		Present:          true,
+		SourceSceneIndex: &src,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	actions := map[int]string{}
+	for _, ch := range out.Changes {
+		actions[ch.TrackIndex] = ch.Action
+	}
+	if actions[0] != "restored" || actions[1] != "skipped_already_present" {
+		t.Errorf("actions = %v", actions)
+	}
+	if !c.hasClip[[2]int{0, 1}] {
+		t.Error("track 0 scene 1 should have been restored")
+	}
+}
+
+func TestSetSceneClipPresenceRequiresSource(t *testing.T) {
+	c := &fakeSceneClient{numTracks: 1}
+	_, err := setSceneClipPresence(c, SetSceneClipPresenceInput{SceneIndex: 0, Present: true})
+	if err == nil || !strings.Contains(err.Error(), "source_scene_index") {
+		t.Fatalf("expected source_scene_index error, got %v", err)
+	}
+}
+
+func TestSetSceneClipPresenceRequiresConfirm(t *testing.T) {
+	c := &fakeSceneClient{numTracks: 1, hasClip: map[[2]int]bool{{0, 0}: true}}
+	_, err := setSceneClipPresence(c, SetSceneClipPresenceInput{SceneIndex: 0, Present: false})
+	if err == nil || !strings.Contains(err.Error(), "confirm_required") {
+		t.Fatalf("expected confirm_required, got %v", err)
+	}
+	if c.hasClip[[2]int{0, 0}] != true {
+		t.Error("clip should not be deleted without confirm")
+	}
+}

--- a/internal/tools/ableton_scene_variations.go
+++ b/internal/tools/ableton_scene_variations.go
@@ -189,7 +189,7 @@ func discardSceneVariation(client variationClient, sceneIndex int, cause error) 
 	return fmt.Errorf("scene variation failed: %w; duplicated scene %d removed", cause, sceneIndex)
 }
 
-func queryNumScenes(client variationClient) (int, error) {
+func queryNumScenes(client oscQuerier) (int, error) {
 	res, err := client.Query("/live/song/get/num_scenes")
 	if err != nil {
 		return 0, fmt.Errorf("get scene count: %w", err)

--- a/internal/tools/ableton_simpler.go
+++ b/internal/tools/ableton_simpler.go
@@ -1,0 +1,321 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+// Simpler LOM enums (see Live Object Model: SimplerDevice, Sample).
+var (
+	simplerPlaybackModes        = []string{"classic", "one_shot", "slicing"}
+	simplerSlicingPlaybackModes = []string{"mono", "poly", "thru"}
+	simplerSlicingStyles        = []string{"transient", "beat", "region", "manual"}
+	simplerBeatDivisions        = []string{"1/16", "1/16T", "1/8", "1/8T", "1/4", "1/4T", "1/2", "1/2T", "1 Bar", "2 Bars", "4 Bars"}
+)
+
+func nameForIndex(list []string, idx int) string {
+	if idx >= 0 && idx < len(list) {
+		return list[idx]
+	}
+	return ""
+}
+
+// indexForName resolves a human name (case-insensitive) or a numeric string to an
+// enum index. Returns false when the value is empty or out of range.
+func indexForName(list []string, s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	if n, err := strconv.Atoi(s); err == nil {
+		if n >= 0 && n < len(list) {
+			return n, true
+		}
+		return 0, false
+	}
+	low := strings.ToLower(s)
+	for i, name := range list {
+		if strings.ToLower(name) == low {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func simplerStatusError(status string) error {
+	switch status {
+	case "invalid_track_index":
+		return errors.New("invalid track_index")
+	case "invalid_device_index":
+		return errors.New("invalid device_index")
+	case "not_simpler":
+		return errors.New("device is not a Simpler (OriginalSimpler)")
+	case "no_sample":
+		return errors.New("Simpler has no sample loaded")
+	default:
+		return fmt.Errorf("simpler op failed: status=%s", status)
+	}
+}
+
+type GetSimplerInput struct {
+	TrackIndex  int `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex int `json:"device_index" jsonschema:"minimum=0"`
+}
+
+type SimplerState struct {
+	TrackIndex              int    `json:"track_index"`
+	DeviceIndex             int    `json:"device_index"`
+	PlaybackMode            int    `json:"playback_mode"`
+	PlaybackModeName        string `json:"playback_mode_name"`
+	SlicingPlaybackMode     int    `json:"slicing_playback_mode"`
+	SlicingPlaybackModeName string `json:"slicing_playback_mode_name"`
+	SlicingStyle            *int   `json:"slicing_style,omitempty"`
+	SlicingStyleName        string `json:"slicing_style_name,omitempty"`
+	SlicingBeatDivision     *int   `json:"slicing_beat_division,omitempty"`
+	SlicingBeatDivisionName string `json:"slicing_beat_division_name,omitempty"`
+	NumSlices               int    `json:"num_slices"`
+	HasSample               bool   `json:"has_sample"`
+}
+
+func parseSimplerState(res []interface{}) (SimplerState, error) {
+	if err := ensureResponseLen(res, 3); err != nil {
+		return SimplerState{}, err
+	}
+	track, err := abletonosc.AsInt(res[0])
+	if err != nil {
+		return SimplerState{}, fmt.Errorf("parse track_index: %w", err)
+	}
+	device, err := abletonosc.AsInt(res[1])
+	if err != nil {
+		return SimplerState{}, fmt.Errorf("parse device_index: %w", err)
+	}
+	status := fmt.Sprint(res[2])
+	if status != "ok" {
+		return SimplerState{TrackIndex: track, DeviceIndex: device}, simplerStatusError(status)
+	}
+	if err := ensureResponseLen(res, 9); err != nil {
+		return SimplerState{}, err
+	}
+	pm, _ := abletonosc.AsInt(res[3])
+	spm, _ := abletonosc.AsInt(res[4])
+	ss, _ := abletonosc.AsInt(res[5])
+	bd, _ := abletonosc.AsInt(res[6])
+	ns, _ := abletonosc.AsInt(res[7])
+	hs, _ := abletonosc.AsInt(res[8])
+	state := SimplerState{
+		TrackIndex:              track,
+		DeviceIndex:             device,
+		PlaybackMode:            pm,
+		PlaybackModeName:        nameForIndex(simplerPlaybackModes, pm),
+		SlicingPlaybackMode:     spm,
+		SlicingPlaybackModeName: nameForIndex(simplerSlicingPlaybackModes, spm),
+		NumSlices:               ns,
+		HasSample:               hs != 0,
+	}
+	if ss >= 0 {
+		state.SlicingStyle = &ss
+		state.SlicingStyleName = nameForIndex(simplerSlicingStyles, ss)
+	}
+	if bd >= 0 {
+		state.SlicingBeatDivision = &bd
+		state.SlicingBeatDivisionName = nameForIndex(simplerBeatDivisions, bd)
+	}
+	return state, nil
+}
+
+func getSimplerState(client *abletonosc.Client, track, device int) (SimplerState, error) {
+	res, err := client.QueryWithTimeout(3*time.Second, "/live/device/simpler/get",
+		int32(track), int32(device))
+	if err != nil {
+		return SimplerState{}, fmt.Errorf("get simpler failed (browser patch required): %w", err)
+	}
+	return parseSimplerState(res)
+}
+
+func NewAbletonGetSimpler(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_simpler",
+		"Ableton Live: get Simpler state (playback mode, slicing mode/style/beat division, slice count) with human-readable names; requires the browser patch",
+		func(_ *ai.ToolContext, input GetSimplerInput) (SimplerState, error) {
+			if input.TrackIndex < 0 || input.DeviceIndex < 0 {
+				return SimplerState{}, errors.New("track_index and device_index must be >= 0")
+			}
+			return getSimplerState(client, input.TrackIndex, input.DeviceIndex)
+		},
+	)
+}
+
+func sendSimplerSet(client *abletonosc.Client, track, device int, prop string, value int) error {
+	res, err := client.QueryWithTimeout(3*time.Second, "/live/device/simpler/set",
+		int32(track), int32(device), prop, int32(value))
+	if err != nil {
+		return fmt.Errorf("set %s failed (browser patch required): %w", prop, err)
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return err
+	}
+	status := fmt.Sprint(res[2])
+	if status == "set" {
+		return nil
+	}
+	if status == "error" && len(res) > 4 {
+		return fmt.Errorf("set %s failed: %s", prop, fmt.Sprint(res[4]))
+	}
+	return simplerStatusError(status)
+}
+
+type SetSimplerPlaybackModeInput struct {
+	TrackIndex  int    `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex int    `json:"device_index" jsonschema:"minimum=0"`
+	Mode        string `json:"mode" jsonschema:"description=Playback mode: classic, one_shot, or slicing"`
+}
+
+func NewAbletonSetSimplerPlaybackMode(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_simpler_playback_mode",
+		"Ableton Live: set Simpler playback mode (classic / one_shot / slicing); requires the browser patch. Returns the resulting Simpler state",
+		func(_ *ai.ToolContext, input SetSimplerPlaybackModeInput) (SimplerState, error) {
+			if input.TrackIndex < 0 || input.DeviceIndex < 0 {
+				return SimplerState{}, errors.New("track_index and device_index must be >= 0")
+			}
+			idx, ok := indexForName(simplerPlaybackModes, input.Mode)
+			if !ok {
+				return SimplerState{}, fmt.Errorf("invalid mode %q; use one of: %s", input.Mode, strings.Join(simplerPlaybackModes, ", "))
+			}
+			if err := sendSimplerSet(client, input.TrackIndex, input.DeviceIndex, "playback_mode", idx); err != nil {
+				return SimplerState{}, err
+			}
+			return getSimplerState(client, input.TrackIndex, input.DeviceIndex)
+		},
+	)
+}
+
+type SetSimplerSlicingInput struct {
+	TrackIndex   int    `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex  int    `json:"device_index" jsonschema:"minimum=0"`
+	Style        string `json:"style,omitempty" jsonschema:"description=Slicing style: transient, beat, region, or manual"`
+	BeatDivision string `json:"beat_division,omitempty" jsonschema:"description=Beat division when style=beat: 1/16, 1/16T, 1/8, 1/8T, 1/4, 1/4T, 1/2, 1/2T, 1 Bar, 2 Bars, 4 Bars"`
+}
+
+func NewAbletonSetSimplerSlicing(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_set_simpler_slicing",
+		"Ableton Live: set Simpler slicing style and/or beat division (requires a loaded sample). Does not switch playback mode; call ableton_set_simpler_playback_mode with slicing to hear slices. Returns the resulting Simpler state",
+		func(_ *ai.ToolContext, input SetSimplerSlicingInput) (SimplerState, error) {
+			if input.TrackIndex < 0 || input.DeviceIndex < 0 {
+				return SimplerState{}, errors.New("track_index and device_index must be >= 0")
+			}
+			style := strings.TrimSpace(input.Style)
+			bd := strings.TrimSpace(input.BeatDivision)
+			if style == "" && bd == "" {
+				return SimplerState{}, errors.New("provide style and/or beat_division")
+			}
+			if style != "" {
+				idx, ok := indexForName(simplerSlicingStyles, style)
+				if !ok {
+					return SimplerState{}, fmt.Errorf("invalid style %q; use one of: %s", style, strings.Join(simplerSlicingStyles, ", "))
+				}
+				if err := sendSimplerSet(client, input.TrackIndex, input.DeviceIndex, "slicing_style", idx); err != nil {
+					return SimplerState{}, err
+				}
+			}
+			if bd != "" {
+				idx, ok := indexForName(simplerBeatDivisions, bd)
+				if !ok {
+					return SimplerState{}, fmt.Errorf("invalid beat_division %q; use one of: %s", bd, strings.Join(simplerBeatDivisions, ", "))
+				}
+				if err := sendSimplerSet(client, input.TrackIndex, input.DeviceIndex, "slicing_beat_division", idx); err != nil {
+					return SimplerState{}, err
+				}
+			}
+			return getSimplerState(client, input.TrackIndex, input.DeviceIndex)
+		},
+	)
+}
+
+type GetSimplerSlicesInput struct {
+	TrackIndex  int `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex int `json:"device_index" jsonschema:"minimum=0"`
+}
+
+type SimplerSlice struct {
+	Index       int     `json:"index"`
+	StartSample int     `json:"start_sample"`
+	StartSec    float64 `json:"start_sec"`
+	Note        int     `json:"note" jsonschema:"description=Default C1-based MIDI note (36 + index); Live's slice-to-note mapping in Slicing mode"`
+}
+
+type SimplerSlicesOutput struct {
+	TrackIndex   int            `json:"track_index"`
+	DeviceIndex  int            `json:"device_index"`
+	SampleRate   int            `json:"sample_rate"`
+	SampleLength int            `json:"sample_length"`
+	LengthSec    float64        `json:"length_sec"`
+	Slices       []SimplerSlice `json:"slices"`
+}
+
+func parseSimplerSlices(res []interface{}) (SimplerSlicesOutput, error) {
+	if err := ensureResponseLen(res, 3); err != nil {
+		return SimplerSlicesOutput{}, err
+	}
+	track, err := abletonosc.AsInt(res[0])
+	if err != nil {
+		return SimplerSlicesOutput{}, fmt.Errorf("parse track_index: %w", err)
+	}
+	device, err := abletonosc.AsInt(res[1])
+	if err != nil {
+		return SimplerSlicesOutput{}, fmt.Errorf("parse device_index: %w", err)
+	}
+	status := fmt.Sprint(res[2])
+	if status != "ok" {
+		return SimplerSlicesOutput{TrackIndex: track, DeviceIndex: device}, simplerStatusError(status)
+	}
+	if err := ensureResponseLen(res, 5); err != nil {
+		return SimplerSlicesOutput{}, err
+	}
+	sampleRate, _ := abletonosc.AsInt(res[3])
+	sampleLength, _ := abletonosc.AsInt(res[4])
+	out := SimplerSlicesOutput{
+		TrackIndex:   track,
+		DeviceIndex:  device,
+		SampleRate:   sampleRate,
+		SampleLength: sampleLength,
+	}
+	if sampleRate > 0 {
+		out.LengthSec = float64(sampleLength) / float64(sampleRate)
+	}
+	for i, raw := range res[5:] {
+		startSample, err := abletonosc.AsInt(raw)
+		if err != nil {
+			continue
+		}
+		slice := SimplerSlice{Index: i, StartSample: startSample, Note: 36 + i}
+		if sampleRate > 0 {
+			slice.StartSec = float64(startSample) / float64(sampleRate)
+		}
+		out.Slices = append(out.Slices, slice)
+	}
+	return out, nil
+}
+
+func NewAbletonGetSimplerSlices(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_simpler_slices",
+		"Ableton Live: get the Simpler slice map (start position in samples and seconds per slice, plus default C1-based MIDI note); requires a sliced sample and the browser patch",
+		func(_ *ai.ToolContext, input GetSimplerSlicesInput) (SimplerSlicesOutput, error) {
+			if input.TrackIndex < 0 || input.DeviceIndex < 0 {
+				return SimplerSlicesOutput{}, errors.New("track_index and device_index must be >= 0")
+			}
+			res, err := client.QueryWithTimeout(3*time.Second, "/live/device/simpler/get/slices",
+				int32(input.TrackIndex), int32(input.DeviceIndex))
+			if err != nil {
+				return SimplerSlicesOutput{}, fmt.Errorf("get simpler slices failed (browser patch required): %w", err)
+			}
+			return parseSimplerSlices(res)
+		},
+	)
+}

--- a/internal/tools/ableton_simpler_test.go
+++ b/internal/tools/ableton_simpler_test.go
@@ -1,0 +1,110 @@
+package tools
+
+import "testing"
+
+func TestIndexForName(t *testing.T) {
+	if idx, ok := indexForName(simplerPlaybackModes, "slicing"); !ok || idx != 2 {
+		t.Errorf("slicing = (%d,%v), want (2,true)", idx, ok)
+	}
+	if idx, ok := indexForName(simplerPlaybackModes, "SLICING"); !ok || idx != 2 {
+		t.Errorf("case-insensitive SLICING = (%d,%v), want (2,true)", idx, ok)
+	}
+	if idx, ok := indexForName(simplerPlaybackModes, "1"); !ok || idx != 1 {
+		t.Errorf("numeric '1' = (%d,%v), want (1,true)", idx, ok)
+	}
+	if _, ok := indexForName(simplerPlaybackModes, "nope"); ok {
+		t.Error("unknown name should not resolve")
+	}
+	if _, ok := indexForName(simplerPlaybackModes, "9"); ok {
+		t.Error("out-of-range numeric should not resolve")
+	}
+	if idx, ok := indexForName(simplerBeatDivisions, "1 Bar"); !ok || idx != 8 {
+		t.Errorf("'1 Bar' = (%d,%v), want (8,true)", idx, ok)
+	}
+}
+
+func TestParseSimplerStateOK(t *testing.T) {
+	// track, device, ok, playback=2(slicing), slicing_playback=1(poly),
+	// slicing_style=1(beat), beat_division=4(1/4), num_slices=8, has_sample=1
+	res := []interface{}{int32(6), int32(0), "ok", int32(2), int32(1), int32(1), int32(4), int32(8), int32(1)}
+	st, err := parseSimplerState(res)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if st.PlaybackMode != 2 || st.PlaybackModeName != "slicing" {
+		t.Errorf("playback = %d/%q, want 2/slicing", st.PlaybackMode, st.PlaybackModeName)
+	}
+	if st.SlicingPlaybackModeName != "poly" {
+		t.Errorf("slicing_playback_name = %q, want poly", st.SlicingPlaybackModeName)
+	}
+	if st.SlicingStyle == nil || *st.SlicingStyle != 1 || st.SlicingStyleName != "beat" {
+		t.Errorf("slicing_style = %v/%q, want 1/beat", st.SlicingStyle, st.SlicingStyleName)
+	}
+	if st.SlicingBeatDivision == nil || *st.SlicingBeatDivision != 4 || st.SlicingBeatDivisionName != "1/4" {
+		t.Errorf("beat_division = %v/%q, want 4/'1/4'", st.SlicingBeatDivision, st.SlicingBeatDivisionName)
+	}
+	if st.NumSlices != 8 || !st.HasSample {
+		t.Errorf("num_slices/has_sample = %d/%v, want 8/true", st.NumSlices, st.HasSample)
+	}
+}
+
+func TestParseSimplerStateNoSample(t *testing.T) {
+	// has_sample=0, slicing_style/beat_division = -1 (should be omitted → nil)
+	res := []interface{}{int32(6), int32(0), "ok", int32(0), int32(0), int32(-1), int32(-1), int32(0), int32(0)}
+	st, err := parseSimplerState(res)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if st.PlaybackModeName != "classic" {
+		t.Errorf("playback_name = %q, want classic", st.PlaybackModeName)
+	}
+	if st.SlicingStyle != nil {
+		t.Errorf("slicing_style = %v, want nil when no sample", st.SlicingStyle)
+	}
+	if st.SlicingBeatDivision != nil {
+		t.Errorf("beat_division = %v, want nil when no sample", st.SlicingBeatDivision)
+	}
+	if st.HasSample {
+		t.Error("has_sample = true, want false")
+	}
+}
+
+func TestParseSimplerStateNotSimpler(t *testing.T) {
+	res := []interface{}{int32(3), int32(1), "not_simpler"}
+	_, err := parseSimplerState(res)
+	if err == nil {
+		t.Fatal("expected error for not_simpler, got nil")
+	}
+}
+
+func TestParseSimplerSlices(t *testing.T) {
+	// track, device, ok, sample_rate=44100, sample_length=88200, slices at 0, 22050, 44100
+	res := []interface{}{int32(6), int32(0), "ok", int32(44100), int32(88200), int32(0), int32(22050), int32(44100)}
+	out, err := parseSimplerSlices(res)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.SampleRate != 44100 || out.SampleLength != 88200 {
+		t.Errorf("rate/length = %d/%d, want 44100/88200", out.SampleRate, out.SampleLength)
+	}
+	if out.LengthSec != 2.0 {
+		t.Errorf("length_sec = %v, want 2.0", out.LengthSec)
+	}
+	if len(out.Slices) != 3 {
+		t.Fatalf("slices len = %d, want 3", len(out.Slices))
+	}
+	if out.Slices[1].StartSample != 22050 || out.Slices[1].StartSec != 0.5 {
+		t.Errorf("slice[1] = %d/%v, want 22050/0.5", out.Slices[1].StartSample, out.Slices[1].StartSec)
+	}
+	if out.Slices[0].Note != 36 || out.Slices[2].Note != 38 {
+		t.Errorf("notes = %d..%d, want 36..38", out.Slices[0].Note, out.Slices[2].Note)
+	}
+}
+
+func TestParseSimplerSlicesNoSample(t *testing.T) {
+	res := []interface{}{int32(6), int32(0), "no_sample"}
+	_, err := parseSimplerSlices(res)
+	if err == nil {
+		t.Fatal("expected error for no_sample, got nil")
+	}
+}

--- a/internal/tools/ableton_slice_preset.go
+++ b/internal/tools/ableton_slice_preset.go
@@ -1,0 +1,275 @@
+package tools
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+const slicePresetVersion = 1
+
+// SlicePreset captures a Simpler's manual slice map plus the slicing/playback
+// context, so a chop can be reproduced later on the same sample.
+type SlicePreset struct {
+	Version             int       `json:"version"`
+	Name                string    `json:"name"`
+	SampleRate          int       `json:"sample_rate"`
+	SampleLength        int       `json:"sample_length"`
+	PlaybackMode        int       `json:"playback_mode"`
+	SlicingStyle        int       `json:"slicing_style"`
+	SlicingBeatDivision int       `json:"slicing_beat_division"`
+	Slices              []int     `json:"slices"`
+	SavedAt             time.Time `json:"saved_at"`
+}
+
+var slicePresetNameSanitize = regexp.MustCompile(`[^a-zA-Z0-9_.\- ]+`)
+
+func slicePresetDir() string {
+	dir, err := os.UserConfigDir()
+	if err != nil || dir == "" {
+		dir = os.TempDir()
+	}
+	return filepath.Join(dir, "ableton-osc-mcp", "slice-presets")
+}
+
+func slicePresetPath(name string) (string, error) {
+	clean := strings.TrimSpace(name)
+	if clean == "" {
+		return "", errors.New("preset name is required")
+	}
+	clean = slicePresetNameSanitize.ReplaceAllString(clean, "_")
+	return filepath.Join(slicePresetDir(), clean+".json"), nil
+}
+
+func writeSlicePreset(path string, preset SlicePreset) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create slice preset dir: %w", err)
+	}
+	data, err := json.MarshalIndent(preset, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode slice preset: %w", err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}
+
+func readSlicePreset(path string) (SlicePreset, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return SlicePreset{}, fmt.Errorf("slice preset not found: %s", strings.TrimSuffix(filepath.Base(path), ".json"))
+	}
+	if err != nil {
+		return SlicePreset{}, fmt.Errorf("read slice preset: %w", err)
+	}
+	var p SlicePreset
+	if err := json.Unmarshal(data, &p); err != nil {
+		return SlicePreset{}, fmt.Errorf("parse slice preset: %w", err)
+	}
+	if p.Version != slicePresetVersion {
+		return SlicePreset{}, fmt.Errorf("unsupported slice preset version: %d", p.Version)
+	}
+	return p, nil
+}
+
+func sliceStartSamples(slices []SimplerSlice) []int {
+	out := make([]int, 0, len(slices))
+	for _, s := range slices {
+		out = append(out, s.StartSample)
+	}
+	return out
+}
+
+func derefIntOr(p *int, def int) int {
+	if p != nil {
+		return *p
+	}
+	return def
+}
+
+// sendSimplerSetSlices replaces the Simpler's manual slices with the given
+// sample-frame positions via the browser patch. Returns the resulting count.
+func sendSimplerSetSlices(client *abletonosc.Client, track, device int, slices []int) (int, error) {
+	args := []interface{}{int32(track), int32(device)}
+	for _, s := range slices {
+		args = append(args, int32(s))
+	}
+	res, err := client.QueryWithTimeout(5*time.Second, "/live/device/simpler/set/slices", args...)
+	if err != nil {
+		return 0, fmt.Errorf("set slices failed (browser patch required): %w", err)
+	}
+	if err := ensureResponseLen(res, 3); err != nil {
+		return 0, err
+	}
+	status := fmt.Sprint(res[2])
+	if status != "ok" {
+		if status == "error" && len(res) > 4 {
+			return 0, fmt.Errorf("set slices failed at %s: %s", fmt.Sprint(res[3]), fmt.Sprint(res[4]))
+		}
+		return 0, simplerStatusError(status)
+	}
+	num := 0
+	if len(res) > 3 {
+		num, _ = abletonosc.AsInt(res[3])
+	}
+	return num, nil
+}
+
+type SaveSlicePresetInput struct {
+	TrackIndex  int    `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex int    `json:"device_index" jsonschema:"minimum=0"`
+	Name        string `json:"name" jsonschema:"description=Preset name (stored as JSON under the app config dir)"`
+}
+
+type SlicePresetOutput struct {
+	Name         string `json:"name"`
+	Path         string `json:"path"`
+	NumSlices    int    `json:"num_slices"`
+	SampleRate   int    `json:"sample_rate"`
+	SampleLength int    `json:"sample_length"`
+	Note         string `json:"note,omitempty"`
+}
+
+func NewAbletonSaveSlicePreset(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_save_slice_preset",
+		"Ableton Live: save a Simpler's slice map (slice points in sample frames + slicing/playback modes) to a reusable JSON preset under the app config dir. Reproduce later on the same sample with ableton_load_slice_preset. Requires the browser patch",
+		func(_ *ai.ToolContext, input SaveSlicePresetInput) (SlicePresetOutput, error) {
+			if input.TrackIndex < 0 || input.DeviceIndex < 0 {
+				return SlicePresetOutput{}, errors.New("track_index and device_index must be >= 0")
+			}
+			path, err := slicePresetPath(input.Name)
+			if err != nil {
+				return SlicePresetOutput{}, err
+			}
+			res, err := client.QueryWithTimeout(3*time.Second, "/live/device/simpler/get/slices",
+				int32(input.TrackIndex), int32(input.DeviceIndex))
+			if err != nil {
+				return SlicePresetOutput{}, fmt.Errorf("get simpler slices failed (browser patch required): %w", err)
+			}
+			slicesOut, err := parseSimplerSlices(res)
+			if err != nil {
+				return SlicePresetOutput{}, err
+			}
+			state, err := getSimplerState(client, input.TrackIndex, input.DeviceIndex)
+			if err != nil {
+				return SlicePresetOutput{}, err
+			}
+			preset := SlicePreset{
+				Version:             slicePresetVersion,
+				Name:                strings.TrimSpace(input.Name),
+				SampleRate:          slicesOut.SampleRate,
+				SampleLength:        slicesOut.SampleLength,
+				PlaybackMode:        state.PlaybackMode,
+				SlicingStyle:        derefIntOr(state.SlicingStyle, 3),
+				SlicingBeatDivision: derefIntOr(state.SlicingBeatDivision, -1),
+				Slices:              sliceStartSamples(slicesOut.Slices),
+				SavedAt:             time.Now().UTC(),
+			}
+			if len(preset.Slices) == 0 {
+				return SlicePresetOutput{}, errors.New("no slices to save (slice the sample first, or check the Simpler is in a sliced state)")
+			}
+			if err := writeSlicePreset(path, preset); err != nil {
+				return SlicePresetOutput{}, err
+			}
+			return SlicePresetOutput{
+				Name:         preset.Name,
+				Path:         path,
+				NumSlices:    len(preset.Slices),
+				SampleRate:   preset.SampleRate,
+				SampleLength: preset.SampleLength,
+			}, nil
+		},
+	)
+}
+
+type LoadSlicePresetInput struct {
+	TrackIndex  int    `json:"track_index" jsonschema:"minimum=0"`
+	DeviceIndex int    `json:"device_index" jsonschema:"minimum=0"`
+	Name        string `json:"name" jsonschema:"description=Preset name to restore"`
+	Force       *bool  `json:"force,omitempty" jsonschema:"description=Apply even if the loaded sample length differs from the preset (default false)"`
+}
+
+func NewAbletonLoadSlicePreset(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_load_slice_preset",
+		"Ableton Live: restore a saved slice preset onto a Simpler (switches to Manual slicing and re-inserts the saved slice points). Guards against a mismatched sample by length unless force=true. Requires the browser patch. Returns the resulting Simpler state",
+		func(_ *ai.ToolContext, input LoadSlicePresetInput) (SimplerState, error) {
+			if input.TrackIndex < 0 || input.DeviceIndex < 0 {
+				return SimplerState{}, errors.New("track_index and device_index must be >= 0")
+			}
+			path, err := slicePresetPath(input.Name)
+			if err != nil {
+				return SimplerState{}, err
+			}
+			preset, err := readSlicePreset(path)
+			if err != nil {
+				return SimplerState{}, err
+			}
+			if len(preset.Slices) == 0 {
+				return SimplerState{}, errors.New("preset has no slices")
+			}
+			force := input.Force != nil && *input.Force
+			if !force {
+				res, err := client.QueryWithTimeout(3*time.Second, "/live/device/simpler/get/slices",
+					int32(input.TrackIndex), int32(input.DeviceIndex))
+				if err != nil {
+					return SimplerState{}, fmt.Errorf("get simpler slices failed (browser patch required): %w", err)
+				}
+				current, err := parseSimplerSlices(res)
+				if err != nil {
+					return SimplerState{}, err
+				}
+				if preset.SampleLength > 0 && current.SampleLength > 0 && preset.SampleLength != current.SampleLength {
+					return SimplerState{}, fmt.Errorf("loaded sample length %d != preset %d; load the same sample or set force=true", current.SampleLength, preset.SampleLength)
+				}
+			}
+			if _, err := sendSimplerSetSlices(client, input.TrackIndex, input.DeviceIndex, preset.Slices); err != nil {
+				return SimplerState{}, err
+			}
+			// Restore playback mode so a slicing preset plays as slices again.
+			if err := sendSimplerSet(client, input.TrackIndex, input.DeviceIndex, "playback_mode", preset.PlaybackMode); err != nil {
+				return SimplerState{}, err
+			}
+			return getSimplerState(client, input.TrackIndex, input.DeviceIndex)
+		},
+	)
+}
+
+type ListSlicePresetsOutput struct {
+	Dir     string   `json:"dir"`
+	Presets []string `json:"presets"`
+}
+
+func NewAbletonListSlicePresets(g *genkit.Genkit) ai.Tool {
+	return genkit.DefineTool(g, "ableton_list_slice_presets",
+		"Ableton Live: list saved slice presets (names) available for ableton_load_slice_preset.",
+		func(_ *ai.ToolContext, _ struct{}) (ListSlicePresetsOutput, error) {
+			dir := slicePresetDir()
+			out := ListSlicePresetsOutput{Dir: dir, Presets: []string{}}
+			entries, err := os.ReadDir(dir)
+			if errors.Is(err, os.ErrNotExist) {
+				return out, nil
+			}
+			if err != nil {
+				return ListSlicePresetsOutput{}, fmt.Errorf("read slice preset dir: %w", err)
+			}
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+					continue
+				}
+				out.Presets = append(out.Presets, strings.TrimSuffix(e.Name(), ".json"))
+			}
+			sort.Strings(out.Presets)
+			return out, nil
+		},
+	)
+}

--- a/internal/tools/ableton_slice_preset_test.go
+++ b/internal/tools/ableton_slice_preset_test.go
@@ -1,0 +1,86 @@
+package tools
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSlicePresetPathSanitize(t *testing.T) {
+	p, err := slicePresetPath("my chop/../evil*name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	base := filepath.Base(p)
+	if base != "my chop_.._evil_name.json" {
+		t.Errorf("sanitized base = %q", base)
+	}
+	if _, err := slicePresetPath("   "); err == nil {
+		t.Error("empty name should error")
+	}
+}
+
+func TestSlicePresetRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chop.json")
+	in := SlicePreset{
+		Version:             slicePresetVersion,
+		Name:                "chop",
+		SampleRate:          44100,
+		SampleLength:        88200,
+		PlaybackMode:        2,
+		SlicingStyle:        3,
+		SlicingBeatDivision: -1,
+		Slices:              []int{0, 22050, 44100},
+		SavedAt:             time.Now().UTC().Truncate(time.Second),
+	}
+	if err := writeSlicePreset(path, in); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := readSlicePreset(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got.SampleLength != in.SampleLength || len(got.Slices) != 3 || got.Slices[2] != 44100 {
+		t.Errorf("round trip mismatch: %+v", got)
+	}
+	if got.PlaybackMode != 2 || got.SlicingStyle != 3 {
+		t.Errorf("modes mismatch: playback=%d style=%d", got.PlaybackMode, got.SlicingStyle)
+	}
+}
+
+func TestReadSlicePresetMissing(t *testing.T) {
+	_, err := readSlicePreset(filepath.Join(t.TempDir(), "nope.json"))
+	if err == nil {
+		t.Fatal("expected error for missing preset")
+	}
+}
+
+func TestReadSlicePresetBadVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "old.json")
+	if err := writeSlicePreset(path, SlicePreset{Version: 999, Slices: []int{0}}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := readSlicePreset(path); err == nil {
+		t.Fatal("expected unsupported version error")
+	}
+}
+
+func TestSliceStartSamples(t *testing.T) {
+	slices := []SimplerSlice{{StartSample: 0}, {StartSample: 100}, {StartSample: 250}}
+	got := sliceStartSamples(slices)
+	if len(got) != 3 || got[1] != 100 || got[2] != 250 {
+		t.Errorf("sliceStartSamples = %v", got)
+	}
+}
+
+func TestDerefIntOr(t *testing.T) {
+	v := 7
+	if got := derefIntOr(&v, 3); got != 7 {
+		t.Errorf("derefIntOr(&7,3) = %d, want 7", got)
+	}
+	if got := derefIntOr(nil, 3); got != 3 {
+		t.Errorf("derefIntOr(nil,3) = %d, want 3", got)
+	}
+}

--- a/internal/tools/ableton_sounding.go
+++ b/internal/tools/ableton_sounding.go
@@ -1,0 +1,199 @@
+package tools
+
+import (
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+// SoundingDevice is a device in the track chain (name + class for resume anchors).
+type SoundingDevice struct {
+	Index     int    `json:"index"`
+	Name      string `json:"name"`
+	ClassName string `json:"class_name,omitempty"`
+}
+
+// SoundingTrack is one track's mute/solo/playing state, device chain, and clip presence.
+type SoundingTrack struct {
+	Index             int              `json:"index"`
+	Name              string           `json:"name"`
+	Mute              bool             `json:"mute"`
+	Solo              bool             `json:"solo"`
+	PlayingSlotIndex  int              `json:"playing_slot_index" jsonschema:"description=-1 when nothing is playing on this track"`
+	Devices           []SoundingDevice `json:"devices"`
+	ClipSlotsOccupied []int            `json:"clip_slots_occupied" jsonschema:"description=Scene indices that currently have a clip"`
+}
+
+type SoundingSnapshotOutput struct {
+	TempoBPM  float64          `json:"tempo_bpm"`
+	IsPlaying bool             `json:"is_playing"`
+	Scenes    []SceneNameEntry `json:"scenes"`
+	Tracks    []SoundingTrack  `json:"tracks"`
+}
+
+type soundingQuerier interface {
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+// parseTrackDataBlock unpacks a flat /live/song/get/track_data reply for:
+// track.name, track.mute, track.solo, track.playing_slot_index, clip_slot.has_clip
+// Layout per track: name, mute, solo, playing_slot, then numScenes has_clip bools.
+func parseTrackDataBlock(values []interface{}, numTracks, numScenes int) ([]SoundingTrack, error) {
+	need := numTracks * (4 + numScenes)
+	if len(values) < need {
+		return nil, fmt.Errorf("track_data too short: got %d want >= %d (tracks=%d scenes=%d)", len(values), need, numTracks, numScenes)
+	}
+	tracks := make([]SoundingTrack, 0, numTracks)
+	i := 0
+	for t := 0; t < numTracks; t++ {
+		name := fmt.Sprint(values[i])
+		i++
+		mute, err := abletonosc.AsBool(values[i])
+		if err != nil {
+			return nil, fmt.Errorf("track %d mute: %w", t, err)
+		}
+		i++
+		solo, err := abletonosc.AsBool(values[i])
+		if err != nil {
+			return nil, fmt.Errorf("track %d solo: %w", t, err)
+		}
+		i++
+		playing, err := abletonosc.AsInt(values[i])
+		if err != nil {
+			return nil, fmt.Errorf("track %d playing_slot: %w", t, err)
+		}
+		i++
+		occupied := make([]int, 0)
+		for s := 0; s < numScenes; s++ {
+			has, err := abletonosc.AsBool(values[i])
+			if err != nil {
+				return nil, fmt.Errorf("track %d scene %d has_clip: %w", t, s, err)
+			}
+			i++
+			if has {
+				occupied = append(occupied, s)
+			}
+		}
+		tracks = append(tracks, SoundingTrack{
+			Index:             t,
+			Name:              name,
+			Mute:              mute,
+			Solo:              solo,
+			PlayingSlotIndex:  playing,
+			Devices:           []SoundingDevice{},
+			ClipSlotsOccupied: occupied,
+		})
+	}
+	return tracks, nil
+}
+
+func getSoundingSnapshot(client soundingQuerier) (SoundingSnapshotOutput, error) {
+	tempoRes, err := client.Query("/live/song/get/tempo")
+	if err != nil {
+		return SoundingSnapshotOutput{}, fmt.Errorf("get tempo: %w", err)
+	}
+	if err := ensureResponseLen(tempoRes, 1); err != nil {
+		return SoundingSnapshotOutput{}, err
+	}
+	tempo, err := abletonosc.AsFloat64(tempoRes[0])
+	if err != nil {
+		return SoundingSnapshotOutput{}, err
+	}
+
+	playingRes, err := client.Query("/live/song/get/is_playing")
+	if err != nil {
+		return SoundingSnapshotOutput{}, fmt.Errorf("get is_playing: %w", err)
+	}
+	if err := ensureResponseLen(playingRes, 1); err != nil {
+		return SoundingSnapshotOutput{}, err
+	}
+	isPlaying, err := abletonosc.AsBool(playingRes[0])
+	if err != nil {
+		return SoundingSnapshotOutput{}, err
+	}
+
+	numTracks, err := queryNumTracks(client)
+	if err != nil {
+		return SoundingSnapshotOutput{}, fmt.Errorf("get num tracks: %w", err)
+	}
+	numScenes, err := queryNumScenes(client)
+	if err != nil {
+		return SoundingSnapshotOutput{}, fmt.Errorf("get num scenes: %w", err)
+	}
+
+	sceneNames, err := querySceneNames(client)
+	if err != nil {
+		return SoundingSnapshotOutput{}, fmt.Errorf("get scene names: %w", err)
+	}
+	scenes := make([]SceneNameEntry, 0, len(sceneNames))
+	for i, n := range sceneNames {
+		scenes = append(scenes, SceneNameEntry{Index: i, Name: n})
+	}
+
+	out := SoundingSnapshotOutput{
+		TempoBPM:  tempo,
+		IsPlaying: isPlaying,
+		Scenes:    scenes,
+		Tracks:    []SoundingTrack{},
+	}
+	if numTracks == 0 {
+		return out, nil
+	}
+
+	// Bulk: name/mute/solo/playing + has_clip grid. clip_slot count equals scene count in Session view.
+	dataRes, err := client.Query(
+		"/live/song/get/track_data",
+		int32(0), int32(-1),
+		"track.name", "track.mute", "track.solo", "track.playing_slot_index", "clip_slot.has_clip",
+	)
+	if err != nil {
+		return SoundingSnapshotOutput{}, fmt.Errorf("get track_data: %w", err)
+	}
+	tracks, err := parseTrackDataBlock(dataRes, numTracks, numScenes)
+	if err != nil {
+		return SoundingSnapshotOutput{}, err
+	}
+
+	for t := range tracks {
+		namesRes, err := client.Query("/live/track/get/devices/name", int32(t))
+		if err != nil {
+			return SoundingSnapshotOutput{}, fmt.Errorf("get devices name track %d: %w", t, err)
+		}
+		classRes, err := client.Query("/live/track/get/devices/class_name", int32(t))
+		if err != nil {
+			return SoundingSnapshotOutput{}, fmt.Errorf("get devices class track %d: %w", t, err)
+		}
+		if err := ensureResponseLen(namesRes, 1); err != nil {
+			return SoundingSnapshotOutput{}, err
+		}
+		names := toStringSlice(namesRes[1:])
+		classes := []string{}
+		if len(classRes) > 1 {
+			classes = toStringSlice(classRes[1:])
+		}
+		devs := make([]SoundingDevice, 0, len(names))
+		for i, n := range names {
+			d := SoundingDevice{Index: i, Name: n}
+			if i < len(classes) {
+				d.ClassName = classes[i]
+			}
+			devs = append(devs, d)
+		}
+		tracks[t].Devices = devs
+	}
+
+	out.Tracks = tracks
+	return out, nil
+}
+
+func NewAbletonGetSoundingSnapshot(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_get_sounding_snapshot",
+		"Ableton Live: conversation-resume anchor — tempo, playback, scene names, and per-track mute/solo/playing slot, device chain, and which scenes currently have clips. Prefer this over ableton_get_session_snapshot when you need to know what is actually set up to sound.",
+		func(_ *ai.ToolContext, _ struct{}) (SoundingSnapshotOutput, error) {
+			return getSoundingSnapshot(client)
+		},
+	)
+}

--- a/internal/tools/ableton_sounding_test.go
+++ b/internal/tools/ableton_sounding_test.go
@@ -1,0 +1,68 @@
+package tools
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseTrackDataBlock(t *testing.T) {
+	// 2 tracks, 2 scenes:
+	// per track: name, mute, solo, playing, has0, has1
+	values := []interface{}{
+		"Drums", true, false, int32(0), true, false,
+		"Bass", false, true, int32(-1), true, true,
+	}
+	got, err := parseTrackDataBlock(values, 2, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got[0].Name != "Drums" || !got[0].Mute || got[0].Solo || got[0].PlayingSlotIndex != 0 {
+		t.Errorf("track0 = %+v", got[0])
+	}
+	if !reflect.DeepEqual(got[0].ClipSlotsOccupied, []int{0}) {
+		t.Errorf("track0 occupied = %v", got[0].ClipSlotsOccupied)
+	}
+	if got[1].Name != "Bass" || got[1].Mute || !got[1].Solo || got[1].PlayingSlotIndex != -1 {
+		t.Errorf("track1 = %+v", got[1])
+	}
+	if !reflect.DeepEqual(got[1].ClipSlotsOccupied, []int{0, 1}) {
+		t.Errorf("track1 occupied = %v", got[1].ClipSlotsOccupied)
+	}
+}
+
+func TestParseTrackDataBlockTooShort(t *testing.T) {
+	if _, err := parseTrackDataBlock([]interface{}{"Drums"}, 2, 2); err == nil {
+		t.Fatal("expected error for short payload")
+	}
+}
+
+func TestGetSoundingSnapshot(t *testing.T) {
+	client := snapshotQuerierStub{results: map[string]snapshotQueryResult{
+		"/live/song/get/tempo":       {values: []interface{}{float32(90)}},
+		"/live/song/get/is_playing":  {values: []interface{}{false}},
+		"/live/song/get/num_tracks":  {values: []interface{}{int32(1)}},
+		"/live/song/get/num_scenes":  {values: []interface{}{int32(1)}},
+		"/live/song/get/scenes/name": {values: []interface{}{"Intro"}},
+		"/live/song/get/track_data": {values: []interface{}{
+			"Drums", false, false, int32(-1), true,
+		}},
+		"/live/track/get/devices/name":       {values: []interface{}{int32(0), "Boom Bap Kit"}},
+		"/live/track/get/devices/class_name": {values: []interface{}{int32(0), "DrumGroupDevice"}},
+	}}
+	got, err := getSoundingSnapshot(client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.TempoBPM != 90 || got.IsPlaying || len(got.Scenes) != 1 || got.Scenes[0].Name != "Intro" {
+		t.Errorf("header = %+v", got)
+	}
+	if len(got.Tracks) != 1 || got.Tracks[0].Name != "Drums" {
+		t.Fatalf("tracks = %+v", got.Tracks)
+	}
+	if len(got.Tracks[0].Devices) != 1 || got.Tracks[0].Devices[0].ClassName != "DrumGroupDevice" {
+		t.Errorf("devices = %+v", got.Tracks[0].Devices)
+	}
+	if !reflect.DeepEqual(got.Tracks[0].ClipSlotsOccupied, []int{0}) {
+		t.Errorf("occupied = %v", got.Tracks[0].ClipSlotsOccupied)
+	}
+}

--- a/internal/tools/ableton_taste.go
+++ b/internal/tools/ableton_taste.go
@@ -13,8 +13,8 @@ import (
 )
 
 type RecordVariationPreferenceInput struct {
-	Instrument string `json:"instrument" jsonschema:"description=Comparison family: drum, bass, scene, or mix"`
-	Variation  string `json:"variation" jsonschema:"description=Variation that was compared (e.g. groove, lift, volume)"`
+	Instrument string `json:"instrument" jsonschema:"description=Comparison family: drum, bass, scene, mix, or fx"`
+	Variation  string `json:"variation" jsonschema:"description=Variation that was compared (e.g. groove, lift, volume, bypass)"`
 	Preferred  string `json:"preferred" jsonschema:"description=Which version you preferred: source or variation"`
 	Note       string `json:"note,omitempty" jsonschema:"description=Optional short reason for the choice (max 500 characters)"`
 }
@@ -47,11 +47,11 @@ type tasteStore interface {
 	Path() string
 }
 
-var tasteInstrumentOrder = []string{"bass", "drum", "mix", "scene"}
+var tasteInstrumentOrder = []string{"bass", "drum", "fx", "mix", "scene"}
 
 func NewAbletonRecordVariationPreference(g *genkit.Genkit, store tasteStore) ai.Tool {
 	return genkit.DefineTool(g, "ableton_record_variation_preference",
-		"Ableton Live: after an A/B listen, record whether source or variation matched your taste (drum, bass, scene, or mix) — usually follows ableton_compare_ab_variation or a mix compare",
+		"Ableton Live: after an A/B listen, record whether source or variation matched your taste (drum, bass, scene, mix, or fx) — usually follows ableton_compare_ab_variation, mix compare, or ableton_compare_fx_bypass",
 		func(_ *ai.ToolContext, input RecordVariationPreferenceInput) (TasteProfileOutput, error) {
 			preference, err := validateTastePreference(input)
 			if err != nil {
@@ -127,8 +127,12 @@ func validateTasteInstrumentVariation(instrument, variation string) error {
 		if !isMixVariation(variation) {
 			return errors.New("mix variation must be volume")
 		}
+	case "fx":
+		if !isFXVariation(variation) {
+			return errors.New("fx variation must be bypass")
+		}
 	default:
-		return errors.New("instrument must be drum, bass, scene, or mix")
+		return errors.New("instrument must be drum, bass, scene, mix, or fx")
 	}
 	return nil
 }
@@ -139,6 +143,10 @@ func isSceneVariation(variation string) bool {
 
 func isMixVariation(variation string) bool {
 	return variation == "volume"
+}
+
+func isFXVariation(variation string) bool {
+	return variation == "bypass"
 }
 
 func tasteProfileOutput(profile taste.Profile, path string) TasteProfileOutput {
@@ -230,6 +238,8 @@ func tasteVariationsFor(instrument string) []string {
 		return []string{"lift", "pullback"}
 	case "mix":
 		return []string{"volume"}
+	case "fx":
+		return []string{"bypass"}
 	default:
 		return nil
 	}

--- a/internal/tools/ableton_taste_test.go
+++ b/internal/tools/ableton_taste_test.go
@@ -84,8 +84,11 @@ func TestTasteProfileOutput(t *testing.T) {
 	if !strings.Contains(joined, "scene pullback") || !strings.Contains(joined, "mix volume") {
 		t.Errorf("NextSuggestions missing scene/mix = %v", got.NextSuggestions)
 	}
-	if len(got.NextSuggestions) != 4 {
-		t.Errorf("want 4 family suggestions, got %v", got.NextSuggestions)
+	if !strings.Contains(joined, "fx bypass") {
+		t.Errorf("NextSuggestions missing fx = %v", got.NextSuggestions)
+	}
+	if len(got.NextSuggestions) != 5 {
+		t.Errorf("want 5 family suggestions, got %v", got.NextSuggestions)
 	}
 }
 
@@ -96,11 +99,11 @@ func TestTasteProfileColdStartSuggestions(t *testing.T) {
 	if got.PreferencesRecorded != 0 {
 		t.Fatalf("PreferencesRecorded = %d", got.PreferencesRecorded)
 	}
-	if len(got.NextSuggestions) != 4 {
-		t.Fatalf("cold start suggestions = %v, want 4", got.NextSuggestions)
+	if len(got.NextSuggestions) != 5 {
+		t.Fatalf("cold start suggestions = %v, want 5", got.NextSuggestions)
 	}
 	joined := strings.Join(got.NextSuggestions, "\n")
-	for _, want := range []string{"bass groove", "drum density", "mix volume", "scene lift"} {
+	for _, want := range []string{"bass groove", "drum density", "fx bypass", "mix volume", "scene lift"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("cold start missing %q in %v", want, got.NextSuggestions)
 		}

--- a/internal/tools/ableton_track_ops.go
+++ b/internal/tools/ableton_track_ops.go
@@ -1,0 +1,281 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+
+	"github.com/nozomi-koborinai/ableton-osc-mcp/internal/abletonosc"
+)
+
+type DuplicateTrackForProcessingInput struct {
+	TrackIndex int    `json:"track_index" jsonschema:"description=Source track to duplicate,minimum=0"`
+	WetName    string `json:"wet_name,omitempty" jsonschema:"description=Name for the duplicated (processed/wet) track; default '<name> wet'"`
+	DrySuffix  string `json:"dry_suffix,omitempty" jsonschema:"description=If set, rename the original (dry) track by appending this, e.g. ' dry'"`
+}
+
+type DuplicateTrackForProcessingOutput struct {
+	DryIndex int    `json:"dry_index"`
+	DryName  string `json:"dry_name"`
+	WetIndex int    `json:"wet_index"`
+	WetName  string `json:"wet_name"`
+}
+
+type oscQuerier interface {
+	Query(address string, args ...interface{}) ([]interface{}, error)
+}
+
+type trackDupeClient interface {
+	Send(address string, args ...interface{}) error
+	Query(address string, args ...interface{}) ([]interface{}, error)
+	QueryWithTimeout(timeout time.Duration, address string, args ...interface{}) ([]interface{}, error)
+}
+
+func queryTrackName(client oscQuerier, trackIndex int) (string, error) {
+	res, err := client.Query("/live/track/get/name", int32(trackIndex))
+	if err != nil {
+		return "", err
+	}
+	if err := ensureResponseLen(res, 2); err != nil {
+		return "", err
+	}
+	return fmt.Sprint(res[1]), nil
+}
+
+func queryNumTracks(client oscQuerier) (int, error) {
+	res, err := client.Query("/live/song/get/num_tracks")
+	if err != nil {
+		return 0, err
+	}
+	if err := ensureResponseLen(res, 1); err != nil {
+		return 0, err
+	}
+	return abletonosc.AsInt(res[0])
+}
+
+// duplicateTrackForProcessing duplicates a track so the original stays dry and
+// the copy (inserted right after) becomes the processed/wet version. Both start
+// identical; the caller then adds/removes effects on one. Uses stock
+// /live/song/duplicate_track.
+func duplicateTrackForProcessing(client trackDupeClient, input DuplicateTrackForProcessingInput) (DuplicateTrackForProcessingOutput, error) {
+	if input.TrackIndex < 0 {
+		return DuplicateTrackForProcessingOutput{}, errors.New("track_index must be >= 0")
+	}
+	origName, err := queryTrackName(client, input.TrackIndex)
+	if err != nil {
+		return DuplicateTrackForProcessingOutput{}, fmt.Errorf("get track name: %w", err)
+	}
+	before, err := queryNumTracks(client)
+	if err != nil {
+		return DuplicateTrackForProcessingOutput{}, fmt.Errorf("get num tracks: %w", err)
+	}
+	if input.TrackIndex >= before {
+		return DuplicateTrackForProcessingOutput{}, fmt.Errorf("track_index %d out of range (%d tracks)", input.TrackIndex, before)
+	}
+
+	if err := client.Send("/live/song/duplicate_track", int32(input.TrackIndex)); err != nil {
+		return DuplicateTrackForProcessingOutput{}, fmt.Errorf("duplicate track: %w", err)
+	}
+
+	// duplicate_track is fire-and-forget; confirm a track was actually added.
+	after, err := queryNumTracks(client)
+	if err != nil {
+		return DuplicateTrackForProcessingOutput{}, fmt.Errorf("verify duplicate: %w", err)
+	}
+	if after != before+1 {
+		return DuplicateTrackForProcessingOutput{}, fmt.Errorf("duplicate did not add a track (before=%d after=%d)", before, after)
+	}
+
+	dryIndex := input.TrackIndex
+	wetIndex := input.TrackIndex + 1
+
+	wetName := strings.TrimSpace(input.WetName)
+	if wetName == "" {
+		wetName = strings.TrimSpace(origName + " wet")
+	}
+	if err := client.Send("/live/track/set/name", int32(wetIndex), wetName); err != nil {
+		return DuplicateTrackForProcessingOutput{}, fmt.Errorf("name wet track: %w", err)
+	}
+
+	dryName := origName
+	if suffix := input.DrySuffix; suffix != "" {
+		dryName = origName + suffix
+		if err := client.Send("/live/track/set/name", int32(dryIndex), dryName); err != nil {
+			return DuplicateTrackForProcessingOutput{}, fmt.Errorf("name dry track: %w", err)
+		}
+	}
+
+	return DuplicateTrackForProcessingOutput{
+		DryIndex: dryIndex,
+		DryName:  dryName,
+		WetIndex: wetIndex,
+		WetName:  wetName,
+	}, nil
+}
+
+func NewAbletonDuplicateTrackForProcessing(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_duplicate_track_for_processing",
+		"Ableton Live: duplicate a track into a dry/wet pair. The original stays as the dry track (optionally suffixed) and the copy right after it becomes the processed 'wet' track. Both start identical (same clips and devices) so you can process one; returns both indices and names.",
+		func(_ *ai.ToolContext, input DuplicateTrackForProcessingInput) (DuplicateTrackForProcessingOutput, error) {
+			return duplicateTrackForProcessing(client, input)
+		},
+	)
+}
+
+type DuplicateTrackInput struct {
+	TrackIndex int    `json:"track_index" jsonschema:"description=Track to duplicate; the copy is inserted immediately after,minimum=0"`
+	Name       string `json:"name,omitempty" jsonschema:"description=Optional name for the duplicated track"`
+}
+
+type DuplicateTrackOutput struct {
+	SourceIndex int    `json:"source_index"`
+	NewIndex    int    `json:"new_index"`
+	Name        string `json:"name"`
+	TracksAfter int    `json:"tracks_after"`
+}
+
+func NewAbletonDuplicateTrack(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_duplicate_track",
+		"Ableton Live: duplicate a track (clips + devices). The copy is inserted right after the source; confirms success via track count before/after.",
+		func(_ *ai.ToolContext, input DuplicateTrackInput) (DuplicateTrackOutput, error) {
+			if input.TrackIndex < 0 {
+				return DuplicateTrackOutput{}, errors.New("track_index must be >= 0")
+			}
+			before, err := queryNumTracks(client)
+			if err != nil {
+				return DuplicateTrackOutput{}, fmt.Errorf("get num tracks: %w", err)
+			}
+			if input.TrackIndex >= before {
+				return DuplicateTrackOutput{}, fmt.Errorf("track_index %d out of range (%d tracks)", input.TrackIndex, before)
+			}
+			if err := client.Send("/live/song/duplicate_track", int32(input.TrackIndex)); err != nil {
+				return DuplicateTrackOutput{}, fmt.Errorf("duplicate track: %w", err)
+			}
+			after, err := queryNumTracks(client)
+			if err != nil {
+				return DuplicateTrackOutput{}, fmt.Errorf("verify duplicate: %w", err)
+			}
+			if after != before+1 {
+				return DuplicateTrackOutput{}, fmt.Errorf("duplicate did not add a track (before=%d after=%d)", before, after)
+			}
+			newIndex := input.TrackIndex + 1
+			name := strings.TrimSpace(input.Name)
+			if name != "" {
+				if err := client.Send("/live/track/set/name", int32(newIndex), name); err != nil {
+					return DuplicateTrackOutput{}, fmt.Errorf("set track name: %w", err)
+				}
+			} else {
+				name, _ = queryTrackName(client, newIndex)
+			}
+			return DuplicateTrackOutput{
+				SourceIndex: input.TrackIndex,
+				NewIndex:    newIndex,
+				Name:        name,
+				TracksAfter: after,
+			}, nil
+		},
+	)
+}
+
+type DeleteTrackInput struct {
+	TrackIndex int  `json:"track_index" jsonschema:"description=Track to delete (destructive),minimum=0"`
+	Confirm    bool `json:"confirm,omitempty" jsonschema:"description=Must be true to execute; omit/false returns a preview error without deleting. Prefer ableton_preview_destructive first."`
+}
+
+type DeleteTrackOutput struct {
+	TrackIndex   int    `json:"track_index"`
+	Name         string `json:"name,omitempty"`
+	TracksBefore int    `json:"tracks_before"`
+	TracksAfter  int    `json:"tracks_after"`
+}
+
+func NewAbletonDeleteTrack(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_delete_track",
+		"Ableton Live: delete a track by index (destructive). Requires confirm=true. Without confirm, returns a preview. Confirms success via track count before/after. Prefer mute or dry/wet duplicate when you only need to park material.",
+		func(_ *ai.ToolContext, input DeleteTrackInput) (DeleteTrackOutput, error) {
+			if input.TrackIndex < 0 {
+				return DeleteTrackOutput{}, errors.New("track_index must be >= 0")
+			}
+			before, err := queryNumTracks(client)
+			if err != nil {
+				return DeleteTrackOutput{}, fmt.Errorf("get num tracks: %w", err)
+			}
+			if input.TrackIndex >= before {
+				return DeleteTrackOutput{}, fmt.Errorf("track_index %d out of range (%d tracks)", input.TrackIndex, before)
+			}
+			name, _ := queryTrackName(client, input.TrackIndex)
+			if err := requireConfirm(input.Confirm, "delete_track",
+				fmt.Sprintf("track %d %q (%d total tracks → %d)", input.TrackIndex, name, before, before-1)); err != nil {
+				return DeleteTrackOutput{}, err
+			}
+			if err := client.Send("/live/song/delete_track", int32(input.TrackIndex)); err != nil {
+				return DeleteTrackOutput{}, fmt.Errorf("delete track: %w", err)
+			}
+			after, err := queryNumTracks(client)
+			if err != nil {
+				return DeleteTrackOutput{}, fmt.Errorf("verify delete: %w", err)
+			}
+			if after != before-1 {
+				return DeleteTrackOutput{}, fmt.Errorf("delete did not remove a track (before=%d after=%d)", before, after)
+			}
+			return DeleteTrackOutput{
+				TrackIndex:   input.TrackIndex,
+				Name:         name,
+				TracksBefore: before,
+				TracksAfter:  after,
+			}, nil
+		},
+	)
+}
+
+type DeleteClipInput struct {
+	TrackIndex int  `json:"track_index" jsonschema:"minimum=0"`
+	ClipIndex  int  `json:"clip_index" jsonschema:"description=Scene/clip-slot index to clear,minimum=0"`
+	Confirm    bool `json:"confirm,omitempty" jsonschema:"description=Must be true to execute; omit/false returns a preview error without deleting"`
+}
+
+type DeleteClipOutput struct {
+	TrackIndex int  `json:"track_index"`
+	ClipIndex  int  `json:"clip_index"`
+	HadClip    bool `json:"had_clip"`
+	Deleted    bool `json:"deleted"`
+}
+
+func NewAbletonDeleteClip(g *genkit.Genkit, client *abletonosc.Client) ai.Tool {
+	return genkit.DefineTool(g, "ableton_delete_clip",
+		"Ableton Live: delete the clip in a clip slot (leaves the slot empty). Requires confirm=true when a clip is present. Confirms via has_clip before/after. Idempotent when the slot is already empty.",
+		func(_ *ai.ToolContext, input DeleteClipInput) (DeleteClipOutput, error) {
+			if err := validateTrackClipIndices(input.TrackIndex, input.ClipIndex); err != nil {
+				return DeleteClipOutput{}, err
+			}
+			had, err := slotHasClip(client, input.TrackIndex, input.ClipIndex)
+			if err != nil {
+				return DeleteClipOutput{}, fmt.Errorf("check has_clip: %w", err)
+			}
+			out := DeleteClipOutput{TrackIndex: input.TrackIndex, ClipIndex: input.ClipIndex, HadClip: had}
+			if !had {
+				return out, nil
+			}
+			if err := requireConfirm(input.Confirm, "delete_clip",
+				fmt.Sprintf("clip on track %d slot %d", input.TrackIndex, input.ClipIndex)); err != nil {
+				return DeleteClipOutput{}, err
+			}
+			if err := client.Send("/live/clip_slot/delete_clip", int32(input.TrackIndex), int32(input.ClipIndex)); err != nil {
+				return DeleteClipOutput{}, fmt.Errorf("delete clip: %w", err)
+			}
+			still, err := slotHasClip(client, input.TrackIndex, input.ClipIndex)
+			if err != nil {
+				return DeleteClipOutput{}, fmt.Errorf("verify delete: %w", err)
+			}
+			if still {
+				return DeleteClipOutput{}, errors.New("delete_clip did not clear the slot")
+			}
+			out.Deleted = true
+			return out, nil
+		},
+	)
+}

--- a/internal/tools/ableton_track_ops_test.go
+++ b/internal/tools/ableton_track_ops_test.go
@@ -1,0 +1,113 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeTrackClient simulates the OSC calls used by duplicateTrackForProcessing.
+type fakeTrackClient struct {
+	trackName          string
+	tracks             int
+	duplicateAddsTrack bool
+	sentNames          map[int]string
+	duplicatedFrom     int
+}
+
+func newFakeTrackClient(name string, tracks int) *fakeTrackClient {
+	return &fakeTrackClient{
+		trackName:          name,
+		tracks:             tracks,
+		duplicateAddsTrack: true,
+		sentNames:          map[int]string{},
+		duplicatedFrom:     -1,
+	}
+}
+
+func (f *fakeTrackClient) Send(address string, args ...interface{}) error {
+	switch address {
+	case "/live/song/duplicate_track":
+		f.duplicatedFrom = int(args[0].(int32))
+		if f.duplicateAddsTrack {
+			f.tracks++
+		}
+	case "/live/track/set/name":
+		f.sentNames[int(args[0].(int32))] = args[1].(string)
+	}
+	return nil
+}
+
+func (f *fakeTrackClient) Query(address string, args ...interface{}) ([]interface{}, error) {
+	switch address {
+	case "/live/track/get/name":
+		return []interface{}{args[0], f.trackName}, nil
+	case "/live/song/get/num_tracks":
+		return []interface{}{int32(f.tracks)}, nil
+	}
+	return nil, nil
+}
+
+func (f *fakeTrackClient) QueryWithTimeout(_ time.Duration, address string, args ...interface{}) ([]interface{}, error) {
+	return f.Query(address, args...)
+}
+
+func TestDuplicateTrackDefaults(t *testing.T) {
+	c := newFakeTrackClient("Piano", 7)
+	out, err := duplicateTrackForProcessing(c, DuplicateTrackForProcessingInput{TrackIndex: 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.DryIndex != 3 || out.WetIndex != 4 {
+		t.Errorf("indices = dry %d / wet %d, want 3/4", out.DryIndex, out.WetIndex)
+	}
+	if out.WetName != "Piano wet" {
+		t.Errorf("wet name = %q, want 'Piano wet'", out.WetName)
+	}
+	if out.DryName != "Piano" {
+		t.Errorf("dry name = %q, want unchanged 'Piano'", out.DryName)
+	}
+	if c.sentNames[4] != "Piano wet" {
+		t.Errorf("wet track not renamed: %v", c.sentNames)
+	}
+	if _, renamed := c.sentNames[3]; renamed {
+		t.Error("dry track should not be renamed without dry_suffix")
+	}
+}
+
+func TestDuplicateTrackWithDrySuffixAndCustomWet(t *testing.T) {
+	c := newFakeTrackClient("Chop", 5)
+	out, err := duplicateTrackForProcessing(c, DuplicateTrackForProcessingInput{
+		TrackIndex: 1,
+		WetName:    "Chop FX",
+		DrySuffix:  " dry",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.WetName != "Chop FX" || c.sentNames[2] != "Chop FX" {
+		t.Errorf("custom wet name not applied: out=%q sent=%v", out.WetName, c.sentNames)
+	}
+	if out.DryName != "Chop dry" || c.sentNames[1] != "Chop dry" {
+		t.Errorf("dry suffix not applied: out=%q sent=%v", out.DryName, c.sentNames)
+	}
+}
+
+func TestDuplicateTrackNoAddFails(t *testing.T) {
+	c := newFakeTrackClient("Piano", 7)
+	c.duplicateAddsTrack = false
+	_, err := duplicateTrackForProcessing(c, DuplicateTrackForProcessingInput{TrackIndex: 3})
+	if err == nil {
+		t.Fatal("expected error when duplicate does not add a track")
+	}
+	if !strings.Contains(err.Error(), "did not add") {
+		t.Errorf("error should explain the failure: %v", err)
+	}
+}
+
+func TestDuplicateTrackOutOfRange(t *testing.T) {
+	c := newFakeTrackClient("Piano", 4)
+	if _, err := duplicateTrackForProcessing(c, DuplicateTrackForProcessingInput{TrackIndex: 9}); err == nil {
+		t.Fatal("expected out-of-range error")
+	}
+}

--- a/internal/tools/ableton_variations.go
+++ b/internal/tools/ableton_variations.go
@@ -141,6 +141,7 @@ func createDrumVariation(client variationClient, input CreateDrumVariationInput)
 		"/live/clip_slot/duplicate_clip_to",
 		int32(input.TrackIndex),
 		int32(input.SourceClipIndex),
+		int32(input.TrackIndex),
 		int32(input.TargetClipIndex),
 	); err != nil {
 		return CreateDrumVariationOutput{}, fmt.Errorf("duplicate source clip: %w", err)

--- a/internal/tools/actionable_error.go
+++ b/internal/tools/actionable_error.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ActionableError is a structured failure with a concrete next manual step
+// for the agent/user when automation cannot finish the job.
+type ActionableError struct {
+	Code     string // stable machine-readable code, e.g. "unsupported_live_version"
+	Message  string // what failed
+	NextStep string // one concrete action a human (or agent) should take next
+}
+
+func (e *ActionableError) Error() string {
+	if e == nil {
+		return ""
+	}
+	var b strings.Builder
+	if e.Code != "" {
+		b.WriteString(e.Code)
+		b.WriteString(": ")
+	}
+	b.WriteString(e.Message)
+	if e.NextStep != "" {
+		b.WriteString(" | next: ")
+		b.WriteString(e.NextStep)
+	}
+	return b.String()
+}
+
+func actionable(code, message, next string) error {
+	return &ActionableError{Code: code, Message: message, NextStep: next}
+}
+
+// wrapActionable upgrades a plain error with a code and next step when the
+// underlying error is not already actionable.
+func wrapActionable(err error, code, next string) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := err.(*ActionableError); ok {
+		return err
+	}
+	return &ActionableError{Code: code, Message: err.Error(), NextStep: next}
+}
+
+func formatActionable(code, message, next string) string {
+	return actionable(code, message, next).Error()
+}
+
+// requireConfirm returns a preview-style actionable error when confirm is false.
+func requireConfirm(confirm bool, action string, summary string) error {
+	if confirm {
+		return nil
+	}
+	return actionable(
+		"confirm_required",
+		fmt.Sprintf("preview only — would %s: %s", action, summary),
+		fmt.Sprintf("Re-call with confirm=true to execute %s.", action),
+	)
+}

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 	toolList := []ai.Tool{
 		// Song / Transport
 		tools.NewAbletonTest(g, ableton),
+		tools.NewAbletonPreviewDestructive(g, ableton),
 		tools.NewAbletonDiagnose(g, ableton, tools.DiagnoseSettings{
 			Host:       cfg.AbletonHost,
 			Port:       cfg.AbletonPort,
@@ -69,6 +70,8 @@ func main() {
 		tools.NewAbletonGetTrackDevices(g, ableton),
 		tools.NewAbletonCreateMidiTrack(g, ableton),
 		tools.NewAbletonCreateAudioTrack(g, ableton),
+		tools.NewAbletonDuplicateTrack(g, ableton),
+		tools.NewAbletonDeleteTrack(g, ableton),
 		tools.NewAbletonSetTrackName(g, ableton),
 		tools.NewAbletonMuteTrack(g, ableton),
 		tools.NewAbletonSoloTrack(g, ableton),
@@ -77,6 +80,13 @@ func main() {
 		tools.NewAbletonGetTrackInputRouting(g, ableton),
 		tools.NewAbletonSetTrackInputRouting(g, ableton),
 		tools.NewAbletonSetMonitoring(g, ableton),
+		tools.NewAbletonDuplicateTrackForProcessing(g, ableton),
+		tools.NewAbletonGetReturnTracks(g, ableton),
+		tools.NewAbletonCreateReturnTrack(g, ableton),
+		tools.NewAbletonGetTrackSends(g, ableton),
+		tools.NewAbletonSetTrackSend(g, ableton),
+		tools.NewAbletonGetDeviceSidechain(g, ableton),
+		tools.NewAbletonSetDeviceSidechain(g, ableton),
 
 		// Clips
 		tools.NewAbletonCreateClip(g, ableton),
@@ -87,21 +97,47 @@ func main() {
 		tools.NewAbletonAddMidiNotes(g, ableton),
 		tools.NewAbletonHumanizeClip(g, ableton),
 		tools.NewAbletonDuplicateClipTo(g, ableton),
+		tools.NewAbletonDeleteClip(g, ableton),
 		tools.NewAbletonSetClipName(g, ableton),
+		tools.NewAbletonGetClipProperties(g, ableton),
+		tools.NewAbletonSetClipPitch(g, ableton),
+		tools.NewAbletonSetClipWarp(g, ableton),
+		tools.NewAbletonSetClipRegion(g, ableton),
+		tools.NewAbletonExtractClipRegion(g, ableton),
+		tools.NewAbletonGetClipEnvelope(g, ableton),
+		tools.NewAbletonSetClipEnvelopeSteps(g, ableton),
+		tools.NewAbletonClearClipEnvelope(g, ableton),
 		tools.NewAbletonMatchClipTempo(g, ableton),
 		tools.NewAbletonAnalyzeLocalAudio(g),
 		tools.NewAbletonAnalyzeAudioURL(g),
+		tools.NewAbletonChopDraft(g),
 		tools.NewAbletonCreateDrumVariation(g, ableton),
 		tools.NewAbletonCreateBassVariation(g, ableton),
 		tools.NewAbletonAuditionAB(g, ableton),
 
 		// Scenes
 		tools.NewAbletonFireScene(g, ableton),
+		tools.NewAbletonGetSceneNames(g, ableton),
+		tools.NewAbletonSetSceneName(g, ableton),
+		tools.NewAbletonCreateNamedScenes(g, ableton),
+		tools.NewAbletonSetSceneClipPresence(g, ableton),
 		tools.NewAbletonCreateSceneEnergyVariation(g, ableton),
+		tools.NewAbletonGetSoundingSnapshot(g, ableton),
 
 		// Devices / Browser
 		tools.NewAbletonGetDeviceParameters(g, ableton),
 		tools.NewAbletonSetDeviceParameter(g, ableton),
+		tools.NewAbletonSetDeviceParameterString(g, ableton),
+		tools.NewAbletonDeleteDevice(g, ableton),
+		tools.NewAbletonGetSimpler(g, ableton),
+		tools.NewAbletonSetSimplerPlaybackMode(g, ableton),
+		tools.NewAbletonSetSimplerSlicing(g, ableton),
+		tools.NewAbletonGetSimplerSlices(g, ableton),
+		tools.NewAbletonSaveSlicePreset(g, ableton),
+		tools.NewAbletonLoadSlicePreset(g, ableton),
+		tools.NewAbletonListSlicePresets(g),
+		tools.NewAbletonApplyDeviceIntent(g, ableton),
+		tools.NewAbletonListIntents(g),
 		tools.NewAbletonFindBrowserItem(g, ableton),
 		tools.NewAbletonListBrowserFolder(g, ableton),
 		tools.NewAbletonLoadBrowserItem(g, ableton),
@@ -133,6 +169,7 @@ func main() {
 		// Recipes
 		tools.NewAbletonSetupDrumTrack(g, ableton),
 		tools.NewAbletonCompareABVariation(g, ableton),
+		tools.NewAbletonCompareFXBypass(g, ableton),
 		tools.NewAbletonBuildChordClip(g, ableton),
 
 		// A/B comparison feedback

--- a/remote-script/README.md
+++ b/remote-script/README.md
@@ -2,6 +2,8 @@
 
 Adds Live Browser `load_item()` support and master-track mix helpers so MCP tools can load devices and adjust the mix bus without drag-and-drop.
 
+Developed and smoke-tested against **Ableton Live 11.0.12** (API label `11.0`). Some handlers (notably `create_audio_clip`) require Live **12.0.5+**; see the main [README supported-versions section](../README.md#supported-ableton-live-versions).
+
 ## What it adds
 
 | OSC address | Args | Purpose |
@@ -13,6 +15,27 @@ Adds Live Browser `load_item()` support and master-track mix helpers so MCP tool
 | `/live/browser/load_at_path` | `track_index` (`-1`=master), `device_index`, `root_name`, `*path_parts`, `item_name` | Load by exact path |
 | `/live/browser/debug` | _(none)_ | Dump browser roots (debug) |
 | `/live/clip_slot/create_audio_clip` | `track_index`, `clip_index`, `absolute_path` | Create a session audio clip from a local file (Live 12.0.5+) |
+| `/live/device/get/parameters/value_string` | `track_index`, `device_index` | All parameter display strings in one reply (e.g. `37.0 Hz`, `1/2`, `Ins`) |
+| `/live/device/set/parameter/string` | `track_index`, `device_index`, `parameter_index`, `value` | Set a parameter from a display string (enum name, or numeric with unit like `180 Hz`) |
+| `/live/device/delete` | `track_index`, `device_index` | Delete a device; replies with the device name and count before/after (stock delete is silent) |
+| `/live/device/get/is_active` | `track_index`, `device_index` | Device on/bypass state (`0`/`1`) for FX dry/wet A/B |
+| `/live/device/set/is_active` | `track_index`, `device_index`, `is_active` | Set device on/bypass (`0`/`1`) |
+| `/live/device/simpler/get` | `track_index`, `device_index` | Simpler state: playback_mode, slicing_playback_mode, slicing_style, slicing_beat_division, num_slices, has_sample |
+| `/live/device/simpler/set` | `track_index`, `device_index`, `property`, `value` | Set a Simpler property (playback_mode / slicing_playback_mode / slicing_style / slicing_beat_division) |
+| `/live/device/simpler/get/slices` | `track_index`, `device_index` | Slice map: sample_rate, sample_length, then slice start positions in samples |
+| `/live/device/simpler/set/slices` | `track_index`, `device_index`, `*slice_samples` | Restore a manual slice map onto the same sample |
+| `/live/clip/get/has_envelopes` | `track_index`, `clip_index` | Whether the Session clip has any envelopes |
+| `/live/clip/envelope/get` | `track`, `clip`, `device_index` (`-1`=mixer), `param_index` [, `start`, `end`, `step`] | Sample envelope via `value_at_time` |
+| `/live/clip/envelope/set_steps` | `track`, `clip`, `device_index`, `param_index`, `clear`, `*(time,duration,value)` | Create/write envelope steps |
+| `/live/clip/envelope/clear` | `track`, `clip`, `device_index`, `param_index` | Clear one envelope |
+| `/live/clip/envelope/clear_all` | `track`, `clip` | Clear all envelopes on the clip |
+| `/live/song/get/return_tracks` | — | `(count, *names)` for return tracks (send indices) |
+| `/live/device/get/available_input_routing_types` | `track_index`, `device_index` | Sidechain sources (Compressor on Live 11+) |
+| `/live/device/get/available_input_routing_channels` | `track_index`, `device_index` | Sidechain channels for the current source |
+| `/live/device/get/input_routing_type` | `track_index`, `device_index` | Current sidechain source |
+| `/live/device/set/input_routing_type` | `track_index`, `device_index`, `type_name` | Set sidechain source by display name |
+| `/live/device/get/input_routing_channel` | `track_index`, `device_index` | Current sidechain channel |
+| `/live/device/set/input_routing_channel` | `track_index`, `device_index`, `channel_name` | Set sidechain channel by display name |
 | `/live/master/get/volume` | — | Master volume |
 | `/live/master/set/volume` | `volume` | Set master volume |
 | `/live/master/get/output_meter_level` / `left` / `right` | — | Master meters |

--- a/remote-script/abletonosc/browser.py
+++ b/remote-script/abletonosc/browser.py
@@ -1,3 +1,5 @@
+import re
+
 import Live
 from typing import Any, Optional, Tuple
 
@@ -265,6 +267,391 @@ class BrowserHandler(AbletonOSCHandler):
                 return (track_index, clip_index, "error", str(exc))
             return (track_index, clip_index, "created", path)
 
+        def device_get_parameters_value_string_handler(params: Tuple[Any]):
+            """Params: track_index, device_index.
+
+            Returns UI-friendly display strings for every parameter of a device
+            (e.g. "37.0 Hz", "1/2", "Ins"). Stock AbletonOSC only exposes this per
+            single parameter (/live/device/get/parameter/value_string), which is too
+            many round-trips for devices with many parameters (e.g. EQ Eight has 84).
+            Reply: (track_index, device_index, *display_strings) aligned with the
+            /live/device/get/parameters/* lists.
+            """
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            if track_index < 0 or track_index >= len(self.song.tracks):
+                return (track_index, device_index, "invalid_track_index")
+            track = self.song.tracks[track_index]
+            if device_index < 0 or device_index >= len(track.devices):
+                return (track_index, device_index, "invalid_device_index")
+            device = track.devices[device_index]
+            strings = []
+            for parameter in device.parameters:
+                try:
+                    strings.append(str(parameter.str_for_value(parameter.value)))
+                except Exception:
+                    strings.append("")
+            return (track_index, device_index, *strings)
+
+        def device_set_parameter_string_handler(params: Tuple[Any]):
+            """Params: track_index, device_index, parameter_index, target_string.
+
+            Sets a device parameter from a human-readable string. Three strategies:
+            1. Enum params with value_items (e.g. Mix Type) -> match by name.
+            2. Stepped params (e.g. Interval "1/2", Filter On "On") -> integer scan
+               for an exact display match.
+            3. Continuous params (e.g. "180 Hz", "-3.5 dB", "50 %") -> monotonic
+               binary search over str_for_value, normalizing Hz/kHz.
+            Reply: (track_index, device_index, parameter_index, status, value, display),
+            or (..., "no_match", target, *options) when an enum value is not found.
+            """
+            if len(params) < 4:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            parameter_index = int(params[2])
+            target = str(params[3]).strip()
+            if track_index < 0 or track_index >= len(self.song.tracks):
+                return (track_index, device_index, parameter_index, "invalid_track_index")
+            track = self.song.tracks[track_index]
+            if device_index < 0 or device_index >= len(track.devices):
+                return (track_index, device_index, parameter_index, "invalid_device_index")
+            device = track.devices[device_index]
+            if parameter_index < 0 or parameter_index >= len(device.parameters):
+                return (track_index, device_index, parameter_index, "invalid_parameter_index")
+            parameter = device.parameters[parameter_index]
+
+            def display_of(value):
+                try:
+                    return str(parameter.str_for_value(value))
+                except Exception:
+                    return ""
+
+            def numeric_in(text):
+                text = str(text)
+                match = re.search(r"-?\d+(?:\.\d+)?", text)
+                if match is None:
+                    return None
+                value = float(match.group())
+                lowered = text.lower()
+                if "khz" in lowered:
+                    value *= 1000.0
+                return value
+
+            # Strategy 1: enumerated parameter with named items.
+            try:
+                items = [str(x) for x in parameter.value_items]
+            except Exception:
+                items = []
+            if items:
+                target_lower = target.lower()
+                chosen = None
+                for i, item in enumerate(items):
+                    if item == target:
+                        chosen = i
+                        break
+                if chosen is None:
+                    for i, item in enumerate(items):
+                        if item.lower() == target_lower:
+                            chosen = i
+                            break
+                if chosen is None and target_lower:
+                    for i, item in enumerate(items):
+                        if target_lower in item.lower():
+                            chosen = i
+                            break
+                if chosen is None:
+                    return (track_index, device_index, parameter_index, "no_match", target, *items)
+                try:
+                    parameter.value = float(parameter.min) + chosen
+                except Exception as exc:
+                    return (track_index, device_index, parameter_index, "error", str(exc))
+                return (track_index, device_index, parameter_index, "set", parameter.value, display_of(parameter.value))
+
+            # Strategy 2: stepped integer parameter matched by exact display string.
+            steps = int(round(float(parameter.max) - float(parameter.min)))
+            if 1 <= steps <= 512:
+                target_lower = target.lower()
+                for step in range(steps + 1):
+                    candidate = float(parameter.min) + step
+                    if display_of(candidate).lower() == target_lower:
+                        try:
+                            parameter.value = candidate
+                        except Exception as exc:
+                            return (track_index, device_index, parameter_index, "error", str(exc))
+                        return (track_index, device_index, parameter_index, "set", parameter.value, display_of(parameter.value))
+
+            # Strategy 3: continuous parameter resolved by monotonic binary search.
+            target_num = numeric_in(target)
+            if target_num is not None:
+                lo = float(parameter.min)
+                hi = float(parameter.max)
+                lo_num = numeric_in(display_of(lo))
+                hi_num = numeric_in(display_of(hi))
+                if lo_num is not None and hi_num is not None and lo_num != hi_num:
+                    increasing = hi_num >= lo_num
+                    best = lo
+                    for _ in range(48):
+                        mid = (lo + hi) / 2.0
+                        mid_num = numeric_in(display_of(mid))
+                        if mid_num is None:
+                            break
+                        best = mid
+                        if abs(mid_num - target_num) < 1e-6:
+                            break
+                        if (mid_num < target_num) == increasing:
+                            lo = mid
+                        else:
+                            hi = mid
+                    try:
+                        parameter.value = best
+                    except Exception as exc:
+                        return (track_index, device_index, parameter_index, "error", str(exc))
+                    return (track_index, device_index, parameter_index, "set", parameter.value, display_of(parameter.value))
+
+            return (track_index, device_index, parameter_index, "no_match", target)
+
+        def device_delete_handler(params: Tuple[Any]):
+            """Params: track_index, device_index.
+
+            Deletes a device and reports the device count before/after so the caller
+            can confirm success. Stock /live/track/delete_device returns nothing,
+            which makes success indistinguishable from a timeout.
+            Reply: (track_index, device_index, status, device_name, before, after).
+            """
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            if track_index < 0 or track_index >= len(self.song.tracks):
+                return (track_index, device_index, "invalid_track_index")
+            track = self.song.tracks[track_index]
+            if device_index < 0 or device_index >= len(track.devices):
+                return (track_index, device_index, "invalid_device_index")
+            devices_before = len(track.devices)
+            device_name = str(track.devices[device_index].name)
+            try:
+                track.delete_device(device_index)
+            except Exception as exc:
+                return (track_index, device_index, "error", str(exc))
+            return (track_index, device_index, "deleted", device_name, devices_before, len(track.devices))
+
+        def device_get_is_active_handler(params: Tuple[Any]):
+            """Params: track_index, device_index.
+
+            Reply: (track_index, device_index, is_active) where is_active is 0/1.
+            Stock AbletonOSC does not expose Device.is_active for FX bypass A/B.
+            """
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            if track_index < 0 or track_index >= len(self.song.tracks):
+                return (track_index, device_index, "invalid_track_index")
+            track = self.song.tracks[track_index]
+            if device_index < 0 or device_index >= len(track.devices):
+                return (track_index, device_index, "invalid_device_index")
+            device = track.devices[device_index]
+            try:
+                active = 1 if bool(device.is_active) else 0
+            except Exception as exc:
+                return (track_index, device_index, "error", str(exc))
+            return (track_index, device_index, active)
+
+        def device_set_is_active_handler(params: Tuple[Any]):
+            """Params: track_index, device_index, is_active (0/1).
+
+            Reply: (track_index, device_index, "ok", is_active).
+            """
+            if len(params) < 3:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            want = int(params[2]) != 0
+            if track_index < 0 or track_index >= len(self.song.tracks):
+                return (track_index, device_index, "invalid_track_index")
+            track = self.song.tracks[track_index]
+            if device_index < 0 or device_index >= len(track.devices):
+                return (track_index, device_index, "invalid_device_index")
+            device = track.devices[device_index]
+            try:
+                device.is_active = want
+                active = 1 if bool(device.is_active) else 0
+            except Exception as exc:
+                return (track_index, device_index, "error", str(exc))
+            return (track_index, device_index, "ok", active)
+
+        def _resolve_simpler(track_index: int, device_index: int):
+            """Return (simpler_device, None) or (None, error_status)."""
+            if track_index < 0 or track_index >= len(self.song.tracks):
+                return None, "invalid_track_index"
+            track = self.song.tracks[track_index]
+            if device_index < 0 or device_index >= len(track.devices):
+                return None, "invalid_device_index"
+            device = track.devices[device_index]
+            # Simpler (class_name "OriginalSimpler") exposes playback_mode; other
+            # devices do not, so this doubles as a type guard.
+            if not hasattr(device, "playback_mode"):
+                return None, "not_simpler"
+            return device, None
+
+        def device_simpler_get_handler(params: Tuple[Any]):
+            """Params: track_index, device_index.
+
+            Reply: (track, device, "ok", playback_mode, slicing_playback_mode,
+                    slicing_style, slicing_beat_division, num_slices, has_sample).
+            slicing_style / slicing_beat_division are -1 when no sample is loaded.
+            """
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            device, err = _resolve_simpler(track_index, device_index)
+            if err is not None:
+                return (track_index, device_index, err)
+            slicing_style = -1
+            slicing_beat_division = -1
+            num_slices = 0
+            has_sample = 0
+            try:
+                sample = device.sample
+            except Exception:
+                sample = None
+            if sample is not None:
+                has_sample = 1
+                try:
+                    slicing_style = int(sample.slicing_style)
+                except Exception:
+                    pass
+                try:
+                    slicing_beat_division = int(sample.slicing_beat_division)
+                except Exception:
+                    pass
+                try:
+                    num_slices = len(sample.slices)
+                except Exception:
+                    pass
+            return (
+                track_index,
+                device_index,
+                "ok",
+                int(device.playback_mode),
+                int(device.slicing_playback_mode),
+                slicing_style,
+                slicing_beat_division,
+                num_slices,
+                has_sample,
+            )
+
+        def device_simpler_set_handler(params: Tuple[Any]):
+            """Params: track_index, device_index, property, value (int).
+
+            property in {playback_mode, slicing_playback_mode, slicing_style,
+            slicing_beat_division}. Reply: (track, device, "set", property, value).
+            """
+            if len(params) < 4:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            prop = str(params[2])
+            value = int(params[3])
+            device, err = _resolve_simpler(track_index, device_index)
+            if err is not None:
+                return (track_index, device_index, err)
+            try:
+                if prop == "playback_mode":
+                    device.playback_mode = value
+                elif prop == "slicing_playback_mode":
+                    device.slicing_playback_mode = value
+                elif prop in ("slicing_style", "slicing_beat_division"):
+                    sample = device.sample
+                    if sample is None:
+                        return (track_index, device_index, "no_sample", prop)
+                    setattr(sample, prop, value)
+                else:
+                    return (track_index, device_index, "unknown_property", prop)
+            except Exception as exc:
+                return (track_index, device_index, "error", prop, str(exc))
+            return (track_index, device_index, "set", prop, value)
+
+        def device_simpler_get_slices_handler(params: Tuple[Any]):
+            """Params: track_index, device_index.
+
+            Reply: (track, device, "ok", sample_rate, sample_length, *slice_samples)
+            where each slice value is a start position in samples; divide by
+            sample_rate for seconds. Available since Live 11.
+            """
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            device, err = _resolve_simpler(track_index, device_index)
+            if err is not None:
+                return (track_index, device_index, err)
+            try:
+                sample = device.sample
+            except Exception:
+                sample = None
+            if sample is None:
+                return (track_index, device_index, "no_sample")
+            try:
+                sample_rate = int(sample.sample_rate)
+            except Exception:
+                sample_rate = 0
+            try:
+                sample_length = int(sample.length)
+            except Exception:
+                sample_length = 0
+            try:
+                slices = [int(s) for s in sample.slices]
+            except Exception:
+                slices = []
+            return (track_index, device_index, "ok", sample_rate, sample_length, *slices)
+
+        def device_simpler_set_slices_handler(params: Tuple[Any]):
+            """Params: track_index, device_index, *slice_samples.
+
+            Replaces the Simpler's manual slices with the provided list (sample
+            frames): switches slicing_style to Manual (3), clears existing
+            slices, then inserts each. Used to restore a saved slice preset onto
+            the same sample. Reply: (track, device, "ok", num_slices) or
+            (track, device, err[, detail]).
+            """
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            slice_samples = [int(p) for p in params[2:]]
+            device, err = _resolve_simpler(track_index, device_index)
+            if err is not None:
+                return (track_index, device_index, err)
+            try:
+                sample = device.sample
+            except Exception:
+                sample = None
+            if sample is None:
+                return (track_index, device_index, "no_sample")
+            try:
+                sample.slicing_style = 3  # Manual
+            except Exception:
+                pass
+            try:
+                sample.clear_slices()
+            except Exception as exc:
+                return (track_index, device_index, "error", "clear_slices", str(exc))
+            for value in slice_samples:
+                try:
+                    sample.insert_slice(int(value))
+                except Exception as exc:
+                    return (track_index, device_index, "error", "insert_slice", str(exc))
+            try:
+                num = len(sample.slices)
+            except Exception:
+                num = 0
+            return (track_index, device_index, "ok", num)
+
         self.osc_server.add_handler("/live/browser/find", browser_find_handler)
         self.osc_server.add_handler("/live/browser/debug", browser_debug_handler)
         self.osc_server.add_handler("/live/browser/list_folder", browser_list_folder_handler)
@@ -273,6 +660,382 @@ class BrowserHandler(AbletonOSCHandler):
         self.osc_server.add_handler("/live/device/load/preset", device_load_preset_handler)
         self.osc_server.add_handler(
             "/live/clip_slot/create_audio_clip", clip_slot_create_audio_clip_handler
+        )
+        self.osc_server.add_handler(
+            "/live/device/get/parameters/value_string",
+            device_get_parameters_value_string_handler,
+        )
+        self.osc_server.add_handler(
+            "/live/device/set/parameter/string",
+            device_set_parameter_string_handler,
+        )
+        self.osc_server.add_handler("/live/device/delete", device_delete_handler)
+        self.osc_server.add_handler("/live/device/get/is_active", device_get_is_active_handler)
+        self.osc_server.add_handler("/live/device/set/is_active", device_set_is_active_handler)
+        self.osc_server.add_handler("/live/device/simpler/get", device_simpler_get_handler)
+        self.osc_server.add_handler("/live/device/simpler/set", device_simpler_set_handler)
+        self.osc_server.add_handler("/live/device/simpler/get/slices", device_simpler_get_slices_handler)
+        self.osc_server.add_handler("/live/device/simpler/set/slices", device_simpler_set_slices_handler)
+
+        #----------------------------------------------------------------------
+        # Session clip automation envelopes (Live 11: insert_step / value_at_time)
+        # device_index=-1 selects mixer: param 0=volume, 1=panning, 2+N=send N.
+        #----------------------------------------------------------------------
+        def _resolve_clip(track_index, clip_index):
+            if track_index < 0 or track_index >= len(self.song.tracks):
+                return None, None, "invalid_track_index"
+            track = self.song.tracks[track_index]
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                return None, None, "invalid_clip_index"
+            clip = track.clip_slots[clip_index].clip
+            if clip is None:
+                return track, None, "no_clip"
+            return track, clip, None
+
+        def _resolve_envelope_param(track, device_index, parameter_index):
+            if device_index == -1:
+                mixer = track.mixer_device
+                if parameter_index == 0:
+                    return mixer.volume, None
+                if parameter_index == 1:
+                    return mixer.panning, None
+                send_i = int(parameter_index) - 2
+                if send_i < 0 or send_i >= len(mixer.sends):
+                    return None, "invalid_send_index"
+                return mixer.sends[send_i], None
+            if device_index < 0 or device_index >= len(track.devices):
+                return None, "invalid_device_index"
+            device = track.devices[device_index]
+            if parameter_index < 0 or parameter_index >= len(device.parameters):
+                return None, "invalid_parameter_index"
+            return device.parameters[parameter_index], None
+
+        def clip_get_has_envelopes_handler(params: Tuple[Any]):
+            """Params: track_index, clip_index. Reply: (t, c, has_envelopes)."""
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            clip_index = int(params[1])
+            _track, clip, err = _resolve_clip(track_index, clip_index)
+            if err is not None:
+                return (track_index, clip_index, err)
+            try:
+                has = bool(clip.has_envelopes)
+            except Exception:
+                has = False
+            return (track_index, clip_index, has)
+
+        def clip_envelope_get_handler(params: Tuple[Any]):
+            """Params: track, clip, device_index, param_index [, start, end, step].
+            Samples value_at_time across [start,end] (default 0..clip.length, step 0.25).
+            Reply: (t, c, "ok"|"missing"|err, param_name, *time,value pairs)
+            """
+            if len(params) < 4:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            clip_index = int(params[1])
+            device_index = int(params[2])
+            parameter_index = int(params[3])
+            track, clip, err = _resolve_clip(track_index, clip_index)
+            if err is not None:
+                return (track_index, clip_index, err)
+            param, perr = _resolve_envelope_param(track, device_index, parameter_index)
+            if perr is not None:
+                return (track_index, clip_index, perr)
+            try:
+                env = clip.automation_envelope(param)
+            except Exception as exc:
+                return (track_index, clip_index, "error", str(exc))
+            pname = str(param.name)
+            if env is None:
+                return (track_index, clip_index, "missing", pname)
+            try:
+                length = float(clip.length)
+            except Exception:
+                length = 4.0
+            start = float(params[4]) if len(params) > 4 else 0.0
+            end = float(params[5]) if len(params) > 5 else length
+            step = float(params[6]) if len(params) > 6 else 0.25
+            if step <= 0:
+                step = 0.25
+            if end < start:
+                start, end = end, start
+            samples = []
+            t = start
+            # Cap samples to keep OSC replies bounded.
+            max_points = 257
+            while t <= end + 1e-9 and len(samples) < max_points * 2:
+                try:
+                    v = float(env.value_at_time(t))
+                except Exception:
+                    v = 0.0
+                samples.append(t)
+                samples.append(v)
+                t += step
+            return (track_index, clip_index, "ok", pname) + tuple(samples)
+
+        def clip_envelope_set_steps_handler(params: Tuple[Any]):
+            """Params: track, clip, device_index, param_index, clear_flag,
+            then repeating (time, duration, value).
+            clear_flag: 1 clears the envelope before inserting.
+            Reply: (t, c, "ok", num_steps, param_name) or (t, c, err[, detail]).
+            """
+            if len(params) < 5:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            clip_index = int(params[1])
+            device_index = int(params[2])
+            parameter_index = int(params[3])
+            clear_flag = int(params[4])
+            steps_raw = params[5:]
+            if len(steps_raw) % 3 != 0:
+                return (track_index, clip_index, "error", "steps_must_be_triples")
+            track, clip, err = _resolve_clip(track_index, clip_index)
+            if err is not None:
+                return (track_index, clip_index, err)
+            param, perr = _resolve_envelope_param(track, device_index, parameter_index)
+            if perr is not None:
+                return (track_index, clip_index, perr)
+            pname = str(param.name)
+            try:
+                env = clip.automation_envelope(param)
+            except Exception:
+                env = None
+            if env is None:
+                try:
+                    env = clip.create_automation_envelope(param)
+                except Exception as exc:
+                    return (track_index, clip_index, "error", "create", str(exc))
+            if clear_flag:
+                try:
+                    clip.clear_envelope(param)
+                    env = clip.create_automation_envelope(param)
+                except Exception as exc:
+                    return (track_index, clip_index, "error", "clear", str(exc))
+            count = 0
+            for i in range(0, len(steps_raw), 3):
+                time_b = float(steps_raw[i])
+                duration = float(steps_raw[i + 1])
+                value = float(steps_raw[i + 2])
+                try:
+                    env.insert_step(time_b, duration, value)
+                except Exception as exc:
+                    return (track_index, clip_index, "error", "insert_step", str(exc), count)
+                count += 1
+            return (track_index, clip_index, "ok", count, pname)
+
+        def clip_envelope_clear_handler(params: Tuple[Any]):
+            """Params: track, clip, device_index, param_index.
+            Reply: (t, c, "cleared"|"missing"|err, param_name?).
+            """
+            if len(params) < 4:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            clip_index = int(params[1])
+            device_index = int(params[2])
+            parameter_index = int(params[3])
+            track, clip, err = _resolve_clip(track_index, clip_index)
+            if err is not None:
+                return (track_index, clip_index, err)
+            param, perr = _resolve_envelope_param(track, device_index, parameter_index)
+            if perr is not None:
+                return (track_index, clip_index, perr)
+            pname = str(param.name)
+            try:
+                env = clip.automation_envelope(param)
+            except Exception:
+                env = None
+            if env is None:
+                return (track_index, clip_index, "missing", pname)
+            try:
+                clip.clear_envelope(param)
+            except Exception as exc:
+                return (track_index, clip_index, "error", str(exc))
+            return (track_index, clip_index, "cleared", pname)
+
+        def clip_envelope_clear_all_handler(params: Tuple[Any]):
+            """Params: track, clip. Reply: (t, c, "cleared"|"noop"|err)."""
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            clip_index = int(params[1])
+            _track, clip, err = _resolve_clip(track_index, clip_index)
+            if err is not None:
+                return (track_index, clip_index, err)
+            try:
+                has = bool(clip.has_envelopes)
+            except Exception:
+                has = False
+            if not has:
+                return (track_index, clip_index, "noop")
+            try:
+                clip.clear_all_envelopes()
+            except Exception as exc:
+                return (track_index, clip_index, "error", str(exc))
+            return (track_index, clip_index, "cleared")
+
+        self.osc_server.add_handler("/live/clip/get/has_envelopes", clip_get_has_envelopes_handler)
+        self.osc_server.add_handler("/live/clip/envelope/get", clip_envelope_get_handler)
+        self.osc_server.add_handler("/live/clip/envelope/set_steps", clip_envelope_set_steps_handler)
+        self.osc_server.add_handler("/live/clip/envelope/clear", clip_envelope_clear_handler)
+        self.osc_server.add_handler("/live/clip/envelope/clear_all", clip_envelope_clear_all_handler)
+
+        #----------------------------------------------------------------------
+        # Return tracks + device sidechain routing (Live 11+ CompressorDevice)
+        #----------------------------------------------------------------------
+        def song_get_return_tracks_handler(_params: Tuple[Any]):
+            """Reply: (count, *names) for song.return_tracks."""
+            returns = self.song.return_tracks
+            return (len(returns),) + tuple(str(t.name) for t in returns)
+
+        def _resolve_routable_device(track_index, device_index):
+            if track_index < 0 or track_index >= len(self.song.tracks):
+                return None, "invalid_track_index"
+            track = self.song.tracks[track_index]
+            if device_index < 0 or device_index >= len(track.devices):
+                return None, "invalid_device_index"
+            device = track.devices[device_index]
+            if not hasattr(device, "available_input_routing_types"):
+                return None, "unsupported"
+            return device, None
+
+        def device_get_available_input_routing_types_handler(params: Tuple[Any]):
+            """Params: track_index, device_index.
+            Reply: (track, device, "ok", *type_names) or (track, device, err).
+            """
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            device, err = _resolve_routable_device(track_index, device_index)
+            if err is not None:
+                return (track_index, device_index, err)
+            names = [str(t.display_name) for t in device.available_input_routing_types]
+            return (track_index, device_index, "ok") + tuple(names)
+
+        def device_get_available_input_routing_channels_handler(params: Tuple[Any]):
+            """Params: track_index, device_index.
+            Reply: (track, device, "ok", *channel_names) or (track, device, err).
+            """
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            device, err = _resolve_routable_device(track_index, device_index)
+            if err is not None:
+                return (track_index, device_index, err)
+            if not hasattr(device, "available_input_routing_channels"):
+                return (track_index, device_index, "unsupported")
+            names = [str(c.display_name) for c in device.available_input_routing_channels]
+            return (track_index, device_index, "ok") + tuple(names)
+
+        def device_get_input_routing_type_handler(params: Tuple[Any]):
+            """Params: track_index, device_index.
+            Reply: (track, device, "ok", type_name) or (track, device, err).
+            """
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            device, err = _resolve_routable_device(track_index, device_index)
+            if err is not None:
+                return (track_index, device_index, err)
+            try:
+                name = str(device.input_routing_type.display_name)
+            except Exception as exc:
+                return (track_index, device_index, "error", str(exc))
+            return (track_index, device_index, "ok", name)
+
+        def device_set_input_routing_type_handler(params: Tuple[Any]):
+            """Params: track_index, device_index, type_name.
+            Reply: (track, device, "set", type_name) or (track, device, "not_found", type_name, *options)
+            or (track, device, err).
+            """
+            if len(params) < 3:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            type_name = str(params[2])
+            device, err = _resolve_routable_device(track_index, device_index)
+            if err is not None:
+                return (track_index, device_index, err)
+            for routing_type in device.available_input_routing_types:
+                if str(routing_type.display_name) == type_name:
+                    try:
+                        device.input_routing_type = routing_type
+                    except Exception as exc:
+                        return (track_index, device_index, "error", str(exc))
+                    return (track_index, device_index, "set", type_name)
+            options = [str(t.display_name) for t in device.available_input_routing_types]
+            return (track_index, device_index, "not_found", type_name) + tuple(options)
+
+        def device_get_input_routing_channel_handler(params: Tuple[Any]):
+            """Params: track_index, device_index.
+            Reply: (track, device, "ok", channel_name) or (track, device, err).
+            """
+            if len(params) < 2:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            device, err = _resolve_routable_device(track_index, device_index)
+            if err is not None:
+                return (track_index, device_index, err)
+            if not hasattr(device, "input_routing_channel"):
+                return (track_index, device_index, "unsupported")
+            try:
+                name = str(device.input_routing_channel.display_name)
+            except Exception as exc:
+                return (track_index, device_index, "error", str(exc))
+            return (track_index, device_index, "ok", name)
+
+        def device_set_input_routing_channel_handler(params: Tuple[Any]):
+            """Params: track_index, device_index, channel_name.
+            Reply: (track, device, "set", channel_name) or (track, device, "not_found", …).
+            """
+            if len(params) < 3:
+                return ("error", "missing_args")
+            track_index = int(params[0])
+            device_index = int(params[1])
+            channel_name = str(params[2])
+            device, err = _resolve_routable_device(track_index, device_index)
+            if err is not None:
+                return (track_index, device_index, err)
+            if not hasattr(device, "available_input_routing_channels"):
+                return (track_index, device_index, "unsupported")
+            for channel in device.available_input_routing_channels:
+                if str(channel.display_name) == channel_name:
+                    try:
+                        device.input_routing_channel = channel
+                    except Exception as exc:
+                        return (track_index, device_index, "error", str(exc))
+                    return (track_index, device_index, "set", channel_name)
+            options = [str(c.display_name) for c in device.available_input_routing_channels]
+            return (track_index, device_index, "not_found", channel_name) + tuple(options)
+
+        self.osc_server.add_handler("/live/song/get/return_tracks", song_get_return_tracks_handler)
+        self.osc_server.add_handler(
+            "/live/device/get/available_input_routing_types",
+            device_get_available_input_routing_types_handler,
+        )
+        self.osc_server.add_handler(
+            "/live/device/get/available_input_routing_channels",
+            device_get_available_input_routing_channels_handler,
+        )
+        self.osc_server.add_handler(
+            "/live/device/get/input_routing_type",
+            device_get_input_routing_type_handler,
+        )
+        self.osc_server.add_handler(
+            "/live/device/set/input_routing_type",
+            device_set_input_routing_type_handler,
+        )
+        self.osc_server.add_handler(
+            "/live/device/get/input_routing_channel",
+            device_get_input_routing_channel_handler,
+        )
+        self.osc_server.add_handler(
+            "/live/device/set/input_routing_channel",
+            device_set_input_routing_channel_handler,
         )
 
         # Master-track helpers (also registered by MasterHandler; kept here so hot-reload


### PR DESCRIPTION
## Summary
- Extend the AbletonOSC remote-script patch (readable params, Simpler/slices, routing, envelopes, device `is_active`) and wire matching MCP tools for sampling/processing workflows.
- Add production-oriented audio analysis (BPM/key alternatives, density, band balance, match axes), session ops, destructive previews, FX bypass A/B, and richer `ableton_diagnose` capabilities.
- Document **Ableton Live 11.0.12** as the primary development target and call out version-gated tools (e.g. `create_audio_clip` needs Live 12.0.5+).

## Test plan
- [x] `go test ./...`
- [ ] Apply/update `remote-script/` into AbletonOSC and reload or restart Live
- [ ] `ableton_diagnose` shows new capabilities (`device_is_active`, envelopes, sidechain, etc.)
- [ ] Smoke: Simpler slice get/set, `ableton_compare_fx_bypass`, analyze local wav production fields
- [ ] Confirm Homebrew/binary release still requires a separate remote-script install (not bundled in GoReleaser assets yet)