### PR TITLE
fix: resolve staticcheck failures from #44

### DIFF
--- a/internal/tools/ableton_routing.go
+++ b/internal/tools/ableton_routing.go
@@ -194,11 +194,7 @@ func NewAbletonSetTrackSend(g *genkit.Genkit, client *abletonosc.Client) ai.Tool
 			}
 			res, err := client.Query("/live/track/get/send", int32(input.TrackIndex), int32(input.SendIndex))
 			if err != nil {
-				return SetTrackSendOutput{
-					TrackIndex: input.TrackIndex,
-					SendIndex:  input.SendIndex,
-					Value:      input.Value,
-				}, nil
+				return SetTrackSendOutput(input), nil
 			}
 			if err := ensureResponseLen(res, 3); err != nil {
 				return SetTrackSendOutput{}, err

--- a/internal/tools/ableton_simpler.go
+++ b/internal/tools/ableton_simpler.go
@@ -59,7 +59,7 @@ func simplerStatusError(status string) error {
 	case "not_simpler":
 		return errors.New("device is not a Simpler (OriginalSimpler)")
 	case "no_sample":
-		return errors.New("Simpler has no sample loaded")
+		return errors.New("simpler has no sample loaded")
 	default:
 		return fmt.Errorf("simpler op failed: status=%s", status)
 	}

--- a/internal/tools/actionable_error.go
+++ b/internal/tools/actionable_error.go
@@ -46,10 +46,6 @@ func wrapActionable(err error, code, next string) error {
 	return &ActionableError{Code: code, Message: err.Error(), NextStep: next}
 }
 
-func formatActionable(code, message, next string) string {
-	return actionable(code, message, next).Error()
-}
-
 // requireConfirm returns a preview-style actionable error when confirm is false.
 func requireConfirm(confirm bool, action string, summary string) error {
 	if confirm {


### PR DESCRIPTION
## Summary
- Fix the three `staticcheck` errors that failed CI on #44 after squash-merge to `main`.

## Test plan
- [x] `go test ./internal/tools/`
- [x] `staticcheck ./...`
- [ ] Confirm CI green on this PR